### PR TITLE
Edge Alloy: prod-only OTLP and unified deploy flags

### DIFF
--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -1,6 +1,6 @@
 # Proxmox host monitoring (Alloy LXC)
 
-Each **Proxmox cluster node** can run an **unprivileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and Proxmox **snippets** at `/var/lib/vz/snippets`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), tails **host log files**, and ships everything to **both** Kubernetes clusters over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
+Each **Proxmox cluster node** can run an **unprivileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and Proxmox **snippets** at `/var/lib/vz/snippets`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), tails **host log files**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
 
 OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring.md).
 
@@ -11,9 +11,9 @@ OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring
 
 ## Terraform
 
-- **Scope:** `tf/nodes`, workspace **`test`** or **`prod`**, matching **`-var-file`** (`test.tfvars` / `prod.tfvars`).
-- **Toggle:** **`deploy_proxmox_alloy`** ([`variables.tf`](../tf/nodes/variables.tf)). **`test.tfvars`**: `true`; **`prod.tfvars`**: `false` (rollout control).
-- **CT IDs:** **`alloy_vm_base_id`** + per-node index (see tfvars).
+- **Scope:** `tf/nodes`, workspace **`prod`** with **`-var-file=prod.tfvars`** for edge Alloy (cluster VMs may use test or prod workspace per environment).
+- **Toggles:** **`deploy_proxmox_alloy`** and **`deploy_synology_alloy`** ([`variables.tf`](../tf/nodes/variables.tf)). Both **`true`** in **`prod.tfvars`**, **`false`** in **`test.tfvars`**.
+- **CT IDs:** **`alloy_vm_base_id`** + per-node index (see tfvars; prod uses base **400**).
 - **Credentials:** Proxmox **`root@pam`** for bind mounts -- [`tf/nodes/README.md`](../tf/nodes/README.md), [`docs/secrets.md`](secrets.md).
 - **Provider:** **`bpg/proxmox` >= 0.104** ( **`host_managed`** on LXC NICs).
 - **Networking (required):** **`network_interface.host_managed = true`** on **`eth0`** with **`ip=dhcp`**. Proxmox VE **9.1+** OCI app containers use entrypoint **`/bin/alloy`**, not **`/sbin/init`**; the guest does not run DHCP. Without **`host_managed`**, **`GET /nodes/{node}/lxc/{vmid}/interfaces`** shows **`eth0`** with no IPv4 and Alloy fails OTLP export with **`network is unreachable`** to the DHCP nameserver (site DNS is still **Raconteur** via DHCP once the CT has L3).
@@ -22,18 +22,11 @@ OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring
 
 Network and entrypoint changes often do not affect a **running** CT until restart. Practical sequence: **stop** Alloy CTs, **`terraform apply`**, **start** (or apply while already stopped, then start). Afterward, **`/interfaces`** should list an IPv4 on **`eth0`**.
 
-## Current status (tiles-test)
+After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxmox_alloy = true`** to recreate containers.
 
-| Path | Status |
-|------|--------|
-| **Metrics (Mimir)** | **Working** (verified 2026-05-17 after **`host_managed`**). All four nodes: **`cluster="bond"`**, **`job="integrations/node_exporter"`**, **`instance`** / **`hostname`** = **`nuc-g2p-1`**, **`nuc-g2p-2`**, **`nuc-g3p-1`**, **`nuc-g3p-2`**. Includes **hwmon** (e.g. **`node_hwmon_temp_celsius`**). |
-| **Logs (Loki)** | **Not observed yet.** No **`proxmox-*`** **`job`** or **`host=~"nuc-g.*"`** streams in tiles-test after metrics recovery. Likely separate (empty **`/host/var/log/...`** on Proxmox, journal-only hosts, or tailer errors) -- check Alloy CT logs for **`loki.source.file`**. |
+## Verification (Explore, tiles tenant)
 
-**tiles** (prod cluster) receives the same OTLP stream when CTs export; **`deploy_proxmox_alloy`** is **`false`** in **`prod.tfvars`** today.
-
-## Verification (Explore, tiles-test tenant)
-
-**Metrics live now:**
+**Metrics:**
 
 ```promql
 rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])
