### PR TITLE
Mimir: Set the timeInterval to fix rateInterval computation

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -1143,6 +1143,7 @@ spec:
                     isDefault: true
                     jsonData:
                       prometheusType: Mimir
+                      timeInterval: 60s
                       alertmanagerUid: alertmanager
                       httpHeaderName1: X-Scope-OrgID
                     secureJsonData:

--- a/charts/argocd-applications/templates/mimir-application.yaml
+++ b/charts/argocd-applications/templates/mimir-application.yaml
@@ -41,6 +41,7 @@ spec:
                     isDefault: true
                     jsonData:
                       prometheusType: Mimir
+                      timeInterval: 60s
                       alertmanagerUid: alertmanager
                       httpHeaderName1: X-Scope-OrgID
                     secureJsonData:


### PR DESCRIPTION
It thinks we have 15s samples by default so most of the charts end up empty when they try to compute a 30s rate on 1m data