### PR TITLE
Fix Argo CD bootstrap to load per-cluster value files

### DIFF
--- a/charts/argocd/README.md
+++ b/charts/argocd/README.md
@@ -86,7 +86,7 @@ N/A - ArgoCD is bootstrapped manually and does not have Terraform-managed resour
 ArgoCD is initially bootstrapped via the CI workflow (`.github/workflows/bootstrap-cluster.yaml`) which runs [`bootstrap.sh`](bootstrap.sh):
 
 1. Creates the `argocd` namespace with pod security labels
-2. Runs `helm template` with cluster-specific values (loaded from 1Password)
+2. Runs `helm template` with the same value files as the `argocd` Application (`argocd-values.yaml`, `argocd-<cluster_name>-values.yaml`) plus domain overrides from the environment (loaded from 1Password)
 3. Applies manifests via `kubectl apply --server-side`
 
 After bootstrap, the `argocd-applications` chart installs the ArgoCD Application resource, which enables self-management. ArgoCD then syncs itself (mostly adding tracking annotations) and becomes self-managed.

--- a/charts/argocd/bootstrap.sh
+++ b/charts/argocd/bootstrap.sh
@@ -4,10 +4,22 @@ set -exuo pipefail
 # Source the helper script to set up helm_template_args and set_flags
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck disable=SC1091
 source "${REPO_ROOT}/scripts/helm-common.bash"
 cd "${REPO_ROOT}"
 
 echo "::group::Bootstrap ArgoCD"
+if [[ -z ${cluster_name:-} ]]; then
+	echo "ERROR: cluster_name not set"
+	exit 1
+fi
+
+argocd_cluster_values="${REPO_ROOT}/charts/argocd-applications/values/argocd-${cluster_name}-values.yaml"
+if [[ ! -f $argocd_cluster_values ]]; then
+	echo "ERROR: per-cluster values file not found: ${argocd_cluster_values}"
+	exit 1
+fi
+
 kubectl delete namespace argocd --ignore-not-found
 kubectl create namespace argocd
 kubectl label namespace argocd "pod-security.kubernetes.io/warn=baseline" --overwrite
@@ -15,10 +27,15 @@ kubectl label namespace argocd "pod-security.kubernetes.io/enforce=privileged" -
 kubectl label namespace argocd "trust-bundle=enabled" --overwrite
 kubectl config set-context --current --namespace=argocd
 
+# Mirror charts/argocd/application.yaml valueFiles (Argo cannot helm-template Application CRs here).
+# helm_template_args and set_flags come from helm-common.bash (sourced above).
+# shellcheck disable=SC2154
 helm template argocd charts/argocd --namespace argocd \
 	--skip-crds \
 	"${helm_template_args[@]}" \
 	"${set_flags[@]}" \
+	-f charts/argocd-applications/values/argocd-values.yaml \
+	-f "${argocd_cluster_values}" \
 	--set "argo-cd.global.domain=argocd.${cluster_name:?}.symmatree.com" \
 	--set "argo-cd.server.ingressGrpc.hostname=grpc-argocd.${cluster_name:?}.symmatree.com" |
 	kubectl apply --server-side -f-


### PR DESCRIPTION
## Summary

- Update `charts/argocd/bootstrap.sh` to pass `argocd-values.yaml` and `argocd-<cluster_name>-values.yaml` on `helm template`, matching the `argocd` Application `valueFiles` merge order.
- Require `cluster_name` and the per-cluster values file to exist before bootstrap runs.
- Document the bootstrap value-file behavior in `charts/argocd/README.md`.

Bootstrap had fallen behind when multi-source / per-environment values were added (#455); the first install never picked up repo-server limits from `argocd-tiles-values.yaml`.

## Test plan

- [ ] Re-run bootstrap on a test cluster (or `helm template` with the same `-f` flags and `cluster_name=tiles`) and confirm `argocd-repo-server` has `limits.memory: 384Mi` and `requests.memory: 128Mi`.
- [ ] Confirm bootstrap fails clearly if `argocd-<cluster_name>-values.yaml` is missing.


Made with [Cursor](https://cursor.com)