@@ -51,7 +44,7 @@ rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])
 ## Alloy labels and dashboards
 
 - **Metrics job:** **`integrations/node_exporter`** (via **`prometheus.relabel "unix_node_job"`** in the Alloy template).
-- **Mixin / dashboards:** filter **`cluster="bond"`** and **`instance`** = Proxmox node name (e.g. **`nuc-g2p-1`**). See **node-exporter-mixin** in this repo.
+- **Mixin / dashboards:** filter **`cluster="bond"`** and **`instance`** = Proxmox node name (e.g. **`nuc-g2p-1`**). See **bond-mixin** and **node-exporter-mixin** in this repo.
 
 ## Related docs
 

--- a/docs/synology-monitoring.md
+++ b/docs/synology-monitoring.md
@@ -1,6 +1,6 @@
 # Synology (Raconteur) monitoring
 
-`raconteur.ad.local.symmatree.com` (Synology NAS) is monitored by a single **Grafana Alloy** container that ships metrics and logs to both Kubernetes clusters over OTLP.
+`raconteur.ad.local.symmatree.com` (Synology NAS) is monitored by a single **Grafana Alloy** container that ships metrics and logs to the **tiles** (prod) cluster over OTLP.
 
 ## Architecture
 
@@ -10,16 +10,15 @@ The Alloy container on the NAS collects:
 2. **Hardware metrics** via `prometheus.exporter.snmp` (Synology OIDs, SNMP v3)
 3. **Log files** via `loki.source.file` under `/host/var/log` (messages, synolog, auth, daemon)
 
-Metrics pass through `otelcol.receiver.prometheus` and logs through `otelcol.receiver.loki`; both are labeled with **`cluster="bond"`** in the OTLP payload (attributes) and forwarded to **both** clusters:
+Metrics pass through `otelcol.receiver.prometheus` and logs through `otelcol.receiver.loki`; both are labeled with **`cluster="bond"`** in the OTLP payload (attributes) and forwarded to prod:
 
-- `https://otlp.tiles-test.symmatree.com`
 - `https://otlp.tiles.symmatree.com`
 
-Headers set **`X-Scope-OrgID`** to the cluster tenant (`tiles-test` or `tiles`). Ingress terminates TLS and forwards to **`alloy-alloy-receiver`** (HTTP OTLP, port **4318**) in namespace **`alloy`**. See [`charts/argocd-applications/templates/alloy-application.yaml`](../charts/argocd-applications/templates/alloy-application.yaml).
+Headers set **`X-Scope-OrgID`** to **`tiles`**. Ingress terminates TLS and forwards to **`alloy-alloy-receiver`** (HTTP OTLP, port **4318**) in namespace **`alloy`**. See [`charts/argocd-applications/templates/alloy-application.yaml`](../charts/argocd-applications/templates/alloy-application.yaml).
 
-### Terraform workspace
+### Terraform deploy flag
 
-In [`tf/nodes/synology-alloy.tf`](../tf/nodes/synology-alloy.tf), `synology_container_project.alloy` uses **`count = terraform.workspace == "test" ? 1 : 0`**. The Synology Container Project is created only when **`terraform workspace` is `test`** (and you apply from `tf/nodes` with the matching `-var-file`). It is **not** created for the `prod` Terraform workspace as written today.
+In [`tf/nodes/synology-alloy.tf`](../tf/nodes/synology-alloy.tf), `synology_container_project.alloy` is created when **`deploy_synology_alloy = true`** in the active **`-var-file`**. Edge Alloy is enabled in **`prod.tfvars`** only; apply from **`tf/nodes`** with **`terraform workspace select prod`** and **`-var-file=prod.tfvars`**.
 
 ## Raconteur setup
 
@@ -99,13 +98,11 @@ Log streams use **`host="raconteur"`** and **`job`** per tailer, for example:
 - `synology-auth` -- `/host/var/log/auth.log`
 - `synology-daemon` -- `/host/var/log/daemon.log`
 
-Loki also carries the **Kubernetes tenant** label **`cluster`** (`tiles-test` or `tiles`), matching the org that received OTLP. The **bond** grouping appears inside the JSON log line under **`attributes.cluster`** (and similar) after OTLP decoding.
-
-**Observed (Grafana Loki, tiles-test tenant, 7d range):** non-zero volume for **`synology-auth`** and **`synology-syslog`**; other jobs may be quiet if those files have little traffic.
+Loki also carries the **Kubernetes tenant** label **`cluster="tiles"`**, matching the org that received OTLP. The **bond** grouping appears inside the JSON log line under **`attributes.cluster`** (and similar) after OTLP decoding.
 
 ## Verifying metrics and logs
 
