### PR TITLE
kubernetes-mixin: drop spurious KubeProxyDown (Cilium)

### DIFF
--- a/tanka/environments/kubernetes-mixin/main.jsonnet
+++ b/tanka/environments/kubernetes-mixin/main.jsonnet
@@ -33,11 +33,10 @@ libMonResources.new(
       'k8s-windows-cluster-rsrc-use',
       'k8s-windows-node-rsrc-use',
     ],
-    ruleGroupsToDrop: [
-      'kubernetes-system-kube-proxy',
-    ],
     alertsToDrop: {
       'kubernetes-resources': ['KubeCPUOvercommit', 'KubeMemoryOvercommit'],
+      // prometheusAlerts group kubernetes-system-kube-proxy; absent(up{job="kube-proxy"}) is spurious with Cilium (no kube-proxy DS).
+      'kubernetes-system-kube-proxy': ['KubeProxyDown'],
     },
   },
 )


### PR DESCRIPTION
## Summary

Prod Mimir shows **KubeProxyDown** firing from the kubernetes-mixin **kubernetes-system-kube-proxy** alert group. Clusters use **Cilium** instead of kube-proxy, so **absent(up{job=\"kube-proxy\"})** is expected.

## Change

- Use **alertsToDrop** (see `tanka/lib/monitoring-resources.libsonnet`): keys are `toK8s(group.name)`, values are alert rule `alert` names from the mixin.
- Drop **KubeProxyDown** only (leave **KubeProxyInstanceUnreachable** unless you want that gone too).
- Remove **ruleGroupsToDrop** entry `kubernetes-system-kube-proxy` -- that knob filters **recording** `prometheusRules` groups, not `prometheusAlerts`, so it did not remove kube-proxy alerts.

## Apply

Sync/redeploy **kubernetes-mixin** Argo Application so Alloy pushes updated PrometheusRules to Mimir.

Made with [Cursor](https://cursor.com)