### PR TITLE
fix(ci): scope nodes Terraform cache to tf/nodes lockfile

### DIFF
--- a/.github/workflows/nodes-plan-apply.yaml
+++ b/.github/workflows/nodes-plan-apply.yaml
@@ -111,17 +111,19 @@ jobs:
           workload_identity_provider: ${{ steps.load_secrets.outputs.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ steps.load_secrets.outputs.SERVICE_ACCOUNT_EMAIL }}
 
+      # Only tf/nodes: this workflow never bootstraps /tf/bootstrap, but caching **/.terraform
+      # and hashing **/.terraform.lock.hcl mixes bootstrap + nodes artifacts and restores
+      # unrelated .terraform subtrees onto the checkout. Prefer an exact-only key scoped to the
+      # nodes lockfile; drop restore-keys so we never resurrect a stale same-day entry that
+      # does not match the full key (hits should only be dirs produced solely by terraform
+      # init below). Key prefix `nodes-tf-v2` burns any older wide-cache payloads once.
       - name: Terraform cache
         if: steps.charts_only.outputs.run_terraform == 'true'
         id: tf-cache
         uses: actions/cache@v5
         with:
-          path: |
-            **/.terraform
-          # Use date so we refetch once a day no matter what.
-          key: ${{ runner.os }}-tf-${{ steps.stamps.outputs.DATESTAMP }}-${{ hashFiles('**/.terraform.lock.hcl', 'tf-cache-poison.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-tf-${{ steps.stamps.outputs.DATESTAMP }}-
+          path: tf/nodes/.terraform
+          key: ${{ runner.os }}-nodes-tf-v2-${{ steps.stamps.outputs.DATESTAMP }}-${{ hashFiles('tf/nodes/.terraform.lock.hcl', 'tf-cache-poison.txt') }}
 
       - name: Terraform init
         if: steps.charts_only.outputs.run_terraform == 'true' && steps.tf-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## What went wrong

Manual `nodes-plan-apply` runs failed with **Required plugins are not installed** while push-to-`main` runs (after a lockfile change) recovered. That pattern fits a **bad exact cache hit**, not just "init was skipped too aggressively".

Evidence from `actions/cache` behavior (see [Caching dependencies](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)):

- **`cache-hit` is only `true` for an exact primary key match.** Prefix `restore-keys` matches yield a hit with `cache-hit` not `true`, so **`terraform init` still ran** on fallback -- the old "skip init" path was not the culprit for prefix restores.
- When `cache-hit` is **`true`** we skip `init`, so the only way to get "lockfile wants these providers but nothing in `.terraform/providers"` is a **primary key that matches a tarball that never had a complete `terraform init`** for this workspace, or mixes other trees.

## Root-cause hypothesis

This job **only** runs `terraform init` under `tf/nodes`, but the cache previously used:

- **Path** `**/.terraform` (entire repo)** -- can pack or restore unrelated `.terraform` directories if they exist in the workspace.
- **Key** `hashFiles('**/.terraform.lock.hcl', ...)` -- **bootstrap + nodes** locks in one hash, so nodes cache keys move when only bootstrap changes, while the saved `.terraform` content is still whatever this job last produced under `tf/nodes`.

Together that is a good way to get **key collisions or mixed artifacts** that skip `init` on paper (exact hit) but leave `tf/nodes/.terraform` inconsistent with `tf/nodes/.terraform.lock.hcl`.

## Change

- Cache **only** `tf/nodes/.terraform`.
- Hash **only** `tf/nodes/.terraform.lock.hcl` (plus `tf-cache-poison.txt`).
- **Remove `restore-keys`** so there is no ambiguous same-day sibling entry.
- Migrate key with `nodes-tf-v2` so old wide-cache blobs are not reused once.
- Restore the original rule: **skip `terraform init` only on exact hit** (still the fast path).

---

If this still flakes, next place to look is whether the **post step** ever saves after a partial `init` or whether another workflow shares the same cache key namespace; with this scope that should be unlikely.

Made with [Cursor](https://cursor.com)