### PR TITLE
fix(bootstrap): tag rulesets for CI deploy tags

### DIFF
--- a/tf/bootstrap/github.tf
+++ b/tf/bootstrap/github.tf
@@ -83,6 +83,12 @@ resource "github_repository_ruleset" "tiles-tags" {
   target      = "tag"
   enforcement = "active"
 
+  # GITHUB_TOKEN in workflows is the GitHub Actions app (integration id 15368), not a repo role.
+  bypass_actors {
+    actor_id    = 15368
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
   bypass_actors {
     actor_id    = 5
     actor_type  = "RepositoryRole"
@@ -176,6 +182,11 @@ resource "github_repository_ruleset" "polisher-tags" {
   target      = "tag"
   enforcement = "active"
 
+  bypass_actors {
+    actor_id    = 15368
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
   bypass_actors {
     actor_id    = 5
     actor_type  = "RepositoryRole"

--- a/tf/bootstrap/github.tf
+++ b/tf/bootstrap/github.tf
@@ -83,12 +83,6 @@ resource "github_repository_ruleset" "tiles-tags" {
   target      = "tag"
   enforcement = "active"
 
-  # GITHUB_TOKEN in workflows is the GitHub Actions app (integration id 15368), not a repo role.
-  bypass_actors {
-    actor_id    = 15368
-    actor_type  = "Integration"
-    bypass_mode = "always"
-  }
   bypass_actors {
     actor_id    = 5
     actor_type  = "RepositoryRole"
@@ -104,7 +98,6 @@ resource "github_repository_ruleset" "tiles-tags" {
 
   rules {
     deletion = true
-    update   = true
   }
 }
 
@@ -183,11 +176,6 @@ resource "github_repository_ruleset" "polisher-tags" {
   enforcement = "active"
 
   bypass_actors {
-    actor_id    = 15368
-    actor_type  = "Integration"
-    bypass_mode = "always"
-  }
-  bypass_actors {
     actor_id    = 5
     actor_type  = "RepositoryRole"
     bypass_mode = "always"
@@ -202,7 +190,6 @@ resource "github_repository_ruleset" "polisher-tags" {
 
   rules {
     deletion = true
-    update   = true
   }
 }
 


### PR DESCRIPTION
## Problem

`nodes-plan-apply` force-pushes `refs/tags/test` and `refs/tags/prod` using `GITHUB_TOKEN`. Tag rulesets used `rules.update`, which blocked those pushes unless a bypass actor applied.

Adding GitHub Actions (`Integration` / 15368) to `bypass_actors` fixed tiles in theory but GitHub returned **422** on **symmatree/polisher** (`Actor GitHub Actions integration must be part of the ruleset source or owner organization`).

## Change

- **tiles-tags** and **polisher-tags:** remove `bypass_actors` for Integration 15368; remove the tag **update** rule so workflows can move `test` / `prod` without that bypass. **Deletion** rule unchanged. RepositoryRole bypass unchanged.
- **tiles-main** and **polisher-main:** unchanged in this commit -- still require **nodes-plan-apply** and **pre-commit** (`required_status_checks` with `integration_id` 15368 only for those checks, not for tag bypass).

Apply **`tf/bootstrap`** after merge so GitHub rulesets update.