### PR TITLE
Argo CD: bump repo-server log level from debug to trace

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -255,7 +255,7 @@ data:
   repo.server: argocd-repo-server:8081
   reposerver.git.lsremote.parallelism.limit: "4"
   reposerver.log.format: text
-  reposerver.log.level: debug
+  reposerver.log.level: trace
   reposerver.parallelism.limit: "4"
   server.dex.server: https://argocd-dex-server:5556
   server.dex.server.strict.tls: "false"
@@ -1178,7 +1178,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
+        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-applicationset-controller
@@ -1472,7 +1472,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
+        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -1931,7 +1931,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
+        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2394,7 +2394,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
+        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2638,7 +2638,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: ffca6b2c9a28de7bdf650800a3c73ec0b3a6785321fc836415467ae129bb2645
+        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -125,10 +125,12 @@ argo-cd:
       # Cap concurrent manifest generation and git ls-remote during cold start (see repoServer.livenessProbe).
       reposerver.parallelism.limit: "4"
       reposerver.git.lsremote.parallelism.limit: "4"
-      # Temporary while we diagnose 30-60s MatchRepository / GenerateManifest stalls
-      # against the Tanka CMP sidecar. Per-step traces from the repo-server side are
-      # only emitted at debug level. Revert once the source of the wait is identified.
-      reposerver.log.level: debug
+      # Diagnosing 30-60s MatchRepository / GenerateManifest stalls against the Tanka
+      # CMP sidecar. At debug we observe the repo-server log going silent for ~48s
+      # between accepting a CMP GenerateManifest and the deadline-driven failure --
+      # the silent side is repo-server itself. Bumping to trace to surface whatever
+      # code path is being walked during that window.
+      reposerver.log.level: trace
 
   ## Application controller
   controller:


### PR DESCRIPTION
## Summary

Follow-up to #422 to get usable log lines out of the side that is currently the source of the stalls.

With #422's debug logging in place we now have direct evidence that:

* The **repo-server** accepts CMP-style ``GenerateManifest`` calls, processes Helm-based generations in seconds, then **goes silent for ~48 seconds** before the deadline forces the call to fail with ``error sending tgz file to cmp-server: error sending stream: EOF``.
* The **tanka cmp-server sidecar** logs the mirror image -- ``error receiving tgz file: stream context error: context deadline exceeded`` -- meaning it spent that same ~48 seconds blocked on ``Recv()`` with no bytes arriving from the repo-server.

So the bottleneck is not the sidecar; it is the repo-server's path between accepting the call and starting to stream the tgz. At ``debug`` the repo-server emits nothing in that window. ``trace`` is the next level (per ``argocd-repo-server --loglevel`` flag, ``trace|debug|info|warn|error``) and is the natural next step.

Cmp-server is intentionally **not** changed in this PR; bumping it from info would not help because it is correctly logging "I am waiting on a stream that never delivers".

This is a single-line knob bump in ``charts/argocd/values.yaml``:

``` 
- reposerver.log.level: debug
+ reposerver.log.level: trace
```

The rendered.yaml diff is the value change plus the corresponding ``checksum/cmd-params`` annotation rolls.

## Test plan

- [ ] CI: ``./build.sh`` passes, ``rendered.yaml`` matches.
- [ ] After deploy: ``kubectl -n argocd get cm argocd-cmd-params-cm -o jsonpath='{.data.reposerver\.log\.level}'`` returns ``trace``.
- [ ] After repo-server pod rolls: ``kubectl -n argocd logs deploy/argocd-repo-server -c repo-server`` contains ``level=trace`` lines.
- [ ] Trigger a refresh on a stuck Tanka app (e.g. ``kubernetes-mixin``) and verify the repo-server log produces lines across the previously-silent window between ``started call`` for ``GenerateManifest`` and the deadline-driven failure.


Made with [Cursor](https://cursor.com)