-Use **Grafana Explore** on the Mimir and Loki datasources for the cluster you care about (`tiles-test` vs `tiles`).
+Use **Grafana Explore** on the Mimir and Loki datasources for the **tiles** cluster (`borgmon.tiles.symmatree.com`).
 
 ### Mimir (PromQL)
 
@@ -190,15 +187,15 @@ Component URLs (examples):
 ### No metrics in Mimir
 
 1. Run the **Mimir** PromQL checks in **Verifying metrics and logs**.
-2. Confirm OTLP ingress: from a browser or `curl`, `https://otlp.tiles-test.symmatree.com` should be reachable on your network (401/404 is normal without a full OTLP POST; total failure to connect is a DNS or firewall issue).
+2. Confirm OTLP ingress: from a browser or `curl`, `https://otlp.tiles.symmatree.com` should be reachable on your network (401/404 is normal without a full OTLP POST; total failure to connect is a DNS or firewall issue).
 3. On the NAS, confirm the Alloy container is running (Synology Container Manager) and host network is in use so it can reach the public OTLP hostnames.
 
 ### No logs in Loki
 
 1. Run the **Loki** LogQL checks in **Verifying metrics and logs** with **`{host="raconteur"}`**.
-2. Remember the **Loki** `cluster` label is **`tiles-test` or `tiles`**, not `bond`. Filter on **`host`** / **`job`** for Raconteur streams.
+2. Remember the **Loki** `cluster` label is **`tiles`**, not `bond`. Filter on **`host`** / **`job`** for Raconteur streams.
 3. If only some jobs appear, that matches file activity (e.g. `synology-daemon` may be sparse).
 
 ### Container project missing after apply
 
-Re-read **Terraform workspace** above: the resource is only created for workspace **`test`**.
+Confirm **`deploy_synology_alloy = true`** in **`prod.tfvars`**, workspace **`prod`**, and that you applied with **`-var-file=prod.tfvars`**.

--- a/tf/nodes/README.md
+++ b/tf/nodes/README.md
@@ -79,3 +79,7 @@ This configuration supports two workspaces:
 - **prod**: For the production cluster (`tiles`)
 
 Each workspace has its own `.tfvars` file (`test.tfvars` or `prod.tfvars`) that must be specified with `-var-file` when running `terraform plan` or `terraform apply`. The workspace must be selected before running any Terraform commands.
+
+## Edge Alloy (Synology + Proxmox)
+
+Host-level Grafana Alloy (Raconteur NAS and Proxmox node LXCs) is controlled by **`deploy_synology_alloy`** and **`deploy_proxmox_alloy`** in the tfvars file. Both are **`true`** in **`prod.tfvars`** and **`false`** in **`test.tfvars`**. Apply from **`prod`** workspace with **`-var-file=prod.tfvars`** after merging config changes. See [`docs/synology-monitoring.md`](../../docs/synology-monitoring.md) and [`docs/proxmox-monitoring.md`](../../docs/proxmox-monitoring.md).

--- a/tf/nodes/prod.tfvars
+++ b/tf/nodes/prod.tfvars
@@ -72,8 +72,9 @@ virtual_machines = {
     taint             = ""
   }
 }
