### PR TITLE
Add run-name to operator workflows for clearer Actions list titles.

### DIFF
--- a/.github/workflows/bootstrap-cluster.yaml
+++ b/.github/workflows/bootstrap-cluster.yaml
@@ -1,4 +1,5 @@
 name: "bootstrap-cluster"
+run-name: "Bootstrap ${{ inputs.cluster }} by @${{ github.actor }} [crds=${{ inputs.crds }}, cilium=${{ inputs.cilium }}, argocd=${{ inputs.argocd }}, 1p=${{ inputs.onepassword }}, apps=${{ inputs.argocd_applications }}]"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/nodes-plan-apply.yaml
+++ b/.github/workflows/nodes-plan-apply.yaml
@@ -1,4 +1,16 @@
 name: "nodes-plan-apply"
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' && (
+      inputs.apply == false && format('Plan test+prod by @{0}', github.actor)
+      || inputs.environment == 'test' && format('Apply test, plan prod by @{0}', github.actor)
+      || format('Plan test, apply prod by @{0}', github.actor)
+    )
+    || github.event_name == 'push' && format('Apply test, plan prod (push {0}) by @{1}', github.ref_name, github.actor)
+    || github.event_name == 'pull_request' && format('Plan test+prod (PR #{0}) by @{1}', github.event.pull_request.number, github.actor)
+    || github.event_name == 'schedule' && format('Plan test+prod (schedule) by @{0}', github.actor)
+    || format('{0} by @{1}', github.event_name, github.actor)
+  }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/taint-vms.yaml
+++ b/.github/workflows/taint-vms.yaml
@@ -1,4 +1,5 @@
 name: "taint-vms"
+run-name: "Taint VMs test=${{ inputs.taint_test }} prod=${{ inputs.taint_prod }} by @${{ github.actor }}"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Show key dispatch inputs (and trigger-specific behavior for nodes-plan-apply) so manual runs are easier to scan without opening each workflow.