### PR TITLE
Argo CD: allow postgres operator UI chart repo

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -3066,6 +3066,7 @@ spec:
     - https://charts.containeroo.ch
     - https://grafana.github.io/helm-charts
     - https://opensource.zalando.com/postgres-operator/charts/postgres-operator
+    - https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui
   destinations:
     - server: https://kubernetes.default.svc
       namespace: "*"

--- a/charts/argocd/templates/tiles-appproject.yaml
+++ b/charts/argocd/templates/tiles-appproject.yaml
@@ -11,6 +11,7 @@ spec:
     - https://charts.containeroo.ch
     - https://grafana.github.io/helm-charts
     - https://opensource.zalando.com/postgres-operator/charts/postgres-operator
+    - https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui
   destinations:
     - server: https://kubernetes.default.svc
       namespace: "*"


### PR DESCRIPTION
## Summary
- Add the postgres-operator-ui Helm repository to the `tiles-test` AppProject source repo allow-list.
- Regenerate `charts/argocd/rendered.yaml`.

## Test plan
- `source ~/.zshrc && /home/symmetry/tiles/build.sh`
- Checked rendered `argocd-applications` repo URLs against `charts/argocd/rendered.yaml` AppProject `sourceRepos`; this was the only missing repo URL.


Made with [Cursor](https://cursor.com)