### PR TITLE
Proxmox Alloy instance label and node-exporter-mixin cluster dropdown

### DIFF
--- a/tanka/environments/node-exporter-mixin/main.jsonnet
+++ b/tanka/environments/node-exporter-mixin/main.jsonnet
@@ -5,6 +5,7 @@ libMonResources.new(
   nodeExporterMixin {
     _config+:: {
       nodeExporterSelector: 'job="integrations/node_exporter"',
+      showMultiCluster: true,
     },
   },
   {

--- a/tf/nodes/templates/alloy-proxmox.alloy
+++ b/tf/nodes/templates/alloy-proxmox.alloy
@@ -60,6 +60,13 @@ otelcol.processor.attributes "main" {
     action = "upsert"
   }
 
+  // node-exporter-mixin dashboards filter on `instance`, not `hostname`
+  action {
+    key    = "instance"
+    value  = "${hostname}"
+    action = "upsert"
+  }
+
   output {
     metrics = [
       otelcol.exporter.otlphttp.tiles_test.input,


### PR DESCRIPTION
## Summary

- **Proxmox Alloy** (`tf/nodes/templates/alloy-proxmox.alloy`): upsert `instance` to the same value as `hostname` so node-exporter-mixin dashboards (which filter on `instance`) resolve for OTLP metrics from Proxmox hosts.
- **node-exporter-mixin** (`tanka/environments/node-exporter-mixin/main.jsonnet`): set `showMultiCluster: true` so the cluster template variable is visible on dashboards when switching between Kubernetes clusters and `bond`.

## Deploy notes

- Terraform apply for `tf/nodes` re-uploads the Alloy snippet; restart Proxmox Alloy LXCs if needed so they load the new config.
- Argo CD sync for `node-exporter-mixin` updates Grafana dashboards.

Made with [Cursor](https://cursor.com)