### PR TITLE
Fix ha-ssh-sync SSH identity path for 1Password field names

### DIFF
--- a/charts/static-certs/README.md
+++ b/charts/static-certs/README.md
@@ -160,7 +160,7 @@ kubectl get certificate <name> -n static-certs -o yaml
 
 - **Manual deployment**: Most hosts still need manual extract + install (see below).
 - **Synology DSM (prod only)**: **`synologyDsmSync`** CronJob pushes **`raconteur`**, **`cam`**, and **`photos`** certs to Raconteur when **`values-prod.yaml`** enables it.
-- **Home Assistant (prod only)**: **`homeassistantSshSync`** CronJob pushes **`homeassistant-cert`** to `/config/ssl/` on the Yellow (`10.0.99.9`) via SSH when **`values-prod.yaml`** enables it. Requires 1Password item **`homeassistant-cert-ssh`** (`private_key` / `public_key`) and the **`public_key`** value in the SSH add-on **`authorized_keys`**. Remote paths match **`ha-config`** `configuration.yaml` (`ssl/homeassistant-cert.crt` / `.key`).
+- **Home Assistant (prod only)**: **`homeassistantSshSync`** CronJob pushes **`homeassistant-cert`** to `/config/ssl/` on the Yellow (`10.0.99.9`) via SSH when **`values-prod.yaml`** enables it. Requires 1Password item **`homeassistant-cert-ssh`** (fields **`private key`** / **`public key`**, see **`sshKeySecretKey`** in `values.yaml`) and the **`public key`** value in the SSH add-on **`authorized_keys`**. Remote paths match **`ha-config`** `configuration.yaml` (`ssl/homeassistant-cert.crt` / `.key`).
 - Other static certs are still manual unless extended in chart values.
 - **Special cases**: **`laserjet`** uses PKCS12 / 1Password password (separate template).
 

--- a/charts/static-certs/scripts/ha-ssh-sync-run.sh
+++ b/charts/static-certs/scripts/ha-ssh-sync-run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${DEPLOY_SSH_USER:?}" "${DEPLOY_SSH_SERVER:?}" "${DEPLOY_SSH_KEYFILE:?}" "${DEPLOY_SSH_FULLCHAIN:?}" "${DEPLOY_SSH_REMOTE_CMD:?}" "${SSH_IDENTITY_FILE:?}"
+
+# 1Password field names may contain spaces (e.g. "private key" -> /ssh/private key).
+# acme.sh runs DEPLOY_SSH_CMD via unquoted "$_ssh_cmd" (word-split only, no re-parse
+# of embedded quotes), so -i paths cannot contain spaces. Copy to a temp file first.
+_ssh_identity="$(mktemp)"
+install -m600 "$SSH_IDENTITY_FILE" "$_ssh_identity"
+SSH_IDENTITY_FILE="$_ssh_identity"
+export SSH_IDENTITY_FILE
+export DEPLOY_SSH_CMD="ssh -i ${SSH_IDENTITY_FILE} -o StrictHostKeyChecking=accept-new"
+export DEPLOY_SSH_SCP_CMD="scp -q -i ${SSH_IDENTITY_FILE} -o StrictHostKeyChecking=accept-new"
+
+git clone -q --depth 1 https://github.com/acmesh-official/acme.sh.git /tmp/a
+A=/tmp/a/acme.sh
+H=/tmp/h
+rm -rf "$H"
+mkdir -p "$H"
+p12() {
+	local c=$1 k=$2 lf=$3 ca=$4
+	local p w
+	p=$(mktemp)
+	w=$(openssl rand -hex 16)
+	openssl pkcs12 -export -out "$p" -inkey "$k" -in "$c" -passout "pass:$w" -name tls
+	openssl pkcs12 -in "$p" -nokeys -clcerts -passin "pass:$w" -out "$lf"
+	openssl pkcs12 -in "$p" -nokeys -cacerts -passin "pass:$w" -out "$ca"
+	rm -f "$p"
+}
+one() {
+	local d=$1 c=$2 k=$3
+	local t
+	t=$(mktemp -d)
+	p12 "$c" "$k" "$t/l" "$t/z"
+	local D="$H/${d}_ecc"
+	mkdir -p "$D"
+	install -m0600 "$k" "$D/$d.key"
+	install -m0644 "$t/l" "$D/$d.cer"
+	install -m0644 "$t/z" "$D/ca.cer"
+	install -m0644 "$c" "$D/fullchain.cer"
+	printf 'Le_Domain="%s"\nLe_Alt=\n' "$d" >"$D/$d.conf"
+	export DEPLOY_SSH_USE_SCP=yes
+	"$A" --home "$H" --deploy --deploy-hook ssh -d "$d" --ecc
+	rm -rf "$t"
+}

