### PR TITLE
Argo CD: debug logs, repo-server ServiceMonitor, trace Tanka CMP plugin

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -255,7 +255,7 @@ data:
   repo.server: argocd-repo-server:8081
   reposerver.git.lsremote.parallelism.limit: "4"
   reposerver.log.format: text
-  reposerver.log.level: info
+  reposerver.log.level: debug
   reposerver.parallelism.limit: "4"
   server.dex.server: https://argocd-dex-server:5556
   server.dex.server.strict.tls: "false"
@@ -400,7 +400,9 @@ data:
     spec:
       init:
         # Symlink ./vendor to a shared emptyDir so jb populates one tree for all Tanka apps; tk still sees ./vendor.
-        command: ["sh", "-c", "ln -sfn /var/jb-vendor vendor && /home/argocd/cmp-server/plugins/jb install"]
+        # `sh -xc` traces each command to stderr so we can see how long the symlink + jb install actually take
+        # per invocation (debugging MatchRepository / GenerateManifest stalls). Revert to `sh -c` once resolved.
+        command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && /home/argocd/cmp-server/plugins/jb install"]
       parameters:
         static:
           - name: cluster_name
@@ -421,6 +423,9 @@ data:
   generate.sh: |
     #!/bin/sh
     set -euo pipefail
+    # Trace each command to stderr so we can see per-step timing in the tanka container log
+    # (debugging MatchRepository / GenerateManifest stalls). Remove once resolved.
+    set -x
     if [ -z "${ARGOCD_ENV_TK_ENV:-}" ]; then
       echo "ARGOCD_ENV_TK_ENV is not set" >&2
       exit 1
@@ -990,6 +995,31 @@ spec:
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/instance: argocd
 ---
+# Source: argocd/charts/argo-cd/templates/argocd-repo-server/metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-repo-server-metrics
+  namespace: argocd
+  labels:
+    helm.sh/chart: argo-cd-9.5.2
+    app.kubernetes.io/name: argocd-repo-server-metrics
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/component: repo-server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: "v3.3.7"
+spec:
+  type: ClusterIP  
+  ports:
+  - name: http-metrics
+    protocol: TCP
+    port: 8084
+    targetPort: metrics
+  selector:
+    app.kubernetes.io/name: argocd-repo-server
+    app.kubernetes.io/instance: argocd
+---
 # Source: argocd/charts/argo-cd/templates/argocd-repo-server/service.yaml
 apiVersion: v1
 kind: Service
@@ -1148,7 +1178,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 4ce5512f1d301b3a3324872720e1a22444ac0e0120eeff416ca6cdc3a3fdb444
+        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-applicationset-controller
@@ -1442,7 +1472,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 4ce5512f1d301b3a3324872720e1a22444ac0e0120eeff416ca6cdc3a3fdb444
+        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -1901,7 +1931,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 4ce5512f1d301b3a3324872720e1a22444ac0e0120eeff416ca6cdc3a3fdb444
+        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2364,7 +2394,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 4ce5512f1d301b3a3324872720e1a22444ac0e0120eeff416ca6cdc3a3fdb444
+        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2608,7 +2638,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 4ce5512f1d301b3a3324872720e1a22444ac0e0120eeff416ca6cdc3a3fdb444
+        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -3111,6 +3141,35 @@ spec:
       app.kubernetes.io/name: argocd-metrics
       app.kubernetes.io/instance: argocd
       app.kubernetes.io/component: application-controller
+---
+# Source: argocd/charts/argo-cd/templates/argocd-repo-server/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-repo-server
+  namespace: "argocd"
+  labels:
+    helm.sh/chart: argo-cd-9.5.2
+    app.kubernetes.io/name: argocd-repo-server
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/component: repo-server
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/version: "v3.3.7"
+spec:
+  endpoints:
+    - port: http-metrics
+      interval: 30s
+      path: /metrics
+      honorLabels: false
+  namespaceSelector:
+    matchNames:
+      - argocd
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server-metrics
+      app.kubernetes.io/instance: argocd
+      app.kubernetes.io/component: repo-server
 ---
 # Source: argocd/charts/argo-cd/templates/argocd-server/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/charts/argocd/templates/tanka.yaml
+++ b/charts/argocd/templates/tanka.yaml
@@ -13,7 +13,9 @@ data:
     spec:
       init:
         # Symlink ./vendor to a shared emptyDir so jb populates one tree for all Tanka apps; tk still sees ./vendor.
-        command: ["sh", "-c", "ln -sfn /var/jb-vendor vendor && /home/argocd/cmp-server/plugins/jb install"]
+        # `sh -xc` traces each command to stderr so we can see how long the symlink + jb install actually take
+        # per invocation (debugging MatchRepository / GenerateManifest stalls). Revert to `sh -c` once resolved.
+        command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && /home/argocd/cmp-server/plugins/jb install"]
       parameters:
         static:
           - name: cluster_name
