### PR TITLE
Extract Mimir values into multi-source Argo value files

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -1160,270 +1160,91 @@ metadata:
   name: mimir
 spec:
   project: 'placeholder'
-  source:
-    repoURL: https://grafana.github.io/helm-charts
-    targetRevision: "6.0.5"
-    chart: mimir-distributed
-    helm:
-      valuesObject:
-        vault_name: 'placeholder'
-        cluster_name: 'placeholder'
-        gateway:
-          enabled: true
-          ingress:
-            hosts:
-              - 'mimir.placeholder.symmatree.com'
-            tls:
-              - secretName: mimir-tls
-                hosts:
-                  - 'mimir.placeholder.symmatree.com'
-        # NFS storage architecture: see docs/nfs-storage-architecture.md
-        extraObjects:
-          - apiVersion: v1
-            kind: ConfigMap
-            metadata:
-              name: mimir-data-source
-              namespace: "mimir"
-              labels:
-                grafana_datasource: "1"
-            data:
-              datasource.yaml: |-
-                apiVersion: 1
-                datasources:
-                  - name: Mimir
-                    uid: prom
-                    type: prometheus
-                    url: http://mimir-gateway.mimir.svc/prometheus
-                    isDefault: true
-                    jsonData:
-                      prometheusType: Mimir
-                      timeInterval: 60s
-                      alertmanagerUid: alertmanager
-                      httpHeaderName1: X-Scope-OrgID
-                    secureJsonData:
-                      tlsCACert: $__file{/etc/ssl/certs/ca-certificates.crt}
-                      httpHeaderValue1: "placeholder"
-
-          - apiVersion: v1
-            kind: ConfigMap
-            metadata:
-              name: alertmanager-data-source
-              namespace: "mimir"
-              labels:
-                grafana_datasource: "1"
-            data:
-              datasource.yaml: |-
-                apiVersion: 1
-                datasources:
-                  - name: Mimir Alertmanager
-                    uid: alertmanager
-                    type: alertmanager
-                    url: http://mimir-gateway.mimir.svc/
-                    jsonData:
-                      implementation: mimir
-                      handleGrafanaManagedAlerts: true
-                      httpHeaderName1: X-Scope-OrgID
-                    secureJsonData:
-                      httpHeaderValue1: "placeholder"
-
-          - apiVersion: v1
-            kind: PersistentVolume
-            metadata:
-              name: mimir-mimir-data
-            spec:
-              capacity:
-                storage: 100Gi
-              accessModes:
-                - ReadWriteMany
-              persistentVolumeReclaimPolicy: Retain
-              nfs:
-                server: 'placeholder'
-                path: 'placeholder/mimir-data'
-
-          - apiVersion: v1
-            kind: PersistentVolumeClaim
-            metadata:
-              name: mimir-mimir-data
-              namespace: "mimir"
-            spec:
-              accessModes:
-                - ReadWriteMany
-              resources:
-                requests:
-                  storage: 100Gi
-              volumeName: mimir-mimir-data
-              storageClassName: ""
-
-        global:
-          podLabels: {}
-          extraVolumes:
-            - name: mimir-shared-storage
-              persistentVolumeClaim:
-                claimName: mimir-mimir-data
-          extraVolumeMounts:
-            - name: mimir-shared-storage
-              mountPath: /mnt/mimir-nfs
-
-        mimir:
-          structuredConfig:
-            multitenancy_enabled: true
-            tenant_federation:
-              enabled: true
-            limits:
-              ruler_max_rules_per_rule_group: 100
-              # default is 150000 per user, we are currently all in one
-              max_global_series_per_user: 500000
-              max_fetched_chunks_per_query: 4000000
-            common:
-              storage:
-                backend: filesystem
-                # Set to read-only root path as safety check - will fail if any component
-                # tries to use common.storage instead of explicit storage configs
-                filesystem:
-                  dir: /
-            # Shared storage - mounted at /mnt/mimir-nfs via global extraVolumes
-            # All components can access these paths for long-term storage
-            blocks_storage:
-              backend: filesystem
-              filesystem:
-                dir: /mnt/mimir-nfs/blocks
-            ruler_storage:
-              backend: filesystem
-              filesystem:
-                dir: /mnt/mimir-nfs/ruler
-            alertmanager_storage:
-              backend: filesystem
-              filesystem:
-                dir: /mnt/mimir-nfs/alertmanager
-
-        distributor:
-          resources:
-            requests:
-              cpu: 50m
-              memory: 128Mi
-        alertmanager:
-          zoneAwareReplication:
-            enabled: false
-          resources:
-            requests:
-              cpu: 10m
-              memory: 128Mi
-          statefulSet:
+  sources:
+    - repoURL: https://grafana.github.io/helm-charts
+      targetRevision: "6.0.5"
+      chart: mimir-distributed
+      helm:
+        valueFiles:
+          - $values/charts/argocd-applications/values/mimir-values.yaml
+          - $values/charts/argocd-applications/values/mimir-placeholder-values.yaml
+        valuesObject:
+          vault_name: 'placeholder'
+          cluster_name: 'placeholder'
+          gateway:
             enabled: true
