### PR TITLE
fix(bond-mixin): repair Raconteur disk temperature PromQL

### DIFF
--- a/tanka/environments/bond-mixin/mixin/alerts/raconteur.libsonnet
+++ b/tanka/environments/bond-mixin/mixin/alerts/raconteur.libsonnet
@@ -2,16 +2,17 @@
   local cfg = $._config,
   local snmpSel = 'cluster="%(bondCluster)s", job="%(raconteurSnmpJob)s"' % cfg,
   local hostSel = 'cluster="%(bondCluster)s", instance="%(raconteurInstance)s"' % cfg,
-  local diskTempWithType =
-    |||
-      diskTemperature{%(snmp)s}
-      * on(diskIndex) group_left(diskType)
-      diskType{%(snmp)s}
-    ||| % (cfg { snmp: snmpSel }),
+  local diskTempSata =
+    'diskTemperature{%(snmp)s} * on(diskIndex) group_left(diskType) diskType{%(snmp)s, diskType="%(raconteurDiskTypeSata)s"}'
+    % (cfg { snmp: snmpSel }),
+  local diskTempSsd =
+    'diskTemperature{%(snmp)s} * on(diskIndex) group_left(diskType) diskType{%(snmp)s, diskType="%(raconteurDiskTypeSsd)s"}'
+    % (cfg { snmp: snmpSel }),
   local c = cfg {
     snmp: snmpSel,
     host: hostSel,
-    diskTempWithType: diskTempWithType,
+    diskTempSata: diskTempSata,
+    diskTempSsd: diskTempSsd,
   },
 
   prometheusAlerts+:: {
@@ -59,10 +60,7 @@
           },
           {
             alert: 'BondRaconteurSataDiskTemperatureHigh',
-            expr: |||
-              %(diskTempWithType)s{diskType="%(raconteurDiskTypeSata)s"}
-              > %(raconteurDiskSataTempCelsius)g
-            ||| % c,
+            expr: '%(diskTempSata)s > %(raconteurDiskSataTempCelsius)g' % c,
             'for': c.raconteurDiskSataTempFor,
             labels: { severity: 'warning' },
             annotations: {
@@ -72,10 +70,7 @@
           },
           {
             alert: 'BondRaconteurSsdDiskTemperatureHigh',
-            expr: |||
-              %(diskTempWithType)s{diskType="%(raconteurDiskTypeSsd)s"}
-              > %(raconteurDiskSsdTempCelsius)g
-            ||| % c,
+            expr: '%(diskTempSsd)s > %(raconteurDiskSsdTempCelsius)g' % c,
             'for': c.raconteurDiskSsdTempFor,
             labels: { severity: 'warning' },
             annotations: {


### PR DESCRIPTION
## Summary

- Fix invalid PromQL on `BondRaconteurSataDiskTemperatureHigh` and `BondRaconteurSsdDiskTemperatureHigh`: a multiline join followed by `{diskType=...}` was parsed as a standalone selector (`unexpected "{"`), so the entire `bond-raconteur` PrometheusRule group failed to load in Mimir.
- Filter `diskType` on the `diskType` metric in the join and use single-line expressions.

## Test plan

- [ ] `tk show environments/bond-mixin` -- disk alert `expr` lines are valid one-liners with `diskType` on `diskType{...}`.
- [ ] After deploy to tiles-test: alloy-singleton logs show `bond-mixin/bond-raconteur` rules syncing without parse errors.
- [ ] `ALERTS{alertname=~"BondRaconteur.*"}` in Mimir (rules present; firing only when thresholds exceeded).


Made with [Cursor](https://cursor.com)