### PR TITLE
static-certs: deploy homeassistant-cert to HA Yellow over SSH

### DIFF
--- a/charts/static-certs/README.md
+++ b/charts/static-certs/README.md
@@ -159,7 +159,9 @@ kubectl get certificate <name> -n static-certs -o yaml
 ### Known Limitations
 
 - **Manual deployment**: Most hosts still need manual extract + install (see below).
-- **Synology DSM (prod only)**: **`synologyDsmSync`** CronJob pushes **`raconteur`**, **`cam`**, and **`photos`** certs to Raconteur when **`values-prod.yaml`** enables it; other static certs are still manual unless extended in chart values.
+- **Synology DSM (prod only)**: **`synologyDsmSync`** CronJob pushes **`raconteur`**, **`cam`**, and **`photos`** certs to Raconteur when **`values-prod.yaml`** enables it.
+- **Home Assistant (prod only)**: **`homeassistantSshSync`** CronJob pushes **`homeassistant-cert`** to `/config/ssl/` on the Yellow (`10.0.99.9`) via SSH when **`values-prod.yaml`** enables it. Requires 1Password item **`homeassistant-cert-ssh`** (`private_key` / `public_key`) and the **`public_key`** value in the SSH add-on **`authorized_keys`**. Remote paths match **`ha-config`** `configuration.yaml` (`ssl/homeassistant-cert.crt` / `.key`).
+- Other static certs are still manual unless extended in chart values.
 - **Special cases**: **`laserjet`** uses PKCS12 / 1Password password (separate template).
 
 ## Usage

--- a/charts/static-certs/templates/ha-ssh-configmap.helm.yaml
+++ b/charts/static-certs/templates/ha-ssh-configmap.helm.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.homeassistantSshSync.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-ha-ssh-sync" .Release.Name | quote }}
+  namespace: "{{ .Release.Namespace }}"
+data:
+  run.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${DEPLOY_SSH_USER:?}" "${DEPLOY_SSH_SERVER:?}" "${DEPLOY_SSH_KEYFILE:?}" "${DEPLOY_SSH_FULLCHAIN:?}" "${DEPLOY_SSH_REMOTE_CMD:?}" "${SSH_IDENTITY_FILE:?}"
+    git clone -q --depth 1 https://github.com/acmesh-official/acme.sh.git /tmp/a
+    A=/tmp/a/acme.sh
+    H=/tmp/h; rm -rf "$H"; mkdir -p "$H"
+    p12() {
+      local c=$1 k=$2 lf=$3 ca=$4 p=$(mktemp) w=$(openssl rand -hex 16)
+      openssl pkcs12 -export -out "$p" -inkey "$k" -in "$c" -passout "pass:$w" -name tls
+      openssl pkcs12 -in "$p" -nokeys -clcerts -passin "pass:$w" -out "$lf"
+      openssl pkcs12 -in "$p" -nokeys -cacerts -passin "pass:$w" -out "$ca"
+      rm -f "$p"
+    }
+    one() {
+      local d=$1 c=$2 k=$3 t=$(mktemp -d)
+      p12 "$c" "$k" "$t/l" "$t/z"
+      local D="$H/${d}_ecc"
+      mkdir -p "$D"
+      install -m0600 "$k" "$D/$d.key"
+      install -m0644 "$t/l" "$D/$d.cer"
+      install -m0644 "$t/z" "$D/ca.cer"
+      install -m0644 "$c" "$D/fullchain.cer"
+      printf 'Le_Domain="%s"\nLe_Alt=\n' "$d" >"$D/$d.conf"
+      export DEPLOY_SSH_CMD="ssh -i ${SSH_IDENTITY_FILE} -o StrictHostKeyChecking=accept-new"
+      export DEPLOY_SSH_USE_SCP=yes
+      "$A" --home "$H" --deploy --deploy-hook ssh -d "$d" --ecc
+      rm -rf "$t"
+    }
+{{- range .Values.homeassistantSshSync.certificates }}
+    one "{{ .fqdn }}" "/certs/{{ .volumeMountPath }}/tls.crt" "/certs/{{ .volumeMountPath }}/tls.key"
+{{- end }}
+{{- end }}

