### PR TITLE
Use onepassword ssh secret type instead of a secure note

### DIFF
--- a/charts/static-certs/values.yaml
+++ b/charts/static-certs/values.yaml
@@ -46,7 +46,7 @@ homeassistantSshSync:
   sshKeyOnePasswordItem:
     name: homeassistant-cert-ssh
     itemPath: vaults/tiles-secrets/items/homeassistant-cert-ssh
-  sshKeySecretKey: private_key
+  sshKeySecretKey: "private key"
   certificates:
     - fqdn: homeassistant.local.symmatree.com
       secretName: homeassistant-cert


### PR DESCRIPTION
something was wrong with the old secret, try "import private key" through the op ui rather than deal with whitespace problems from pasting keys. This changes the key in the secret from `private_key` to `private key`