-alloy_vm_base_id     = 400
-deploy_proxmox_alloy = false
+alloy_vm_base_id      = 400
+deploy_synology_alloy = true
+deploy_proxmox_alloy  = true
 
 # Bare-metal AMD workers (see docs/bare-metal-nodes.md). Rising: BIOS and MAC/IP in facts fables/Tiles/Rising.md.
 # Uncomment this block and delete the empty `metal_amd_nodes = {}` line below when enabling Rising.

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -134,9 +134,8 @@ resource "proxmox_virtual_environment_file" "alloy_config" {
   content_type = "snippets"
   source_raw {
     data = templatefile("${path.root}/templates/alloy-proxmox.alloy", {
-      otlp_tiles_test = "https://otlp.tiles-test.symmatree.com"
-      otlp_tiles      = "https://otlp.tiles.symmatree.com"
-      hostname        = each.value
+      otlp_tiles = "https://otlp.tiles.symmatree.com"
+      hostname   = each.value
     })
     file_name = "alloy-proxmox.alloy"
   }

--- a/tf/nodes/synology-alloy.tf
+++ b/tf/nodes/synology-alloy.tf
@@ -28,10 +28,9 @@ module "raconteur_snmp_privacy_password" {
   field_name   = "PRIVACY_PASSWORD"
 }
 
-# Container project configuration
-# Unique; run in sbox while iterating and then prod later.
+# Container project configuration (see deploy_synology_alloy in tfvars)
 resource "synology_container_project" "alloy" {
-  count = terraform.workspace == "test" ? 1 : 0
+  count = var.deploy_synology_alloy ? 1 : 0
   name  = "alloy"
   run   = true
 
@@ -103,8 +102,7 @@ resource "synology_container_project" "alloy" {
     alloy_config = {
       name = "alloy_config"
       content = templatefile("${path.root}/templates/alloy-synology.alloy", {
-        otlp_tiles_test = "https://otlp.tiles-test.symmatree.com"
-        otlp_tiles      = "https://otlp.tiles.symmatree.com"
+        otlp_tiles = "https://otlp.tiles.symmatree.com"
       })
     }
     snmp_config = {

--- a/tf/nodes/templates/alloy-proxmox.alloy
+++ b/tf/nodes/templates/alloy-proxmox.alloy
@@ -1,5 +1,5 @@
 // Alloy configuration for Proxmox host monitoring
-// Collects node_exporter metrics (including hwmon sensors) and system logs, forwarding to OTLP endpoints
+// Collects node_exporter metrics (including hwmon sensors) and system logs, forwarding to prod OTLP
 
 // Node exporter for host system metrics (nesting exposes host /proc and /sys to the container)
 prometheus.exporter.unix "node" {
@@ -8,17 +8,7 @@ prometheus.exporter.unix "node" {
   rootfs_path = "/host"
 }
 
-// OTLP HTTP exporter for tiles-test cluster
-otelcol.exporter.otlphttp "tiles_test" {
-  client {
-    endpoint = "${otlp_tiles_test}"
-    headers = {
-      "X-Scope-OrgID" = "tiles-test",
-    }
-  }
-}
-
-// OTLP HTTP exporter for tiles cluster
+// OTLP HTTP exporter for tiles (prod) cluster
 otelcol.exporter.otlphttp "tiles" {
   client {
     endpoint = "${otlp_tiles}"
@@ -61,7 +51,7 @@ otelcol.receiver.prometheus "main" {
   }
 }
 
-// Add cluster label to both metrics and logs, forwarding to both clusters
+// Add cluster label to metrics and logs, forwarding to prod
 otelcol.processor.attributes "main" {
   action {
     key    = "cluster"
@@ -83,14 +73,8 @@ otelcol.processor.attributes "main" {
   }
 
   output {
-    metrics = [
-      otelcol.exporter.otlphttp.tiles_test.input,
-      otelcol.exporter.otlphttp.tiles.input,
-    ]
-    logs = [
-      otelcol.exporter.otlphttp.tiles_test.input,
-      otelcol.exporter.otlphttp.tiles.input,
-    ]
+    metrics = [otelcol.exporter.otlphttp.tiles.input]
+    logs    = [otelcol.exporter.otlphttp.tiles.input]
   }
 }
 

--- a/tf/nodes/templates/alloy-synology.alloy
+++ b/tf/nodes/templates/alloy-synology.alloy
@@ -1,5 +1,5 @@
 // Alloy configuration for Synology host monitoring
-// Collects node_exporter metrics, SNMP hardware metrics, and system logs, forwarding to OTLP endpoints
+// Collects node_exporter metrics, SNMP hardware metrics, and system logs, forwarding to prod OTLP
 
 // Node exporter for host system metrics
 prometheus.exporter.unix "node" {
@@ -24,17 +24,7 @@ prometheus.exporter.snmp "synology" {
   }
 }
 
-// OTLP HTTP exporter for tiles-test cluster
-otelcol.exporter.otlphttp "tiles_test" {
-  client {
-    endpoint = "${otlp_tiles_test}"
-    headers = {
-      "X-Scope-OrgID" = "tiles-test",
-    }
-  }
-}
-
-// OTLP HTTP exporter for tiles cluster
+// OTLP HTTP exporter for tiles (prod) cluster
 otelcol.exporter.otlphttp "tiles" {
   client {
     endpoint = "${otlp_tiles}"
@@ -85,7 +75,7 @@ otelcol.receiver.prometheus "main" {
   }
 }
 
-// Add cluster label to both metrics and logs, forwarding to both clusters
+// Add cluster label to metrics and logs, forwarding to prod
 otelcol.processor.attributes "main" {
   action {
     key    = "cluster"
@@ -94,14 +84,8 @@ otelcol.processor.attributes "main" {
   }
 
   output {
-    metrics = [
-      otelcol.exporter.otlphttp.tiles_test.input,
-      otelcol.exporter.otlphttp.tiles.input,
-    ]
-    logs = [
-      otelcol.exporter.otlphttp.tiles_test.input,
-      otelcol.exporter.otlphttp.tiles.input,
-    ]
+    metrics = [otelcol.exporter.otlphttp.tiles.input]
+    logs    = [otelcol.exporter.otlphttp.tiles.input]
   }
 }
 

--- a/tf/nodes/test.tfvars
+++ b/tf/nodes/test.tfvars
@@ -31,8 +31,9 @@ virtual_machines = {
   }
 }
 
-alloy_vm_base_id     = 500
-deploy_proxmox_alloy = true
+alloy_vm_base_id      = 500
+deploy_synology_alloy = false
+deploy_proxmox_alloy  = false
 metal_amd_nodes      = {}
 
 # It's a shame the internal volume leaks here

--- a/tf/nodes/variables.tf
+++ b/tf/nodes/variables.tf
@@ -144,7 +144,12 @@ variable "alloy_vm_base_id" {
   type        = number
 }
 
+variable "deploy_synology_alloy" {
+  description = "Whether to deploy the Alloy container project on the Synology NAS (Raconteur). When true, collects host metrics/logs and forwards OTLP to the prod cluster. Enable in prod.tfvars only."
+  type        = bool
+}
+
 variable "deploy_proxmox_alloy" {
-  description = "Whether to deploy Alloy LXC containers on Proxmox nodes (one per node). When true, containers collect host metrics/logs and forward to OTLP. Set per environment (e.g. true for test, false for prod) to avoid duplicate reporting until prod-only deployment is desired."
+  description = "Whether to deploy Alloy LXC containers on Proxmox nodes (one per node). When true, collects host metrics/logs and forwards OTLP to the prod cluster. Enable in prod.tfvars only."
   type        = bool
 }


### PR DESCRIPTION
## Summary

- Edge Alloy on Synology and Proxmox exports metrics and logs to **prod only** (`https://otlp.tiles.symmatree.com`, tenant `tiles`). Removed dual-write to tiles-test.
- Replaced Synology `terraform.workspace == "test"` gate with **`deploy_synology_alloy`**, matching **`deploy_proxmox_alloy`**. Both flags are `true` in `prod.tfvars`, `false` in `test.tfvars`.
- Updated monitoring docs and `tf/nodes/README.md`.

Companion facts doc PR: https://github.com/symmatree/facts/pull/2

## Operator steps after merge

1. Manually delete existing Synology Alloy container project and Proxmox Alloy CTs (if not already done).
2. Optional: `terraform state rm` stale edge Alloy resources in **test** workspace if plans complain.
3. `cd tf/nodes && terraform workspace select prod && terraform apply -var-file=prod.tfvars`
4. Verify in **tiles** Grafana: `cluster="bond"` metrics and `{host="raconteur"}` / `{host=~"nuc-g.*"}` logs.

## Test plan

- [ ] `terraform plan -var-file=prod.tfvars` in prod workspace shows Synology project + Proxmox CTs create (after manual delete)
- [ ] `terraform plan -var-file=test.tfvars` in test workspace shows no edge Alloy resources
- [ ] Raconteur Alloy UI shows only `otelcol.exporter.otlphttp.tiles`
- [ ] PromQL `rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])` on prod Grafana
- [ ] No new `cluster="bond"` series in tiles-test Mimir after cutover