### PR TITLE
fix(tf): Talos 1.13.0 for Image Factory + fables pointer

### DIFF
--- a/docs/bare-metal-nodes.md
+++ b/docs/bare-metal-nodes.md
@@ -99,7 +99,7 @@ Replace placeholders from Terraform outputs or plan. Generic Talos bare-metal co
 - **Metal ISO:** `https://factory.talos.dev/image/<METAL_AMD_SCHEMATIC>/v<TALOS_VERSION>/metal-amd64.iso`
 - **Installer image (machine config, bare metal):** `factory.talos.dev/metal-installer/<METAL_AMD_SCHEMATIC>:v<TALOS_VERSION>`
 
-`TALOS_VERSION` in URLs uses the `v` prefix (e.g. `v1.13.0-beta.1`); `terraform.tfvars` uses the same string without `v` (e.g. `1.13.0-beta.1`).
+`TALOS_VERSION` in URLs uses the `v` prefix (e.g. `v1.13.0`); `terraform.tfvars` uses the same string without `v` (e.g. `1.13.0`).
 
 ## Full-cluster rebuilds and VMs
 

--- a/docs/talos.md
+++ b/docs/talos.md
@@ -1,6 +1,6 @@
 # Talos
 
-This repo pins Talos Linux in [tf/nodes/terraform.tfvars](../tf/nodes/terraform.tfvars) (`talos_version`, for example `1.13.0-beta.1`). Image Factory schematics and ISOs are generated in [tf/nodes/talos-iso.tf](../tf/nodes/talos-iso.tf); installer images are patched in [tf/modules/talos-cluster/nodes.tf](../tf/modules/talos-cluster/nodes.tf).
+This repo pins Talos Linux in [tf/nodes/terraform.tfvars](../tf/nodes/terraform.tfvars) (`talos_version`, for example `1.13.0`). Image Factory schematics and ISOs are generated in [tf/nodes/talos-iso.tf](../tf/nodes/talos-iso.tf); installer images are patched in [tf/modules/talos-cluster/nodes.tf](../tf/modules/talos-cluster/nodes.tf).
 
 ## Image Factory and installer URL shape
 

--- a/tf/nodes/terraform.tfvars
+++ b/tf/nodes/terraform.tfvars
@@ -1,7 +1,7 @@
 onepassword_vault_name = "tiles-secrets"
 admin_user             = "seth.porter@gmail.com"
 proxmox_storage_iso    = "local"
-talos_version          = "1.13.0-beta.1"
+talos_version          = "1.13.0"
 project_id             = "symm-custodes"
 seed_project_id        = "symm-custodes"
 gcp_region             = "us-east1"


### PR DESCRIPTION
Pins `talos_version` to `1.13.0` because Image Factory no longer serves `1.13.0-beta.1`, which broke `nodes-plan-apply` (terraform data source: version not found). Doc examples updated to match.

Includes the `fables` submodule gitlink update as committed on this branch.

Rollout: OS change requires VM recreate (or in-place upgrade); Terraform pin alone does not reboot nodes.

Made with [Cursor](https://cursor.com)