### PR TITLE
fix(nodes): host_managed DHCP for Proxmox Alloy LXCs

### DIFF
--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -16,6 +16,7 @@ Implementation is intended to mirror the Synology pattern; OTLP ingress and rece
   - As of the values checked in-repo: **`test.tfvars`** sets **`deploy_proxmox_alloy = true`**; **`prod.tfvars`** sets **`deploy_proxmox_alloy = false`** (duplicate reporting / rollout control until you flip it).
 - **CT IDs:** **`alloy_vm_base_id`** plus per-node index (cluster-wide unique VMID); **`test.tfvars`** and **`prod.tfvars`** use different bases (see tfvars).
 - **Credentials:** Proxmox **`root@pam`** for the provider that performs bind mounts; see [`tf/nodes/README.md`](../tf/nodes/README.md) and [`docs/secrets.md`](secrets.md).
+- **Networking:** Alloy CTs use **`ip=dhcp`** with **`host_managed = true`** on **`eth0`** (Proxmox VE **9.1+**, **`bpg/proxmox` >= 0.104**). OCI application containers run **`/bin/alloy`** as entrypoint, not **`/sbin/init`**, so the guest does not configure DHCP itself; the host must. Without **`host_managed`**, **`/nodes/{node}/lxc/{vmid}/interfaces`** can show **`eth0`** with no IPv4 and Alloy logs **`network is unreachable`** when exporting to OTLP (DNS never leaves the CT). Site DNS remains **Raconteur (`10.0.99.1`)** via DHCP; do not override nameserver in Terraform unless you intend to bypass that design.
 
 ## Alloy configuration (repo truth)
 
@@ -28,7 +29,7 @@ Implementation is intended to mirror the Synology pattern; OTLP ingress and rece
 
 - **Snippet path:** Config is uploaded as a Proxmox **snippet** and mounted in the CT at **`/var/lib/vz/snippets/alloy-proxmox.alloy`** (same path on host and guest).
 - **Alloy UI:** Entrypoint sets **`--server.http.listen-addr=0.0.0.0:12345`** (see `proxmox-alloy.tf`). Reachability depends on your LAN/firewall; it is not the same as the Synology DSM port.
-- **Entrypoint / config updates:** Comment in **`proxmox-alloy.tf`**: after changing entrypoint or config, the first apply may not refresh a running CT; you may need to **stop** the CTs in the Proxmox UI, then **apply** or **start** so they pick up the new entrypoint.
+- **Entrypoint / network / config updates:** Comment in **`proxmox-alloy.tf`**: after changing entrypoint, **`host_managed`**, or config, the first apply may not refresh a running CT; **stop** the CTs in the Proxmox UI, then **apply** or **start** so they pick up the new settings. After **`host_managed`** is applied, confirm **`GET .../lxc/{vmid}/interfaces`** shows an IPv4 on **`eth0`** and Alloy export errors stop.
 
 ## Findings from Mimir / Loki checks (point-in-time)
 

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -8,9 +8,9 @@
 # VM/CT IDs are unique cluster-wide in Proxmox, so we assign one per node (200, 201, ...).
 # When deploy_proxmox_alloy is false, no containers/OCI/images/snippets are created.
 #
-# Operational note: After changing entrypoint or config, the first apply may not update the
-# running container's entrypoint; a second apply may try and fail to reboot the CTs. Manually
-# stop the containers in the Proxmox UI, then re-apply or start them so they come up with the new entrypoint.
+# Operational note: After changing entrypoint, network (e.g. host_managed), or config, the first
+# apply may not update a running CT. Stop the containers in the Proxmox UI, then re-apply or start
+# them so they pick up the new settings.
 locals {
   alloy_nodes  = var.deploy_proxmox_alloy ? toset(data.proxmox_virtual_environment_nodes.nodes.names) : toset([])
   alloy_vm_ids = { for i, n in sort(tolist(local.alloy_nodes)) : n => var.alloy_vm_base_id + i }
@@ -73,10 +73,13 @@ resource "proxmox_virtual_environment_container" "alloy" {
   }
 
   # Network - bridge to vmbr0 (adjust if your network setup differs)
+  # OCI app containers (entrypoint is /bin/alloy, not /sbin/init) do not run a guest DHCP client.
+  # host_managed requires Proxmox VE 9.1+ and bpg/proxmox provider >= 0.104.
   network_interface {
-    firewall = true
-    name     = "eth0"
-    bridge   = "vmbr0"
+    bridge       = "vmbr0"
+    firewall     = true
+    host_managed = true
+    name         = "eth0"
   }
   console {
     enabled   = true

--- a/tf/nodes/versions.tf
+++ b/tf/nodes/versions.tf
@@ -3,7 +3,8 @@ terraform {
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"
-      version = ">= 0.84"
+      # host_managed on LXC network_interface (Proxmox Alloy CTs) requires >= 0.104.
+      version = ">= 0.104"
     }
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
## Summary

- Set `host_managed = true` on Alloy LXC `eth0` so Proxmox VE runs DHCP for OCI app containers (entrypoint `/bin/alloy`, not `/sbin/init`).
- Bump `bpg/proxmox` provider minimum to `>= 0.104` (feature requires PVE 9.1+).
- Document networking failure mode and post-apply verification in `docs/proxmox-monitoring.md`.

## Context

Alloy CTs were running but not exporting: logs showed `lookup otlp.tiles-test.symmatree.com on 10.0.99.1:53: network is unreachable`. Proxmox `/nodes/{node}/lxc/{vmid}/interfaces` showed `eth0` with no IPv4 while `host-managed=0`.

## Test plan

- [ ] CI Terraform plan (`test` workspace) shows expected `host_managed` / network changes on Alloy CTs
- [ ] After apply: stop CTs if needed, re-apply, confirm `/interfaces` has IPv4 on `eth0`
- [ ] Confirm Alloy export errors stop and `cluster="bond"` Proxmox metrics appear in tiles-test Mimir


Made with [Cursor](https://cursor.com)