### PR TITLE
Argo CD: keep Tanka vendor cache in real dirs

### DIFF
--- a/.cursor/rules/kubectl-kubeconfig-tiles.mdc
+++ b/.cursor/rules/kubectl-kubeconfig-tiles.mdc
@@ -1,0 +1,25 @@
+---
+description: kubectl against tiles clusters -- use KUBECONFIG files, not --context
+alwaysApply: true
+---
+
+# kubectl for Tiles (test vs prod)
+
+When proposing or running **kubectl** against the **Tiles** clusters from this repo, use a **scoped kubeconfig via `KUBECONFIG`** so commands stay approve-friendly (avoid **`kubectl`** **`--context`** for cluster selection).
+
+**Files (operator layout; canonical in `facts/fables/Tiles/TODO.md` / `docs/dev-setup.md`):**
+
+| Cluster    | Typical file              |
+|-----------|---------------------------|
+| **tiles-test** | `$HOME/.kube/tiles-test.yaml` |
+| **tiles** (prod) | `$HOME/.kube/tiles.yaml` |
+
+**Preferred form:**
+
+```bash
+KUBECONFIG="$HOME/.kube/tiles-test.yaml" kubectl get ns
+KUBECONFIG="$HOME/.kube/tiles.yaml" kubectl get ns
+```
+
+- Do **not** rely on **`--context`** (e.g. `admin@tiles-test`, `admin@tiles`) in agent shells unless the operator explicitly overrides this rule -- those names describe contexts **inside** a merged kubeconfig, not this invocation style.
+- If a tool (e.g. MCP) takes a **`context`** parameter separately, follow that tool's schema; still use **`KUBECONFIG=...`** for **`kubectl`** in the terminal.

--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -400,14 +400,14 @@ data:
       name: tanka
     spec:
       init:
-        # Symlink ./vendor to a shared emptyDir so jb populates one tree for all Tanka apps; tk still sees ./vendor.
-        # `flock` serializes `jb install` against the shared cache: jsonnet-bundler is not safe for concurrent
-        # writes to the same vendor dir and panics with "rename ... file exists" when two parallel CMP calls race
-        # on the same module download. The lock file lives in the shared cache itself so it persists for pod
-        # lifetime; busybox flock takes `FILE PROG ARGS` (exclusive + blocking by default), and the upstream
-        # alpine-git-curl image already provides /usr/bin/flock as a busybox applet.
-        # `sh -xc` keeps step-by-step traces in the cmp-server stderr.
-        command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && flock /var/jb-vendor/.lock /home/argocd/cmp-server/plugins/jb install"]
+        # Keep ./vendor as a real directory in the CMP checkout. jsonnet-bundler v0.6.0 writes through a vendor
+        # symlink during extraction, then removes the symlink before creating legacy-import symlinks, failing with
+        # "symlink ... vendor/<package>: no such file or directory".
+        # `flock` serializes copy-in, `jb install`, and copy-back against a shared cache keyed by the lockfile hash:
+        # this avoids concurrent writes and avoids reusing stale package trees after jsonnetfile.lock.json changes.
+        # busybox flock takes `FILE PROG ARGS` (exclusive + blocking by default), and the upstream alpine-git-curl
+        # image already provides /usr/bin/flock as a busybox applet. `sh -xc` keeps step-by-step traces in stderr.
+        command: ["sh", "-xc", "flock /var/jb-vendor/.lock sh -xec 'hash=\"$(sha256sum jsonnetfile.lock.json | cut -d\" \" -f1)\"; cache_dir=\"/var/jb-vendor/${hash}\"; rm -rf vendor; mkdir -p vendor \"${cache_dir}\"; cp -a \"${cache_dir}/.\" vendor/; /home/argocd/cmp-server/plugins/jb install; cp -a vendor/. \"${cache_dir}/\"'"]
       parameters:
         static:
           - name: cluster_name

--- a/charts/argocd/templates/tanka.yaml
+++ b/charts/argocd/templates/tanka.yaml
@@ -12,14 +12,14 @@ data:
       name: tanka
     spec:
       init:
-        # Symlink ./vendor to a shared emptyDir so jb populates one tree for all Tanka apps; tk still sees ./vendor.
-        # `flock` serializes `jb install` against the shared cache: jsonnet-bundler is not safe for concurrent
-        # writes to the same vendor dir and panics with "rename ... file exists" when two parallel CMP calls race
-        # on the same module download. The lock file lives in the shared cache itself so it persists for pod
-        # lifetime; busybox flock takes `FILE PROG ARGS` (exclusive + blocking by default), and the upstream
-        # alpine-git-curl image already provides /usr/bin/flock as a busybox applet.
-        # `sh -xc` keeps step-by-step traces in the cmp-server stderr.
-        command: ["sh", "-xc", "ln -sfn /var/jb-vendor vendor && flock /var/jb-vendor/.lock /home/argocd/cmp-server/plugins/jb install"]
+        # Keep ./vendor as a real directory in the CMP checkout. jsonnet-bundler v0.6.0 writes through a vendor
+        # symlink during extraction, then removes the symlink before creating legacy-import symlinks, failing with
+        # "symlink ... vendor/<package>: no such file or directory".
+        # `flock` serializes copy-in, `jb install`, and copy-back against a shared cache keyed by the lockfile hash:
+        # this avoids concurrent writes and avoids reusing stale package trees after jsonnetfile.lock.json changes.
+        # busybox flock takes `FILE PROG ARGS` (exclusive + blocking by default), and the upstream alpine-git-curl
+        # image already provides /usr/bin/flock as a busybox applet. `sh -xc` keeps step-by-step traces in stderr.
+        command: ["sh", "-xc", "flock /var/jb-vendor/.lock sh -xec 'hash=\"$(sha256sum jsonnetfile.lock.json | cut -d\" \" -f1)\"; cache_dir=\"/var/jb-vendor/${hash}\"; rm -rf vendor; mkdir -p vendor \"${cache_dir}\"; cp -a \"${cache_dir}/.\" vendor/; /home/argocd/cmp-server/plugins/jb install; cp -a vendor/. \"${cache_dir}/\"'"]
       parameters:
         static:
           - name: cluster_name


### PR DESCRIPTION
## Summary
- Keep each Tanka CMP checkout's `vendor/` as a real directory so `jb install` can create legacy-import symlinks successfully.
- Preserve the shared repo-server cache by copying from and back to `/var/jb-vendor/<sha256(jsonnetfile.lock.json)>/` under `flock`.
- Add the Tiles kubectl kubeconfig rule so agent terminal commands use scoped `KUBECONFIG` files instead of `--context`.

## Test plan
- `source ~/.zshrc && /home/symmetry/tiles/build.sh`
- Local repro: symlinked `vendor` fails with `jb v0.6.0`; real `vendor` succeeds; hash-keyed warm cache exits cleanly without downloads.
- `git diff --check -- charts/argocd/templates/tanka.yaml charts/argocd/rendered.yaml`


Made with [Cursor](https://cursor.com)