### PR TITLE
static-certs: push raconteur/cam/photos TLS to Synology DSM (prod)

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -1633,6 +1633,7 @@ spec:
     helm:
       valueFiles:
         - values.yaml
+        - values-placeholder.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: static-certs

--- a/charts/static-certs/README.md
+++ b/charts/static-certs/README.md
@@ -158,9 +158,9 @@ kubectl get certificate <name> -n static-certs -o yaml
 
 ### Known Limitations
 
-- **Manual Deployment**: Certificates must be manually extracted and deployed to external systems
-- **No Automation**: No automatic deployment to external systems (requires manual or script-based deployment)
-- **Special Cases**: Some certificates (like laserjet) require special handling
+- **Manual deployment**: Most hosts still need manual extract + install (see below).
+- **Synology DSM (prod only)**: **`synologyDsmSync`** CronJob pushes **`raconteur`**, **`cam`**, and **`photos`** certs to Raconteur when **`values-prod.yaml`** enables it; other static certs are still manual unless extended in chart values.
+- **Special cases**: **`laserjet`** uses PKCS12 / 1Password password (separate template).
 
 ## Usage
 

--- a/charts/static-certs/application.yaml
+++ b/charts/static-certs/application.yaml
@@ -14,6 +14,7 @@ spec:
     helm:
       valueFiles:
         - values.yaml
+        - values-{{ required ".Values.targetRevision is required" .Values.targetRevision }}.yaml
   destination:
     server: https://kubernetes.default.svc
     namespace: static-certs

--- a/charts/static-certs/templates/dsm-synology-configmap.helm.yaml
+++ b/charts/static-certs/templates/dsm-synology-configmap.helm.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.synologyDsmSync.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-dsm-synology-sync" .Release.Name | quote }}
+  namespace: "{{ .Release.Namespace }}"
+data:
+  run.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${SYNO_SCHEME:?}" "${SYNO_HOSTNAME:?}" "${SYNO_PORT:?}" "${SYNO_USERNAME:?}" "${SYNO_PASSWORD:?}"
+    git clone -q --depth 1 https://github.com/acmesh-official/acme.sh.git /tmp/a
+    A=/tmp/a/acme.sh
+    H=/tmp/h; rm -rf "$H"; mkdir -p "$H"
+    p12() {
+      local c=$1 k=$2 lf=$3 ca=$4 p=$(mktemp) w=$(openssl rand -hex 16)
+      openssl pkcs12 -export -out "$p" -inkey "$k" -in "$c" -passout "pass:$w" -name tls
+      openssl pkcs12 -in "$p" -nokeys -clcerts -passin "pass:$w" -out "$lf"
+      openssl pkcs12 -in "$p" -nokeys -cacerts -passin "pass:$w" -out "$ca"
+      rm -f "$p"
+    }
+    one() {
+      local d=$1 c=$2 k=$3 t=$(mktemp -d)
+      p12 "$c" "$k" "$t/l" "$t/z"
+      local D="$H/${d}_ecc"
+      mkdir -p "$D"
+      install -m0600 "$k" "$D/$d.key"
+      install -m0644 "$t/l" "$D/$d.cer"
+      install -m0644 "$t/z" "$D/ca.cer"
+      install -m0644 "$c" "$D/fullchain.cer"
+      printf 'Le_Domain="%s"\nLe_Alt=\n' "$d" >"$D/$d.conf"
+      export SYNO_CERTIFICATE="$d"
+      "$A" --home "$H" --deploy --deploy-hook synology_dsm -d "$d" --ecc
+      rm -rf "$t"
+    }
+{{- range .Values.synologyDsmSync.certificates }}
+    one "{{ .fqdn }}" "/certs/{{ .volumeMountPath }}/tls.crt" "/certs/{{ .volumeMountPath }}/tls.key"
+{{- end }}
+{{- end }}

