### PR TITLE
Retry operation

### DIFF
--- a/.github/workflows/bootstrap-cluster.yaml
+++ b/.github/workflows/bootstrap-cluster.yaml
@@ -116,6 +116,7 @@ jobs:
           cluster_name: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/cluster_name"
           external_ip_cidr: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/external_ip_cidr"
           vault_name: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/vault_name"
+          project_id: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/project_id"
           loki_bucket_chunks: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/loki_bucket_chunks"
           loki_bucket_ruler: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/loki_bucket_ruler"
           loki_bucket_admin: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/loki_bucket_admin"

--- a/charts/argocd/application.yaml
+++ b/charts/argocd/application.yaml
@@ -15,6 +15,8 @@ spec:
       valueFiles:
         - values.yaml
       valuesObject:
+        # Pass config values needed by argocd chart templates (e.g., tiles-appproject.yaml)
+        cluster_name: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
         targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
         argo-cd:
           global:

--- a/charts/argocd/bootstrap.sh
+++ b/charts/argocd/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -exuo pipefail
 
-# Source the helper script to set up helm_template_args and set_flags
+# Source the helper script to set up helm_template_args and config_set_flags
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 source "${REPO_ROOT}/scripts/helm-common.bash"
@@ -15,11 +15,12 @@ kubectl label namespace argocd "pod-security.kubernetes.io/enforce=privileged" -
 kubectl label namespace argocd "trust-bundle=enabled" --overwrite
 kubectl config set-context --current --namespace=argocd
 
+# Use config_set_flags which contains all config variables from the environment.
+# Additional --set flags override computed values that ArgoCD will also set.
 helm template argocd charts/argocd --namespace argocd \
 	--skip-crds \
 	"${helm_template_args[@]}" \
-	"${set_flags[@]}" \
-	--set "cluster_name=${cluster_name:?}" \
+	"${config_set_flags[@]}" \
 	--set "argo-cd.global.domain=argocd.${cluster_name:?}.symmatree.com" \
 	--set "argo-cd.server.ingressGrpc.hostname=grpc-argocd.${cluster_name:?}.symmatree.com" |
 	kubectl apply --server-side -f-

--- a/charts/cilium/bootstrap.sh
+++ b/charts/cilium/bootstrap.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-# Source the helper script to set up helm_template_args and set_flags
+# Source the helper script to set up helm_template_args and config_set_flags
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 source "${REPO_ROOT}/scripts/helm-common.bash"
 cd "${REPO_ROOT}"
 
 echo "::group::Bootstrap Cilium"
+# Verify required variables are set (subset of CONFIG_VARS needed for cilium)
 required_vars=(
 	"pod_cidr"
 	"cluster_name"
@@ -27,10 +28,13 @@ kubectl create namespace cilium
 kubectl label namespace cilium "pod-security.kubernetes.io/warn=baseline" --overwrite
 kubectl label namespace cilium "pod-security.kubernetes.io/enforce=privileged" --overwrite
 kubectl config set-context --current --namespace=cilium
+
+# Use config_set_flags which contains all config variables from the environment.
+# Additional --set flags override computed values that ArgoCD will also set.
 helm template cilium charts/cilium --namespace cilium \
 	--skip-crds \
 	"${helm_template_args[@]}" \
-	"${set_flags[@]}" \
+	"${config_set_flags[@]}" \
 	--set "cilium.ipv4NativeRoutingCIDR=${pod_cidr:?}" \
 	--set "cilium.cluster.name=${cluster_name:?}" \
 	--set "cilium.hubble.ui.ingress.hosts[0]=hubble.${cluster_name:?}.symmatree.com" \


### PR DESCRIPTION
Add `cluster_name` to Helm template command in `bootstrap.sh` to correctly name the ArgoCD AppProject.

The `argocd/bootstrap.sh` script was not passing the `cluster_name` value to the Helm template command, causing the AppProject to be named "placeholder" instead of the actual cluster name. This resulted in a chicken-and-egg problem where ArgoCD applications referenced a project that did not exist, as the AppProject was created with the wrong name.

---
[Slack Thread](https://porter-farms.slack.com/archives/C0A49SJUJ2U/p1766348252945959?thread_ts=1766348252.945959&cid=C0A49SJUJ2U)

<a href="https://cursor.com/background-agent?bcId=bc-f0b513e2-fc90-44cc-8106-6a7b6a5a99ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f0b513e2-fc90-44cc-8106-6a7b6a5a99ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

