### PR TITLE
argocd: serialize Tanka CMP jb install with flock against shared cache

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -401,9 +401,13 @@ data:
     spec:
       init:
         # Symlink ./vendor to a shared emptyDir so jb populates one tree for all Tanka apps; tk still sees ./vendor.
-        # `sh -xc` traces each command to stderr so we can see how long the symlink + jb install actually take
-        # per invocation (debugging MatchRepository / GenerateManifest stalls). Revert to `sh -c` once resolved.
-        command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && /home/argocd/cmp-server/plugins/jb install"]
+        # `flock` serializes `jb install` against the shared cache: jsonnet-bundler is not safe for concurrent
+        # writes to the same vendor dir and panics with "rename ... file exists" when two parallel CMP calls race
+        # on the same module download. The lock file lives in the shared cache itself so it persists for pod
+        # lifetime; busybox flock takes `FILE PROG ARGS` (exclusive + blocking by default), and the upstream
+        # alpine-git-curl image already provides /usr/bin/flock as a busybox applet.
+        # `sh -xc` keeps step-by-step traces in the cmp-server stderr.
+        command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && flock /var/jb-vendor/.lock /home/argocd/cmp-server/plugins/jb install"]
       parameters:
         static:
           - name: cluster_name

--- a/charts/argocd/templates/tanka.yaml
+++ b/charts/argocd/templates/tanka.yaml
@@ -13,9 +13,13 @@ data:
     spec:
       init:
         # Symlink ./vendor to a shared emptyDir so jb populates one tree for all Tanka apps; tk still sees ./vendor.
-        # `sh -xc` traces each command to stderr so we can see how long the symlink + jb install actually take
-        # per invocation (debugging MatchRepository / GenerateManifest stalls). Revert to `sh -c` once resolved.
-        command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && /home/argocd/cmp-server/plugins/jb install"]
+        # `flock` serializes `jb install` against the shared cache: jsonnet-bundler is not safe for concurrent
+        # writes to the same vendor dir and panics with "rename ... file exists" when two parallel CMP calls race
+        # on the same module download. The lock file lives in the shared cache itself so it persists for pod
+        # lifetime; busybox flock takes `FILE PROG ARGS` (exclusive + blocking by default), and the upstream
+        # alpine-git-curl image already provides /usr/bin/flock as a busybox applet.
+        # `sh -xc` keeps step-by-step traces in the cmp-server stderr.
+        command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && flock /var/jb-vendor/.lock /home/argocd/cmp-server/plugins/jb install"]
       parameters:
         static:
           - name: cluster_name


### PR DESCRIPTION
## Summary

The shared `/var/jb-vendor` cache (PR #394) was added to amortize Jsonnet dependency downloads across all Tanka apps -- they share a single library dir, so without the cache every CMP call was independently downloading the entire stack from GitHub and the cold cluster was unreliable. We very much want to keep that.

But `jsonnet-bundler` (`jb`) is not safe for concurrent writes to the same vendor dir. With the controller -> repo gRPC deadline bumped to 300s in #425 we finally saw the underlying failure surface from `tanka` sidecar logs:

`````
+ ln -sfn /var/jb-vendor vendor
+ /home/argocd/cmp-server/plugins/jb install
GET https://github.com/grafana/alloy/archive/<sha>.tar.gz 200
panic: rename /tmp/_cmp_server/<uuid>/tanka/vendor/.tmp/<sha>/operations/alloy-mixin
              /tmp/_cmp_server/<uuid>/tanka/vendor/github.com/grafana/alloy/operations/alloy-mixin:
              file exists
goroutine 1 [running]:
github.com/jsonnet-bundler/jsonnet-bundler/pkg.(*GitPackage).Install(...)
`````

Two (or more) parallel CMP `jb install` calls racing on the rename of the same downloaded module into the shared cache. ArgoCD runs CMP calls in parallel with `reposerver.parallelism.limit: 4`, so as soon as the cluster has more than one Tanka app refreshing at once we hit it.

This PR wraps the install in `flock` so only one `jb install` runs at a time per repo-server pod:

`````diff
- command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && /home/argocd/cmp-server/plugins/jb install"]
+ command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && flock /var/jb-vendor/.lock /home/argocd/cmp-server/plugins/jb install"]
`````

### Why `flock` and not an overlay/runtime install

Verified live in the running tanka sidecar:

`````
$ command -v flock
/usr/bin/flock
$ ls -la /usr/bin/flock
lrwxrwxrwx 1 root root 12 Jun 25  2017 /usr/bin/flock -> /bin/busybox
$ apk info -W /usr/bin/flock
/usr/bin/flock symlink target is owned by busybox-1.26.2-r5
`````

The upstream `prontotools/alpine-git-curl` image already ships `flock` as a busybox applet. No overlay image, no `apk add` at runtime. Busybox `flock` takes `FILE PROG ARGS`, defaults to exclusive + blocking, which is exactly the semantics we want.

### Why a lock file inside the cache

`/var/jb-vendor` is the shared `emptyDir` mounted into the tanka container. Putting `.lock` inside it means:

- It persists for the pod lifetime alongside the cache it protects.
- Both the cache and its lock get cleaned up together when the pod is recycled.
- No extra volume / no /tmp cleanup concerns.

### Behavior

- **Cold start (multiple parallel CMP calls):** first wins the lock and does the full download once; the rest queue and then run against the warm cache, so total wallclock is ~ one cold install + N-1 fast no-ops. With the 300s deadline from #425 there is plenty of headroom.
- **Warm steady state:** lock is essentially free; `jb install` is a no-op once everything is present.
- **Crash safety:** kernel releases the lock when the holding process exits, including on the panic itself, so a crashing jb does not wedge the pod.
- **Versus option (3) "warm at startup":** declined per operator feedback -- as soon as a dep changes we are back to "only one can refresh at a time" anyway, so we may as well always serialize.

## Test plan

- [ ] Roll out and watch `tanka` sidecar logs across a refresh of the Tanka apps -- confirm no more `panic: rename ... file exists`.
- [ ] Confirm previously-Unknown Tanka apps move to Synced/Healthy.
- [ ] Confirm subsequent CMP invocations are fast (warm cache + cheap lock acquire).


Made with [Cursor](https://cursor.com)