--- a/charts/static-certs/templates/dsm-synology-cronjob.helm.yaml
+++ b/charts/static-certs/templates/dsm-synology-cronjob.helm.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.synologyDsmSync.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ printf "%s-dsm-synology-sync" .Release.Name | quote }}
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  schedule: {{ .Values.synologyDsmSync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: default
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ printf "%s-dsm-synology-sync" .Release.Name | quote }}
+                defaultMode: 0755
+{{- range .Values.synologyDsmSync.certificates }}
+            - name: tls-{{ .volumeMountPath }}
+              secret:
+                secretName: {{ .secretName | quote }}
+{{- end }}
+          containers:
+            - name: sync
+              image: {{ .Values.synologyDsmSync.image | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -e
+                  apk add --no-cache openssl bash curl git ca-certificates >/dev/null
+                  exec /bin/bash /scripts/run.sh
+              env:
+                - name: SYNO_SCHEME
+                  value: {{ .Values.synologyDsmSync.synology.scheme | quote }}
+                - name: SYNO_HOSTNAME
+                  value: {{ .Values.synologyDsmSync.synology.hostname | quote }}
+                - name: SYNO_PORT
+                  value: {{ .Values.synologyDsmSync.synology.port | quote }}
+                - name: SYNO_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.synologyDsmSync.loginOnePasswordItem.name | quote }}
+                      key: {{ .Values.synologyDsmSync.loginSecretKeys.usernameKey | quote }}
+                - name: SYNO_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.synologyDsmSync.loginOnePasswordItem.name | quote }}
+                      key: {{ .Values.synologyDsmSync.loginSecretKeys.passwordKey | quote }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+{{- range .Values.synologyDsmSync.certificates }}
+                - name: tls-{{ .volumeMountPath }}
+                  mountPath: {{ printf "/certs/%s" .volumeMountPath | quote }}
+                  readOnly: true
+{{- end }}
+{{- end }}

--- a/charts/static-certs/templates/dsm-synology-onepassword.helm.yaml
+++ b/charts/static-certs/templates/dsm-synology-onepassword.helm.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.synologyDsmSync.enabled }}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: "{{ .Values.synologyDsmSync.loginOnePasswordItem.name }}"
+  namespace: "{{ .Release.Namespace }}"
+type: Opaque
+spec:
+  itemPath: "{{ .Values.synologyDsmSync.loginOnePasswordItem.itemPath }}"
+{{- end }}

--- a/charts/static-certs/values-placeholder.yaml
+++ b/charts/static-certs/values-placeholder.yaml
@@ -1,0 +1,3 @@
+# Used when helm-common supplies targetRevision=placeholder (e.g. build.sh).
+synologyDsmSync:
+  enabled: false

--- a/charts/static-certs/values-prod.yaml
+++ b/charts/static-certs/values-prod.yaml
@@ -1,0 +1,3 @@
+# tiles (prod): push static TLS to Synology DSM.
+synologyDsmSync:
+  enabled: true

--- a/charts/static-certs/values-test.yaml
+++ b/charts/static-certs/values-test.yaml
@@ -1,0 +1,3 @@
+# tiles-test and local renders: do not push to Raconteur DSM (prod cluster owns sync).
+synologyDsmSync:
+  enabled: false

--- a/charts/static-certs/values.yaml
+++ b/charts/static-certs/values.yaml
@@ -1,6 +1,34 @@
 baseDomain: local.symmatree.com
 clusterIssuer: real-cert
 namespace: static-certs
+
+# Push TLS material from selected Certificate secrets to Synology DSM (acme.sh synology_dsm deploy hook).
+# DSM login Secret is synced from 1Password via OnePasswordItem (same pattern as laserjet password).
+synologyDsmSync:
+  enabled: false
+  schedule: "0 7 * * *"
+  image: alpine:3.20
+  synology:
+    scheme: https
+    hostname: raconteur.ad.local.symmatree.com
+    port: "5001"
+  loginOnePasswordItem:
+    name: raconteur-login
+    itemPath: vaults/tiles-secrets/items/raconteur-login
+  loginSecretKeys:
+    usernameKey: username
+    passwordKey: password
+  certificates:
+    - fqdn: raconteur.ad.local.symmatree.com
+      secretName: raconteur-cert
+      volumeMountPath: raconteur
+    - fqdn: cam.local.symmatree.com
+      secretName: cam-cert
+      volumeMountPath: cam
+    - fqdn: photos.local.symmatree.com
+      secretName: photos-cert
+      volumeMountPath: photos
+
 staticCerts:
   - name: raconteur
     subdomain: .ad

--- a/docs/config-propagation.md
+++ b/docs/config-propagation.md
@@ -61,7 +61,7 @@ The architecture uses 1Password as the interface between Terraform (infrastructu
 
 Terraform collects cluster configuration values from its variables and outputs, then stores them in a 1Password secure note item named `{cluster_name}-misc-config`. The item contains a `config` section with the following fields:
 
-- `targetRevision` - Git branch/tag to deploy
+- `targetRevision` - Git branch/tag to deploy (also selects Helm overlays such as `charts/static-certs/values-${targetRevision}.yaml` in the static-certs Application)
 - `cluster_name` - Name of the Kubernetes cluster
 - `pod_cidr` - CIDR range for pod IPs
 - `external_ip_cidr` - CIDR range for external IPs


### PR DESCRIPTION
## Summary
CronJob in `static-certs` clones acme.sh and runs `synology_dsm` deploy for three cert-manager secrets. DSM login via `OnePasswordItem` (`raconteur-login`).

## Environment split
- `values.yaml` + `values-${targetRevision}.yaml` (same `targetRevision` as misc-config: `prod` / `test`)
- `values-prod.yaml`: `synologyDsmSync.enabled: true`
- `values-test.yaml` + `values-placeholder.yaml`: disabled (no fighting over Raconteur)

## Notes
- `charts/argocd-applications/templates/static-certs-application.yaml` is a symlink to `charts/static-certs/application.yaml`; valueFiles live in one place.
- Optional later: cache acme.sh in CI or a small image to avoid repeated `git clone`.


Made with [Cursor](https://cursor.com)