@@ -34,6 +36,9 @@ data:
   generate.sh: |
     #!/bin/sh
     set -euo pipefail
+    # Trace each command to stderr so we can see per-step timing in the tanka container log
+    # (debugging MatchRepository / GenerateManifest stalls). Remove once resolved.
+    set -x
     if [ -z "${ARGOCD_ENV_TK_ENV:-}" ]; then
       echo "ARGOCD_ENV_TK_ENV is not set" >&2
       exit 1

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -125,6 +125,10 @@ argo-cd:
       # Cap concurrent manifest generation and git ls-remote during cold start (see repoServer.livenessProbe).
       reposerver.parallelism.limit: "4"
       reposerver.git.lsremote.parallelism.limit: "4"
+      # Temporary while we diagnose 30-60s MatchRepository / GenerateManifest stalls
+      # against the Tanka CMP sidecar. Per-step traces from the repo-server side are
+      # only emitted at debug level. Revert once the source of the wait is identified.
+      reposerver.log.level: debug
 
   ## Application controller
   controller:
@@ -268,6 +272,15 @@ argo-cd:
     livenessProbe:
       timeoutSeconds: 5
       failureThreshold: 3
+    ## Repo-server metrics service configuration
+    metrics:
+      # -- Deploy metrics service
+      enabled: true
+      serviceMonitor:
+        # -- Enable a prometheus ServiceMonitor
+        # Needed to graph argocd_git_request_duration_seconds, argocd_repo_pending_request_total,
+        # grpc_server_handling_seconds_*, etc. for the repo-server -> CMP path.
+        enabled: true
     # Following https://raynix.info/archives/4565
     extraContainers:
       - name: tanka


### PR DESCRIPTION
## Summary

Three observability knobs to help diagnose the 30-60s `MatchRepository` /
`GenerateManifest` stalls we are seeing against the Tanka CMP sidecar on
`tiles-test` (follow-up to #394, which capped parallelism and calmed the
liveness probe but did not eliminate the stalls).

* **`reposerver.log.level: debug`** in `argocd-cmd-params-cm`. The
  per-step traces from the repo-server side of the CMP gRPC calls
  (`MatchRepository`, `GenerateManifest`, git ops) are only emitted at
  debug. Without them we cannot tell where the wall time inside
  repo-server is going before the first byte hits the sidecar.
* **`repoServer.metrics` + `serviceMonitor` enabled.** This adds an
  `argocd-repo-server-metrics` Service on port 8084 and a ServiceMonitor
  so Prometheus / Mimir continuously scrapes
  `argocd_git_request_duration_seconds`,
  `argocd_repo_pending_request_total`,
  `grpc_server_handling_seconds_*`, etc. Right now these only show up
  via one-off `kubectl exec curl` against the metrics port, which is no
  good for historical analysis.
* **`sh -xc` on the Tanka plugin `init` command and `set -x` in
  `generate.sh`** (`charts/argocd/templates/tanka.yaml`). Traces every
  command the per-invocation `jb install` and the manifest generation
  pipeline run, with timestamps in the `tanka` container log, so we can
  see how much time each step actually takes per call.

All three are intended to be temporary; revert once the source of the
stalls is identified.

`charts/argocd/rendered.yaml` is the regenerated `helm template` output
from `./build.sh` (Argo CD subchart pinned at `9.5.2` / `v3.3.7`,
unchanged from `Chart.lock`). The diff includes the new
`argocd-repo-server-metrics` Service + ServiceMonitor, the updated
`reposerver.log.level`, the `sh -xc` / `set -x` lines in the cmp-tanka
ConfigMap, and the corresponding `checksum/cmd-params` annotation
updates on the workloads that mount that CM.

## Test plan

- [ ] CI: `./build.sh` passes (no Helm lint regressions, `rendered.yaml`
      matches what is committed).
- [ ] After deploy: `kubectl -n argocd get svc argocd-repo-server-metrics`
      and `kubectl -n argocd get servicemonitor argocd-repo-server` exist.
- [ ] Mimir: `argocd_git_request_total{namespace="argocd"}` and
      `grpc_server_handling_seconds_count{grpc_service=~".*Repo.*"}` start
      reporting a non-empty series.
- [ ] `kubectl -n argocd logs deploy/argocd-repo-server -c repo-server`
      shows debug-level lines for `MatchRepository` /
      `GenerateManifest` / git ops.
- [ ] `kubectl -n argocd logs deploy/argocd-repo-server -c tanka` shows
      `+ ln -sfn ...`, `+ /home/argocd/cmp-server/plugins/jb install`
      from `init`, and `+`-prefixed lines from `generate.sh` per call.


Made with [Cursor](https://cursor.com)