### PR TITLE
Alloy: integration-only scrape, alloy-mixin + cert-manager-mixin Argo

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -201,7 +201,8 @@ spec:
         alloy-metrics:
           enabled: true
           serviceMonitor:
-            enabled: true
+            # Metrics come from integrations.alloy scrape (job=integrations/alloy, allow-listed).
+            enabled: false
           # This is the instance running prometheus.operator.probes
           # so make it also the blackbox exporter.
           # https://github.com/grafana/alloy/issues/2333#issuecomment-2741631302
@@ -224,7 +225,7 @@ spec:
             }
           enabled: true
           serviceMonitor:
-            enabled: true
+            enabled: false
           alloy:
             resources: # Set 2025-07-20
               # requests:
@@ -234,7 +235,7 @@ spec:
         alloy-logs:
           enabled: true
           serviceMonitor:
-            enabled: true
+            enabled: false
           alloy:
             mounts:
               # /var/log/pods and /var/log/containers exist. (Also audit.)
@@ -243,7 +244,7 @@ spec:
         alloy-receiver:
           enabled: true
           serviceMonitor:
-            enabled: true
+            enabled: false
           controller:
             type: "deployment"
           alloy:
@@ -266,6 +267,30 @@ spec:
                     - alloy-metrics
                     - alloy-singleton
                     - alloy-logs
+                    - alloy-receiver
+                metrics:
+                  tuning:
+                    # Grafana alloy-mixin uses metrics beyond k8s-monitoring default-allow-lists/alloy.yaml.
+                    includeMetrics:
+                      - cluster_minimum_size
+                      - loki_source_file_.*
+                      - loki_source_journal_.*
+                      - loki_write_entry_propagation_latency_seconds.*
+                      - loki_write_request_size_bytes.*
+                      - otelcol_receiver_(accepted|refused)_(metric_points|log_records)_total
+                      - otelcol_exporter_sent_(metric_points|log_records|spans)_total
+                      - otelcol_exporter_send_failed_(metric_points|log_records|spans)_total
+                      - otelcol_exporter_enqueue_failed_(log_records|metric_points|spans)_total
+                      - otelcol_exporter_queue_.*
+                      - otelcol_processor_(incoming|outgoing)_items_total
+                      - otelcol_processor_refused_(metric_points|spans)_total
+                      - otelcol_processor_batch_batch_size_trigger_send_total
+                      - http_(client|server)_duration_milliseconds_bucket
+                      - rpc_(client|server)_duration_milliseconds_bucket
+                      - otelcol_process_cpu_seconds_total
+                      - otelcol_process_memory_rss_bytes
+                      - otelcol_process_runtime_total_alloc_bytes_total
+                      - otelcol_process_uptime_seconds_total
           cert-manager:
             instances:
               - name: cert-manager
@@ -306,6 +331,40 @@ spec:
         pod-security.kubernetes.io/enforce: privileged
         pod-security.kubernetes.io/warn: privileged
         trust-bundle: enabled
+---
+# Source: argocd-applications/templates/alloy-mixin-application.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: alloy-mixin
+spec:
+  project: 'placeholder'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: 'placeholder'
+    path: tanka
+    plugin:
+      env:
+        - name: TK_ENV
+          value: alloy-mixin
+      parameters:
+        - name: cluster_name
+          string: 'placeholder'
+        - name: vault_name
+          string: 'placeholder'
+        - name: project_id
+          string: 'placeholder'
+        - name: app_settings
+          map: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: alloy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
 ---
 # Source: argocd-applications/templates/apprise-application.yaml
 apiVersion: argoproj.io/v1alpha1
@@ -459,6 +518,40 @@ spec:
     managedNamespaceMetadata:
       labels:
         pod-security.kubernetes.io/warn: baseline
+---
+# Source: argocd-applications/templates/cert-manager-mixin-application.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-mixin
+spec:
+  project: 'placeholder'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: 'placeholder'
+    path: tanka
+    plugin:
+      env:
+        - name: TK_ENV
+          value: cert-manager-mixin
+      parameters:
+        - name: cluster_name
+          string: 'placeholder'
+        - name: vault_name
+          string: 'placeholder'
+        - name: project_id
+          string: 'placeholder'
+        - name: app_settings
+          map: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
 ---
 # Source: argocd-applications/templates/cilium-application.yaml
 apiVersion: argoproj.io/v1alpha1

--- a/charts/argocd-applications/templates/alloy-application.yaml
+++ b/charts/argocd-applications/templates/alloy-application.yaml
@@ -199,7 +199,8 @@ spec:
         alloy-metrics:
           enabled: true
           serviceMonitor:
-            enabled: true
+            # Metrics come from integrations.alloy scrape (job=integrations/alloy, allow-listed).
+            enabled: false
           # This is the instance running prometheus.operator.probes
           # so make it also the blackbox exporter.
           # https://github.com/grafana/alloy/issues/2333#issuecomment-2741631302