-          terminationGracePeriodSeconds: 60
-          extraContainers:
-            - name: alert-forward
-              # Pull-always since we build daily with security patches.
-              imagePullPolicy: Always
-              image: "ghcr.io/symmatree/tiles/mimir-webhook:main"
-              ports:
-                - name: webhook
-                  containerPort: 3000
-                  protocol: TCP
-              env:
-                - name: APPRISE_URL
-                  # Trailing slash is required
-                  value: http://apprise.apprise.svc:8000/notify/
-                - name: APPRISE_KEY
-                  value: apprise
+            ingress:
+              hosts:
+                - 'mimir.placeholder.symmatree.com'
+              tls:
+                - secretName: mimir-tls
+                  hosts:
+                    - 'mimir.placeholder.symmatree.com'
+          # NFS storage architecture: see docs/nfs-storage-architecture.md
+          extraObjects:
+            - apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: mimir-data-source
+                namespace: "mimir"
+                labels:
+                  grafana_datasource: "1"
+              data:
+                datasource.yaml: |-
+                  apiVersion: 1
+                  datasources:
+                    - name: Mimir
+                      uid: prom
+                      type: prometheus
+                      url: http://mimir-gateway.mimir.svc/prometheus
+                      isDefault: true
+                      jsonData:
+                        prometheusType: Mimir
+                        timeInterval: 60s
+                        alertmanagerUid: alertmanager
+                        httpHeaderName1: X-Scope-OrgID
+                      secureJsonData:
+                        tlsCACert: $__file{/etc/ssl/certs/ca-certificates.crt}
+                        httpHeaderValue1: "placeholder"
 
-        compactor:
-          terminationGracePeriodSeconds: 60
+            - apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: alertmanager-data-source
+                namespace: "mimir"
+                labels:
+                  grafana_datasource: "1"
+              data:
+                datasource.yaml: |-
+                  apiVersion: 1
+                  datasources:
+                    - name: Mimir Alertmanager
+                      uid: alertmanager
+                      type: alertmanager
+                      url: http://mimir-gateway.mimir.svc/
+                      jsonData:
+                        implementation: mimir
+                        handleGrafanaManagedAlerts: true
+                        httpHeaderName1: X-Scope-OrgID
+                      secureJsonData:
+                        httpHeaderValue1: "placeholder"
 
