### PR TITLE
values.yaml is NOT template-expanded, push values in from application…

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -157,6 +157,10 @@ spec:
           cluster:
             name: "placeholder"
           hubble:
+            tls:
+              auto:
+                certManagerIssuerRef:
+                  name: "placeholder-ca-issuer"
             ui:
               ingress:
                 hosts:

--- a/charts/cilium/application.yaml
+++ b/charts/cilium/application.yaml
@@ -21,6 +21,10 @@ spec:
           cluster:
             name: "{{ .Values.cluster_name }}"
           hubble:
+            tls:
+              auto:
+                certManagerIssuerRef:
+                  name: "{{ .Values.cluster_name }}-ca-issuer"
             ui:
               ingress:
                 hosts:

--- a/charts/cilium/rendered.yaml
+++ b/charts/cilium/rendered.yaml
@@ -2513,7 +2513,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: '{{ .Values.cluster_name }}-ca-issuer'
+    name: placeholder-ca-issuer
   secretName: hubble-relay-client-certs
   commonName: "*.hubble-relay.cilium.io"
   dnsNames:
@@ -2537,7 +2537,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: '{{ .Values.cluster_name }}-ca-issuer'
+    name: placeholder-ca-issuer
   secretName: hubble-server-certs
   commonName: "*.placeholder.hubble-grpc.cilium.io"
   dnsNames:

--- a/charts/cilium/values.yaml
+++ b/charts/cilium/values.yaml
@@ -144,7 +144,7 @@ cilium:
         certManagerIssuerRef:
           group: cert-manager.io
           kind: ClusterIssuer
-          name: "{{ .Values.cluster_name }}-ca-issuer"
+          name: "placeholder-ca-issuer"
     relay:
       # -- Enable Hubble Relay (requires hubble.enabled=true)
       enabled: true


### PR DESCRIPTION
…s.yaml instead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves Hubble TLS cert-manager issuer configuration into Argo CD Application values and updates rendered certificates to use the placeholder issuer.
> 
> - **Helm/Argo CD Applications**:
>   - Add `cilium.hubble.tls.auto.certManagerIssuerRef.name` to `valuesObject` in `charts/cilium/application.yaml` and `charts/argocd-applications/rendered.yaml`.
> - **Cilium Chart**:
>   - Update `charts/cilium/values.yaml` to set `cilium.hubble.tls.auto.certManagerIssuerRef.name` to `"placeholder-ca-issuer"`.
>   - Rendered manifests (`charts/cilium/rendered.yaml`): set `issuerRef.name` to `placeholder-ca-issuer` for Hubble `Certificate` resources and keep ingress/UI host placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c2e9cd3571b79b2e55e7ddec4b762e09204022f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->