--- a/charts/static-certs/templates/ha-ssh-configmap.helm.yaml
+++ b/charts/static-certs/templates/ha-ssh-configmap.helm.yaml
@@ -6,34 +6,7 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
 data:
   run.sh: |
-    #!/usr/bin/env bash
-    set -euo pipefail
-    : "${DEPLOY_SSH_USER:?}" "${DEPLOY_SSH_SERVER:?}" "${DEPLOY_SSH_KEYFILE:?}" "${DEPLOY_SSH_FULLCHAIN:?}" "${DEPLOY_SSH_REMOTE_CMD:?}" "${SSH_IDENTITY_FILE:?}"
-    git clone -q --depth 1 https://github.com/acmesh-official/acme.sh.git /tmp/a
-    A=/tmp/a/acme.sh
-    H=/tmp/h; rm -rf "$H"; mkdir -p "$H"
-    p12() {
-      local c=$1 k=$2 lf=$3 ca=$4 p=$(mktemp) w=$(openssl rand -hex 16)
-      openssl pkcs12 -export -out "$p" -inkey "$k" -in "$c" -passout "pass:$w" -name tls
-      openssl pkcs12 -in "$p" -nokeys -clcerts -passin "pass:$w" -out "$lf"
-      openssl pkcs12 -in "$p" -nokeys -cacerts -passin "pass:$w" -out "$ca"
-      rm -f "$p"
-    }
-    one() {
-      local d=$1 c=$2 k=$3 t=$(mktemp -d)
-      p12 "$c" "$k" "$t/l" "$t/z"
-      local D="$H/${d}_ecc"
-      mkdir -p "$D"
-      install -m0600 "$k" "$D/$d.key"
-      install -m0644 "$t/l" "$D/$d.cer"
-      install -m0644 "$t/z" "$D/ca.cer"
-      install -m0644 "$c" "$D/fullchain.cer"
-      printf 'Le_Domain="%s"\nLe_Alt=\n' "$d" >"$D/$d.conf"
-      export DEPLOY_SSH_CMD="ssh -i ${SSH_IDENTITY_FILE} -o StrictHostKeyChecking=accept-new"
-      export DEPLOY_SSH_USE_SCP=yes
-      "$A" --home "$H" --deploy --deploy-hook ssh -d "$d" --ecc
-      rm -rf "$t"
-    }
+{{ .Files.Get "scripts/ha-ssh-sync-run.sh" | nindent 4 }}
 {{- range .Values.homeassistantSshSync.certificates }}
     one "{{ .fqdn }}" "/certs/{{ .volumeMountPath }}/tls.crt" "/certs/{{ .volumeMountPath }}/tls.key"
 {{- end }}


### PR DESCRIPTION
## Summary

- Extract `homeassistantSshSync` `run.sh` from the ConfigMap template into `charts/static-certs/scripts/ha-ssh-sync-run.sh`.
- Copy the mounted SSH identity file to a space-free temp path before setting `DEPLOY_SSH_CMD` and `DEPLOY_SSH_SCP_CMD`, because acme.sh expands those vars unquoted (word-split only; embedded quotes do not work).
- Update README to document 1Password field names (`private key` / `public key`).

Fixes #480

## Context

Prod `static-certs-ha-ssh-sync` CronJob is failing with `KubeJobFailed`. Investigation found:

1. Invalid/corrupt private key in 1Password on first run (`error in libcrypto`) -- operator action still needed to verify/regenerate the deploy keypair.
2. Code bug: `sshKeySecretKey: "private key"` mounts at `/ssh/private key`, which breaks acme.sh `-i` handling even with a valid key.

## Test plan

- [x] `build.sh` passes (static-certs lint + template)
- [ ] After merge: Argo syncs `static-certs` in tiles prod
- [ ] Operator verifies/regenerates 1Password item `homeassistant-cert-ssh` and confirms `public key` is in HA SSH `authorized_keys`
- [ ] Manual job run succeeds:
  ```bash
  KUBECONFIG="$HOME/.kube/tiles.yaml" kubectl create job -n static-certs \
    --from=cronjob/static-certs-ha-ssh-sync manual-ha-ssh-sync-$(date +%s)
  ```
- [ ] Loki logs show SSH deploy completing without `error in libcrypto`


Made with [Cursor](https://cursor.com)