-        ingester:
-          resources:
-            requests:
-              cpu: 10m
-              memory: 128Mi
-          terminationGracePeriodSeconds: 60
-          replicas: 2
-          zoneAwareReplication:
-            enabled: false
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  podAffinityTerm:
-                    labelSelector:
-                      matchLabels:
-                        app.kubernetes.io/component: ingester
-                        app.kubernetes.io/name: mimir
-                        app.kubernetes.io/instance: mimir
-                    topologyKey: kubernetes.io/hostname
-              requiredDuringSchedulingIgnoredDuringExecution: []
-        kafka:
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-          extraEnv:
-            - name: KAFKA_LOG_RETENTION_HOURS
-              value: "1"
-            - name: KAFKA_OPTS
-              value: "-Dkafka.logs.dir=/tmp/kafka-logs/"
-        chunks-cache:
-          enabled: false
-          replicas: 1
-          # allocated memory in MB
-          allocatedMemory: 512
-        index-cache:
-          enabled: false
-          replicas: 1
-          allocatedMemory: 128
-
-        metadata-cache:
-          enabled: false
-          replicas: 1
-          allocatedMemory: 128
-
-        results-cache:
-          enabled: false
-          replicas: 1
-          allocatedMemory: 128
-
-        minio:
-          enabled: false
-
-        overrides_exporter:
-          replicas: 1
-          resources:
-            limits:
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 128Mi
-
-        querier:
-          replicas: 1
-          resources:
-            requests:
-              cpu: 50m
-          terminationGracePeriodSeconds: 60
-        query_scheduler:
-          resources:
-            requests:
-              cpu: 50m
-              memory: 128Mi
-        query_frontend:
-          replicas: 1
-          resources:
-            requests:
-              cpu: 50m
-          terminationGracePeriodSeconds: 60
-
-        ruler:
-          replicas: 1
-          terminationGracePeriodSeconds: 60
-          resources:
-            requests:
-              cpu: 100m
-        store_gateway:
-          zoneAwareReplication:
-            enabled: false
-          resources:
-            requests:
-              cpu: 100m
-
+            - apiVersion: v1
+              kind: PersistentVolume
+              metadata:
+                name: mimir-mimir-data
+              spec:
+                capacity:
+                  storage: 100Gi
+                accessModes:
+                  - ReadWriteMany
+                persistentVolumeReclaimPolicy: Retain
+                nfs:
+                  server: 'placeholder'
+                  path: 'placeholder/mimir-data'
+    - repoURL: https://github.com/symmatree/tiles.git
+      targetRevision: 'placeholder'
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: mimir

--- a/charts/argocd-applications/templates/README-mimir.md
+++ b/charts/argocd-applications/templates/README-mimir.md
@@ -14,4 +14,15 @@ This is pretty stock, but a few decisions:
 
 ## Configuration
 