@@ -222,7 +223,7 @@ spec:
             }
           enabled: true
           serviceMonitor:
-            enabled: true
+            enabled: false
           alloy:
             resources: # Set 2025-07-20
               # requests:
@@ -232,7 +233,7 @@ spec:
         alloy-logs:
           enabled: true
           serviceMonitor:
-            enabled: true
+            enabled: false
           alloy:
             mounts:
               # /var/log/pods and /var/log/containers exist. (Also audit.)
@@ -241,7 +242,7 @@ spec:
         alloy-receiver:
           enabled: true
           serviceMonitor:
-            enabled: true
+            enabled: false
           controller:
             type: "deployment"
           alloy:
@@ -264,6 +265,30 @@ spec:
                     - alloy-metrics
                     - alloy-singleton
                     - alloy-logs
+                    - alloy-receiver
+                metrics:
+                  tuning:
+                    # Grafana alloy-mixin uses metrics beyond k8s-monitoring default-allow-lists/alloy.yaml.
+                    includeMetrics:
+                      - cluster_minimum_size
+                      - loki_source_file_.*
+                      - loki_source_journal_.*
+                      - loki_write_entry_propagation_latency_seconds.*
+                      - loki_write_request_size_bytes.*
+                      - otelcol_receiver_(accepted|refused)_(metric_points|log_records)_total
+                      - otelcol_exporter_sent_(metric_points|log_records|spans)_total
+                      - otelcol_exporter_send_failed_(metric_points|log_records|spans)_total
+                      - otelcol_exporter_enqueue_failed_(log_records|metric_points|spans)_total
+                      - otelcol_exporter_queue_.*
+                      - otelcol_processor_(incoming|outgoing)_items_total
+                      - otelcol_processor_refused_(metric_points|spans)_total
+                      - otelcol_processor_batch_batch_size_trigger_send_total
+                      - http_(client|server)_duration_milliseconds_bucket
+                      - rpc_(client|server)_duration_milliseconds_bucket
+                      - otelcol_process_cpu_seconds_total
+                      - otelcol_process_memory_rss_bytes
+                      - otelcol_process_runtime_total_alloc_bytes_total
+                      - otelcol_process_uptime_seconds_total
           cert-manager:
             instances:
               - name: cert-manager

--- a/charts/argocd-applications/templates/alloy-mixin-application.yaml
+++ b/charts/argocd-applications/templates/alloy-mixin-application.yaml
@@ -1,0 +1,1 @@
+../../../tanka/environments/alloy-mixin/application.yaml

--- a/charts/argocd-applications/templates/cert-manager-mixin-application.yaml
+++ b/charts/argocd-applications/templates/cert-manager-mixin-application.yaml
@@ -1,0 +1,1 @@
+../../../tanka/environments/cert-manager-mixin/application.yaml

--- a/tanka/environments/alloy-mixin/main.jsonnet
+++ b/tanka/environments/alloy-mixin/main.jsonnet
@@ -2,9 +2,14 @@ local alloyMixin = import 'github.com/grafana/alloy/operations/alloy-mixin/mixin
 local libMonResources = import 'monitoring-resources.libsonnet';
 
 libMonResources.new(
-  alloyMixin,
+  alloyMixin {
+    _config+:: {
+      filterSelector: 'job="integrations/alloy"',
+    },
+  },
   {
     folder: 'Alloy',
     namespace: 'alloy',
+    tags: ['alloy'],
   },
 )


### PR DESCRIPTION
## Summary

- **k8s-monitoring / Alloy:** Turn off per-collector ServiceMonitors for `alloy-metrics`, `alloy-singleton`, `alloy-logs`, and `alloy-receiver`; keep metrics via **`integrations.alloy`** (`job="integrations/alloy"`) so we do not double-scrape Alloy into Mimir.
- **integrations.alloy:** Add **`alloy-receiver`** to label selectors so its metrics stay ingested without a ServiceMonitor. Extend **`metrics.tuning.includeMetrics`** with patterns needed by the **Grafana alloy-mixin** dashboards beyond `default-allow-lists/alloy.yaml`.
- **Argo CD:** Symlink [`alloy-mixin/application.yaml`](tanka/environments/alloy-mixin/application.yaml) and [`cert-manager-mixin/application.yaml`](tanka/environments/cert-manager-mixin/application.yaml) under `charts/argocd-applications/templates/` like the other mixin apps (deploys respective `TK_ENV` via tanka CMP).
- **alloy-mixin:** Set mixin `_config.filterSelector` to `job="integrations/alloy"` so dashboards align with integration scrape targets.

## Operational note

Roll out refreshes Alloy generated config (`integrations` scrape + mixin allow-list tuning). Confirm in Mimir that duplicate `job` scrape paths are gone before relying on alerting math.

Regenerated [`charts/argocd-applications/rendered.yaml`](charts/argocd-applications/rendered.yaml) via `./build.sh`.

Made with [Cursor](https://cursor.com)