--- a/charts/static-certs/templates/ha-ssh-cronjob.helm.yaml
+++ b/charts/static-certs/templates/ha-ssh-cronjob.helm.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.homeassistantSshSync.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ printf "%s-ha-ssh-sync" .Release.Name | quote }}
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  schedule: {{ .Values.homeassistantSshSync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: default
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ printf "%s-ha-ssh-sync" .Release.Name | quote }}
+                defaultMode: 0755
+            - name: ssh-key
+              secret:
+                secretName: {{ .Values.homeassistantSshSync.sshKeyOnePasswordItem.name | quote }}
+                defaultMode: 0400
+{{- range .Values.homeassistantSshSync.certificates }}
+            - name: tls-{{ .volumeMountPath }}
+              secret:
+                secretName: {{ .secretName | quote }}
+{{- end }}
+          containers:
+            - name: sync
+              image: {{ .Values.homeassistantSshSync.image | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -e
+                  apk add --no-cache openssl bash curl git ca-certificates openssh-client >/dev/null
+                  exec /bin/bash /scripts/run.sh
+              env:
+                - name: DEPLOY_SSH_USER
+                  value: {{ .Values.homeassistantSshSync.ssh.user | quote }}
+                - name: DEPLOY_SSH_SERVER
+                  value: {{ printf "%s:%s" .Values.homeassistantSshSync.ssh.host .Values.homeassistantSshSync.ssh.port | quote }}
+                - name: DEPLOY_SSH_KEYFILE
+                  value: {{ .Values.homeassistantSshSync.ssh.remotePaths.privkey | quote }}
+                - name: DEPLOY_SSH_FULLCHAIN
+                  value: {{ .Values.homeassistantSshSync.ssh.remotePaths.fullchain | quote }}
+                - name: DEPLOY_SSH_REMOTE_CMD
+                  value: {{ .Values.homeassistantSshSync.ssh.remoteCmd | quote }}
+                - name: SSH_IDENTITY_FILE
+                  value: {{ printf "/ssh/%s" .Values.homeassistantSshSync.sshKeySecretKey | quote }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: ssh-key
+                  mountPath: /ssh
+                  readOnly: true
+{{- range .Values.homeassistantSshSync.certificates }}
+                - name: tls-{{ .volumeMountPath }}
+                  mountPath: {{ printf "/certs/%s" .volumeMountPath | quote }}
+                  readOnly: true
+{{- end }}
+{{- end }}

--- a/charts/static-certs/templates/ha-ssh-onepassword.helm.yaml
+++ b/charts/static-certs/templates/ha-ssh-onepassword.helm.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.homeassistantSshSync.enabled }}
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: "{{ .Values.homeassistantSshSync.sshKeyOnePasswordItem.name }}"
+  namespace: "{{ .Release.Namespace }}"
+type: Opaque
+spec:
+  itemPath: "{{ .Values.homeassistantSshSync.sshKeyOnePasswordItem.itemPath }}"
+{{- end }}

--- a/charts/static-certs/values-prod.yaml
+++ b/charts/static-certs/values-prod.yaml
@@ -1,3 +1,5 @@
-# tiles (prod): push static TLS to Synology DSM.
+# tiles (prod): push static TLS to Synology DSM and Home Assistant.
 synologyDsmSync:
+  enabled: true
+homeassistantSshSync:
   enabled: true

--- a/charts/static-certs/values.yaml
+++ b/charts/static-certs/values.yaml
@@ -29,6 +29,29 @@ synologyDsmSync:
       secretName: photos-cert
       volumeMountPath: photos
 
+# Push homeassistant-cert to HA Yellow over SSH (acme.sh ssh deploy hook).
+# Deploy key Secret is synced from 1Password. Paths match ha-config configuration.yaml.
+homeassistantSshSync:
+  enabled: false
+  schedule: "15 7 * * *"
+  image: alpine:3.20
+  ssh:
+    user: root
+    host: 10.0.99.9
+    port: "22"
+    remotePaths:
+      fullchain: /config/ssl/homeassistant-cert.crt
+      privkey: /config/ssl/homeassistant-cert.key
+    remoteCmd: ha core restart
+  sshKeyOnePasswordItem:
+    name: homeassistant-cert-ssh
+    itemPath: vaults/tiles-secrets/items/homeassistant-cert-ssh
+  sshKeySecretKey: private_key
+  certificates:
+    - fqdn: homeassistant.local.symmatree.com
+      secretName: homeassistant-cert
+      volumeMountPath: homeassistant
+
 staticCerts:
   - name: raconteur
     subdomain: .ad


### PR DESCRIPTION
## Summary

- Add **`homeassistantSshSync`**: prod-only daily CronJob (07:15 UTC) that pushes `homeassistant-cert` to the HA Yellow at `10.0.99.9` via acme.sh `ssh` deploy hook.
- Writes `/config/ssl/homeassistant-cert.crt` and `.key` (paths from `ha-config`), then runs `ha core restart`.
- Sync deploy SSH private key from 1Password item **`homeassistant-cert-ssh`** (`private_key` field).

## Prerequisites (operator, before first successful job)

1. 1Password item `homeassistant-cert-ssh` in `tiles-secrets` (done).
2. Add the item's **`public_key`** to Advanced SSH & Web Terminal **`authorized_keys`** on the Yellow.

## Test plan

- [ ] Argo sync `static-certs` on prod
- [ ] Confirm `OnePasswordItem` / Secret `homeassistant-cert-ssh` in `static-certs` namespace
- [ ] One-shot job: `kubectl create job -n static-certs ha-ssh-sync-manual --from=cronjob/static-certs-ha-ssh-sync`
- [ ] Job logs show successful scp + `ha core restart`
- [ ] `https://homeassistant.local.symmatree.com:8123/` shows updated cert expiry


Made with [Cursor](https://cursor.com)