### PR TITLE
fix(cilium): L2 pod announcements interface pattern for 1.19

### DIFF
--- a/charts/cilium/rendered.yaml
+++ b/charts/cilium/rendered.yaml
@@ -310,7 +310,7 @@ data:
   l2-announcements-renew-deadline: "7s"
   l2-announcements-retry-period: "1s"
   enable-l2-pod-announcements: "true"
-  l2-pod-announcements-interface: "enp3s0"
+  l2-pod-announcements-interface-pattern: "^enp3s0$"
   enable-pmtu-discovery: "true"
 
   packetization-layer-pmtud-mode: "blackhole"
@@ -1495,7 +1495,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "0a41cd2130eba4ba9294cddd5c466ced55da4b6ed6e3d1c1d8d681e150bf545b"
+        cilium.io/cilium-configmap-checksum: "0aa05b58a5dea2d7a68182359862353ced3fd8d7f7410cde0571a6d026b78f56"
         kubectl.kubernetes.io/default-container: cilium-agent
       labels:
         k8s-app: cilium
@@ -2196,7 +2196,7 @@ spec:
     metadata:
       annotations:
         # ensure pods roll when configmap updates
-        cilium.io/cilium-configmap-checksum: "0a41cd2130eba4ba9294cddd5c466ced55da4b6ed6e3d1c1d8d681e150bf545b"
+        cilium.io/cilium-configmap-checksum: "0aa05b58a5dea2d7a68182359862353ced3fd8d7f7410cde0571a6d026b78f56"
       labels:
         io.cilium/app: operator
         name: cilium-operator

--- a/charts/cilium/values.yaml
+++ b/charts/cilium/values.yaml
@@ -64,8 +64,9 @@ cilium:
     # -- Enable L2 pod announcements
     # Not so we can talk to them but to help routing.
     enabled: true
-    # -- Interface used for sending Gratuitous ARP pod announcements
-    interface: enp3s0
+    # -- Regex for interface(s) used for Gratuitous ARP. Cilium 1.19+ requires this key in the
+    # ConfigMap (l2-pod-announcements-interface-pattern); interface-only is not sufficient for the agent.
+    interfacePattern: "^enp3s0$"
   pmtuDiscovery:
     # -- Enable path MTU discovery to send ICMP fragmentation-needed replies to
     # the client.

--- a/helm-cache-poison.txt
+++ b/helm-cache-poison.txt
@@ -1,3 +1,3 @@
 # Helm cache poison file
 # Modify this file to force Helm cache invalidation
-# Last updated: 2025-04-18
+# Last updated: 2025-04-18-bravo

--- a/tf/nodes/.terraform.lock.hcl
+++ b/tf/nodes/.terraform.lock.hcl
@@ -1,6 +1,7 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+
 provider "registry.terraform.io/1password/onepassword" {
   version     = "3.3.1"
   constraints = ">= 2.1.2"


### PR DESCRIPTION
## Problem

After upgrading Cilium, agents can crash-loop with:

```
'--l2-pod-announcements-interface-pattern' must be set, when --enable-l2-pod-announcements=true'
```

Helm still emits `l2-pod-announcements-interface` when only `l2podAnnouncements.interface` is set; the 1.19 agent requires the `-pattern` ConfigMap key. That leaves `node.cilium.io/agent-not-ready` on nodes and blocks scheduling (e.g. replacement `argocd-repo-server` pods stuck Pending).

## Change

Set `l2podAnnouncements.interfacePattern: "^enp3s0$"` (same NIC as before) so Helm renders `l2-pod-announcements-interface-pattern`. Regenerated `charts/cilium/rendered.yaml` via `./build.sh`.

## Merge / rollout

Merge when ready; let Argo sync Cilium from Git (no imperative cluster edits from this PR).

Made with [Cursor](https://cursor.com)