-* **Tenant Limits**: The `max_rules_per_rule_group` limit is set to 50 to accommodate rule groups with up to 50 rules per group. This was increased from the default of 20 to support actual workload requirements (observed: 26 rules) with headroom for future growth.
+External chart (`mimir-distributed` from Grafana). Values are split across:
+
+| Location | Role |
+|----------|------|
+| [`values/mimir-values.yaml`](../values/mimir-values.yaml) | Static chart values (structured config, caches, sidecar, affinity, etc.) |
+| [`values/mimir-tiles-test-values.yaml`](../values/mimir-tiles-test-values.yaml) | Resource requests/limits for `tiles-test` |
+| [`values/mimir-tiles-values.yaml`](../values/mimir-tiles-values.yaml) | Resource requests/limits for `tiles` (prod; same as legacy monolith until tuned) |
+| [`mimir-application.yaml`](mimir-application.yaml) `valuesObject` | Cluster-templated keys only (ingress, NFS PV, Grafana datasource ConfigMaps) |
+
+The Application uses [multi-source](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/#helm-value-files-from-external-git-repository): Grafana chart + tiles git `ref: values` so `valueFiles` can use `$values/charts/argocd-applications/values/...`. Merge order: chart defaults &lt; `valueFiles` (base then `mimir-<cluster_name>-values.yaml`) &lt; `valuesObject`.
+
+* **Tenant Limits**: `ruler_max_rules_per_rule_group` is 100 in `mimir-values.yaml` (increased from default 20 for workload headroom).

--- a/charts/argocd-applications/templates/mimir-application.yaml
+++ b/charts/argocd-applications/templates/mimir-application.yaml
@@ -4,270 +4,91 @@ metadata:
   name: mimir
 spec:
   project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
-  source:
-    repoURL: https://grafana.github.io/helm-charts
-    targetRevision: "6.0.5"
-    chart: mimir-distributed
-    helm:
-      valuesObject:
-        vault_name: '{{ required ".Values.vault_name is required" .Values.vault_name }}'
-        cluster_name: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
-        gateway:
-          enabled: true
-          ingress:
-            hosts:
-              - 'mimir.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
-            tls:
-              - secretName: mimir-tls
-                hosts:
-                  - 'mimir.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
-        # NFS storage architecture: see docs/nfs-storage-architecture.md
-        extraObjects:
-          - apiVersion: v1
-            kind: ConfigMap
-            metadata:
-              name: mimir-data-source
-              namespace: "mimir"
-              labels:
-                grafana_datasource: "1"
-            data:
-              datasource.yaml: |-
-                apiVersion: 1
-                datasources:
-                  - name: Mimir
-                    uid: prom
-                    type: prometheus
-                    url: http://mimir-gateway.mimir.svc/prometheus
-                    isDefault: true
-                    jsonData:
-                      prometheusType: Mimir
-                      timeInterval: 60s
-                      alertmanagerUid: alertmanager
-                      httpHeaderName1: X-Scope-OrgID
-                    secureJsonData:
-                      tlsCACert: $__file{/etc/ssl/certs/ca-certificates.crt}
-                      httpHeaderValue1: "{{ .Values.cluster_name }}"
-
-          - apiVersion: v1
-            kind: ConfigMap
-            metadata:
-              name: alertmanager-data-source
-              namespace: "mimir"
-              labels:
-                grafana_datasource: "1"
-            data:
-              datasource.yaml: |-
-                apiVersion: 1
-                datasources:
-                  - name: Mimir Alertmanager
-                    uid: alertmanager
-                    type: alertmanager
-                    url: http://mimir-gateway.mimir.svc/
-                    jsonData:
-                      implementation: mimir
-                      handleGrafanaManagedAlerts: true
-                      httpHeaderName1: X-Scope-OrgID
-                    secureJsonData:
-                      httpHeaderValue1: "{{ .Values.cluster_name }}"
-
-          - apiVersion: v1
-            kind: PersistentVolume
-            metadata:
-              name: mimir-mimir-data
-            spec:
-              capacity:
-                storage: 100Gi
-              accessModes:
-                - ReadWriteMany
-              persistentVolumeReclaimPolicy: Retain
-              nfs:
-                server: '{{ required ".Values.nfs_server is required" .Values.nfs_server }}'
-                path: '{{ required ".Values.cluster_nfs_path is required" .Values.cluster_nfs_path }}/mimir-data'
-
-          - apiVersion: v1
-            kind: PersistentVolumeClaim
-            metadata:
-              name: mimir-mimir-data
-              namespace: "mimir"
-            spec:
-              accessModes:
-                - ReadWriteMany
-              resources:
-                requests:
-                  storage: 100Gi
-              volumeName: mimir-mimir-data
-              storageClassName: ""
-
-        global:
-          podLabels: {}
-          extraVolumes:
-            - name: mimir-shared-storage
-              persistentVolumeClaim:
-                claimName: mimir-mimir-data
-          extraVolumeMounts:
-            - name: mimir-shared-storage
-              mountPath: /mnt/mimir-nfs
-
-        mimir:
-          structuredConfig:
-            multitenancy_enabled: true
-            tenant_federation:
-              enabled: true
-            limits:
-              ruler_max_rules_per_rule_group: 100
-              # default is 150000 per user, we are currently all in one
-              max_global_series_per_user: 500000
-              max_fetched_chunks_per_query: 4000000
-            common:
-              storage:
-                backend: filesystem
-                # Set to read-only root path as safety check - will fail if any component
-                # tries to use common.storage instead of explicit storage configs
-                filesystem:
-                  dir: /
-            # Shared storage - mounted at /mnt/mimir-nfs via global extraVolumes
-            # All components can access these paths for long-term storage
-            blocks_storage:
-              backend: filesystem
-              filesystem:
-                dir: /mnt/mimir-nfs/blocks
-            ruler_storage:
-              backend: filesystem
-              filesystem:
-                dir: /mnt/mimir-nfs/ruler
-            alertmanager_storage:
-              backend: filesystem
-              filesystem:
-                dir: /mnt/mimir-nfs/alertmanager
-
-        distributor:
-          resources:
-            requests:
-              cpu: 50m
-              memory: 128Mi
-        alertmanager:
-          zoneAwareReplication:
-            enabled: false
-          resources:
-            requests:
-              cpu: 10m
-              memory: 128Mi
-          statefulSet:
+  sources:
+    - repoURL: https://grafana.github.io/helm-charts
+      targetRevision: "6.0.5"
+      chart: mimir-distributed
+      helm:
+        valueFiles:
+          - $values/charts/argocd-applications/values/mimir-values.yaml
+          - $values/charts/argocd-applications/values/mimir-{{ required ".Values.cluster_name is required" .Values.cluster_name }}-values.yaml
+        valuesObject:
+          vault_name: '{{ required ".Values.vault_name is required" .Values.vault_name }}'
+          cluster_name: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+          gateway:
             enabled: true
-          terminationGracePeriodSeconds: 60
-          extraContainers:
-            - name: alert-forward
-              # Pull-always since we build daily with security patches.
-              imagePullPolicy: Always
-              image: "ghcr.io/symmatree/tiles/mimir-webhook:main"
-              ports:
-                - name: webhook
-                  containerPort: 3000
-                  protocol: TCP
-              env:
-                - name: APPRISE_URL
-                  # Trailing slash is required
-                  value: http://apprise.apprise.svc:8000/notify/
-                - name: APPRISE_KEY
-                  value: apprise
+            ingress:
+              hosts:
+                - 'mimir.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
+              tls:
+                - secretName: mimir-tls
+                  hosts:
+                    - 'mimir.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
+          # NFS storage architecture: see docs/nfs-storage-architecture.md
+          extraObjects:
+            - apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: mimir-data-source
+                namespace: "mimir"
+                labels:
+                  grafana_datasource: "1"
+              data:
+                datasource.yaml: |-
+                  apiVersion: 1
+                  datasources:
+                    - name: Mimir
+                      uid: prom
+                      type: prometheus
+                      url: http://mimir-gateway.mimir.svc/prometheus
+                      isDefault: true
+                      jsonData:
+                        prometheusType: Mimir
+                        timeInterval: 60s
+                        alertmanagerUid: alertmanager
+                        httpHeaderName1: X-Scope-OrgID
+                      secureJsonData:
+                        tlsCACert: $__file{/etc/ssl/certs/ca-certificates.crt}
+                        httpHeaderValue1: "{{ .Values.cluster_name }}"
 
-        compactor:
-          terminationGracePeriodSeconds: 60
+            - apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: alertmanager-data-source
+                namespace: "mimir"
+                labels:
+                  grafana_datasource: "1"
+              data:
+                datasource.yaml: |-
+                  apiVersion: 1
+                  datasources:
+                    - name: Mimir Alertmanager
+                      uid: alertmanager
+                      type: alertmanager
+                      url: http://mimir-gateway.mimir.svc/
+                      jsonData:
+                        implementation: mimir
+                        handleGrafanaManagedAlerts: true
+                        httpHeaderName1: X-Scope-OrgID
+                      secureJsonData:
+                        httpHeaderValue1: "{{ .Values.cluster_name }}"
 
-        ingester:
-          resources:
-            requests:
-              cpu: 10m
-              memory: 128Mi
-          terminationGracePeriodSeconds: 60
-          replicas: 2
-          zoneAwareReplication:
-            enabled: false
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  podAffinityTerm:
-                    labelSelector:
-                      matchLabels:
-                        app.kubernetes.io/component: ingester
-                        app.kubernetes.io/name: mimir
-                        app.kubernetes.io/instance: mimir
-                    topologyKey: kubernetes.io/hostname
-              requiredDuringSchedulingIgnoredDuringExecution: []
-        kafka:
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-          extraEnv:
-            - name: KAFKA_LOG_RETENTION_HOURS
-              value: "1"
-            - name: KAFKA_OPTS
-              value: "-Dkafka.logs.dir=/tmp/kafka-logs/"
-        chunks-cache:
-          enabled: false
-          replicas: 1
-          # allocated memory in MB
-          allocatedMemory: 512
-        index-cache:
-          enabled: false
-          replicas: 1
-          allocatedMemory: 128
-
-        metadata-cache:
-          enabled: false
-          replicas: 1
-          allocatedMemory: 128
-
-        results-cache:
-          enabled: false
-          replicas: 1
-          allocatedMemory: 128
-
-        minio:
-          enabled: false
-
-        overrides_exporter:
-          replicas: 1
-          resources:
-            limits:
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 128Mi
-
-        querier:
-          replicas: 1
-          resources:
-            requests:
-              cpu: 50m
-          terminationGracePeriodSeconds: 60
-        query_scheduler:
-          resources:
-            requests:
-              cpu: 50m
-              memory: 128Mi
-        query_frontend:
-          replicas: 1
-          resources:
-            requests:
-              cpu: 50m
-          terminationGracePeriodSeconds: 60
-
-        ruler:
-          replicas: 1
-          terminationGracePeriodSeconds: 60
-          resources:
-            requests:
-              cpu: 100m
-        store_gateway:
-          zoneAwareReplication:
-            enabled: false
-          resources:
-            requests:
-              cpu: 100m
-
+            - apiVersion: v1
+              kind: PersistentVolume
+              metadata:
+                name: mimir-mimir-data
+              spec:
+                capacity:
+                  storage: 100Gi
+                accessModes:
+                  - ReadWriteMany
+                persistentVolumeReclaimPolicy: Retain
+                nfs:
+                  server: '{{ required ".Values.nfs_server is required" .Values.nfs_server }}'
+                  path: '{{ required ".Values.cluster_nfs_path is required" .Values.cluster_nfs_path }}/mimir-data'
+    - repoURL: https://github.com/symmatree/tiles.git
+      targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: mimir

--- a/charts/argocd-applications/values/mimir-tiles-test-values.yaml
+++ b/charts/argocd-applications/values/mimir-tiles-test-values.yaml
@@ -1,0 +1,59 @@
+# Low requests for tiles-test scheduling. Overrides mimir-values.yaml resource keys.
+
+distributor:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+alertmanager:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 128Mi
+
+ingester:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 128Mi
+
+kafka:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+overrides_exporter:
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+querier:
+  resources:
+    requests:
+      cpu: 50m
+
+query_scheduler:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+query_frontend:
+  resources:
+    requests:
+      cpu: 50m
+
+ruler:
+  resources:
+    requests:
+      cpu: 100m
+
+store_gateway:
+  resources:
+    requests:
+      cpu: 100m

--- a/charts/argocd-applications/values/mimir-tiles-values.yaml
+++ b/charts/argocd-applications/values/mimir-tiles-values.yaml
@@ -1,0 +1,59 @@
+# Resource overrides for tiles (prod). Same as pre-split monolithic valuesObject; tune here when raising prod requests/limits.
+
+distributor:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+alertmanager:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 128Mi
+
+ingester:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 128Mi
+
+kafka:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+overrides_exporter:
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+querier:
+  resources:
+    requests:
+      cpu: 50m
+
+query_scheduler:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+query_frontend:
+  resources:
+    requests:
+      cpu: 50m
+
+ruler:
+  resources:
+    requests:
+      cpu: 100m
+
+store_gateway:
+  resources:
+    requests:
+      cpu: 100m

--- a/charts/argocd-applications/values/mimir-values.yaml
+++ b/charts/argocd-applications/values/mimir-values.yaml
@@ -1,0 +1,146 @@
+# Static Mimir values (mimir-distributed chart). Per-cluster resources in mimir-<cluster_name>-values.yaml.
+# Templated keys (gateway ingress, NFS PV, datasource org header) stay in mimir-application.yaml valuesObject.
+
+global:
+  podLabels: {}
+  extraVolumes:
+    - name: mimir-shared-storage
+      persistentVolumeClaim:
+        claimName: mimir-mimir-data
+  extraVolumeMounts:
+    - name: mimir-shared-storage
+      mountPath: /mnt/mimir-nfs
+
+extraObjects:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: mimir-mimir-data
+      namespace: "mimir"
+    spec:
+      accessModes:
+        - ReadWriteMany
+      resources:
+        requests:
+          storage: 100Gi
+      volumeName: mimir-mimir-data
+      storageClassName: ""
+
+mimir:
+  structuredConfig:
+    multitenancy_enabled: true
+    tenant_federation:
+      enabled: true
+    limits:
+      ruler_max_rules_per_rule_group: 100
+      # default is 150000 per user, we are currently all in one
+      max_global_series_per_user: 500000
+      max_fetched_chunks_per_query: 4000000
+    common:
+      storage:
+        backend: filesystem
+        # Set to read-only root path as safety check - will fail if any component
+        # tries to use common.storage instead of explicit storage configs
+        filesystem:
+          dir: /
+    # Shared storage - mounted at /mnt/mimir-nfs via global extraVolumes
+    blocks_storage:
+      backend: filesystem
+      filesystem:
+        dir: /mnt/mimir-nfs/blocks
+    ruler_storage:
+      backend: filesystem
+      filesystem:
+        dir: /mnt/mimir-nfs/ruler
+    alertmanager_storage:
+      backend: filesystem
+      filesystem:
+        dir: /mnt/mimir-nfs/alertmanager
+
+alertmanager:
+  zoneAwareReplication:
+    enabled: false
+  statefulSet:
+    enabled: true
+  terminationGracePeriodSeconds: 60
+  extraContainers:
+    - name: alert-forward
+      imagePullPolicy: Always
+      image: "ghcr.io/symmatree/tiles/mimir-webhook:main"
+      ports:
+        - name: webhook
+          containerPort: 3000
+          protocol: TCP
+      env:
+        - name: APPRISE_URL
+          value: http://apprise.apprise.svc:8000/notify/
+        - name: APPRISE_KEY
+          value: apprise
+
+compactor:
+  terminationGracePeriodSeconds: 60
+
+ingester:
+  terminationGracePeriodSeconds: 60
+  replicas: 2
+  zoneAwareReplication:
+    enabled: false
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: ingester
+                app.kubernetes.io/name: mimir
+                app.kubernetes.io/instance: mimir
+            topologyKey: kubernetes.io/hostname
+      requiredDuringSchedulingIgnoredDuringExecution: []
+
+kafka:
+  extraEnv:
+    - name: KAFKA_OPTS
+      value: "-Dkafka.logs.dir=/tmp/kafka-logs/"
+
+chunks-cache:
+  enabled: false
+  replicas: 1
+  allocatedMemory: 512
+
+index-cache:
+  enabled: false
+  replicas: 1
+  allocatedMemory: 128
+
+metadata-cache:
+  enabled: false
+  replicas: 1
+  allocatedMemory: 128
+
+results-cache:
+  enabled: false
+  replicas: 1
+  allocatedMemory: 128
+
+minio:
+  enabled: false
+
+overrides_exporter:
+  replicas: 1
+
+querier:
+  replicas: 1
+  terminationGracePeriodSeconds: 60
+
+query_frontend:
+  replicas: 1
+  terminationGracePeriodSeconds: 60
+
+ruler:
+  replicas: 1
+  terminationGracePeriodSeconds: 60
+
+store_gateway:
+  zoneAwareReplication:
+    enabled: false


### PR DESCRIPTION
## Summary

- Split the Mimir Application from a single large `valuesObject` into Argo CD **multi-source**: Grafana `mimir-distributed` chart plus tiles git `ref: values` for `$values/charts/argocd-applications/values/...` files.
- **`mimir-values.yaml`**: static chart config (structuredConfig, caches, sidecar, PVC, affinity, etc.).
- **`mimir-tiles-test-values.yaml`** / **`mimir-tiles-values.yaml`**: per-cluster resource requests only (same values as the old monolith for now; prod can be tuned separately later).
- **`mimir-application.yaml`**: slim `valuesObject` for templated keys only (ingress, NFS PV, Grafana datasource ConfigMaps).

No intentional resource or behavior change vs the previous monolithic spec (including omitting `KAFKA_LOG_RETENTION_HOURS`, which this chart version does not support).

## Test plan

- [ ] Merge and sync `argocd-applications` on tiles-test
- [ ] Confirm `mimir` Application is Healthy and uses `sources` with `$values` paths
- [ ] Spot-check a few workload resource requests match `mimir-tiles-test-values.yaml`
- [ ] Repeat on tiles after prod values are ready to diverge (optional)


Made with [Cursor](https://cursor.com)