### PR TITLE
Argo CD: bump controller -> repo-server gRPC deadline 60s -> 300s

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -246,6 +246,7 @@ data:
   commitserver.log.level: info
   controller.log.format: text
   controller.log.level: info
+  controller.repo.server.timeout.seconds: "300"
   dexserver.log.format: text
   dexserver.log.level: info
   notificationscontroller.log.format: text
@@ -1178,7 +1179,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
+        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-applicationset-controller
@@ -1472,7 +1473,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
+        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -1931,7 +1932,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
+        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2394,7 +2395,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
+        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2638,7 +2639,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 216965e48e37d518981a74e3bdf80c55ba4e8fb7cfe71d30709fc9078e0c8f71
+        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -125,6 +125,14 @@ argo-cd:
       # Cap concurrent manifest generation and git ls-remote during cold start (see repoServer.livenessProbe).
       reposerver.parallelism.limit: "4"
       reposerver.git.lsremote.parallelism.limit: "4"
+      # Tanka CMP MatchRepository / GenerateManifest stalls are observed to last
+      # ~60s and consistently hit the default controller -> repo-server gRPC
+      # deadline of 60s, leaving the affected apps stuck in Unknown. We have
+      # not isolated the root cause; this bumps the deadline so the same calls
+      # have headroom to finish and the apps can actually deploy. The deadline
+      # is propagated as a context deadline through the repo-server into the
+      # CMP-server gRPC call, so this also widens the cmp-server side window.
+      controller.repo.server.timeout.seconds: "300"
       # Diagnosing 30-60s MatchRepository / GenerateManifest stalls against the Tanka
       # CMP sidecar. At debug we observe the repo-server log going silent for ~48s
       # between accepting a CMP GenerateManifest and the deadline-driven failure --


### PR DESCRIPTION
## Summary

Sets \`controller.repo.server.timeout.seconds: \"300\"\` (default is 60).

## Why

Tanka CMP \`MatchRepository\` / \`GenerateManifest\` calls have been observed to consistently run ~60s and hit the default 60s deadline, leaving the affected apps stuck in Sync Status: Unknown across refreshes:

\`\`\`
grpc.method=MatchRepository
grpc.start_time=2026-05-09T13:50:18Z
grpc.request.deadline=2026-05-09T13:51:18Z   <-- 60s
grpc.code=Unknown
grpc.error=match repository error receiving stream:
            error receiving tgz file: stream context error:
            context deadline exceeded
\`\`\`

The deadline is set on the application controller's outbound gRPC call to \`repo-server\` and propagated as a context deadline through the \`repo-server\` into the CMP-server gRPC call, so when those calls run long every layer cancels at exactly the deadline.

## What this does NOT do

This does not fix the slowness. The root cause of the long Tanka CMP runs is not yet isolated -- node CPU, RAM, and disk on \`tiles-test-wk\` are not saturated during the silent window, and we have not found the source of the dead air. This change only widens the deadline so the same calls have headroom to finish and the apps can actually deploy while we keep investigating.

## Test plan

- [ ] After merge: confirm \`tiles-test\` Tanka apps that were stuck in Unknown progress to Synced (possibly slowly).
- [ ] Confirm new \`grpc.request.deadline\` values in \`argocd-repo-server\` / \`tanka\` logs are 300s after \`grpc.start_time\`.


Made with [Cursor](https://cursor.com)