### PR TITLE
Phase 1: acebase GNSS Talos patch (issue #488)

### DIFF
--- a/tf/modules/talos-cluster/nodes.tf
+++ b/tf/modules/talos-cluster/nodes.tf
@@ -108,7 +108,8 @@ module "talos-amd-metal" {
           }
         }
       }
-    })] : []
+    })] : [],
+    each.value.machine_config_patches
   )
 }
 
@@ -142,6 +143,7 @@ module "talos-intel-metal" {
           }
         }
       }
-    })] : []
+    })] : [],
+    each.value.machine_config_patches
   )
 }

--- a/tf/modules/talos-cluster/variables.tf
+++ b/tf/modules/talos-cluster/variables.tf
@@ -26,22 +26,24 @@ variable "unifi_network_id" {
 variable "metal_amd_nodes" {
   description = "List of metal AMD nodes in the cluster"
   type = map(object({
-    name        = string
-    type        = string
-    mac_address = string
-    ip_address  = string
-    taint       = string
+    name                   = string
+    type                   = string
+    mac_address            = string
+    ip_address             = string
+    taint                  = string
+    machine_config_patches = optional(list(string), [])
   }))
 }
 
 variable "metal_intel_nodes" {
   description = "List of metal Intel nodes in the cluster"
   type = map(object({
-    name        = string
-    type        = string
-    mac_address = string
-    ip_address  = string
-    taint       = string
+    name                   = string
+    type                   = string
+    mac_address            = string
+    ip_address             = string
+    taint                  = string
+    machine_config_patches = optional(list(string), [])
   }))
   default = {}
 }

--- a/tf/nodes/cluster.tf
+++ b/tf/nodes/cluster.tf
@@ -2,6 +2,24 @@ data "unifi_network" "main" {
   name = var.unifi_network_name
 }
 
+locals {
+  metal_amd_nodes = {
+    for k, v in var.metal_amd_nodes : k => merge(v, {
+      machine_config_patches = [
+        for p in v.machine_config_patches : file("${path.module}/${p}")
+      ]
+    })
+  }
+
+  metal_intel_nodes = {
+    for k, v in var.metal_intel_nodes : k => merge(v, {
+      machine_config_patches = [
+        for p in v.machine_config_patches : file("${path.module}/${p}")
+      ]
+    })
+  }
+}
+
 module "cluster" {
   source                      = "../modules/talos-cluster"
   proxmox_storage_iso         = var.proxmox_storage_iso
@@ -25,8 +43,8 @@ module "cluster" {
   control_plane_vip      = var.control_plane_vip
   control_plane_vip_link = "eth0" # This depends on predictable network ifaces being off
   vms                    = var.virtual_machines
-  metal_amd_nodes        = var.metal_amd_nodes
-  metal_intel_nodes      = var.metal_intel_nodes
+  metal_amd_nodes        = local.metal_amd_nodes
+  metal_intel_nodes      = local.metal_intel_nodes
   nodes_to_iso_ids       = local.nodes_to_iso_ids
   main_project_id        = local.main_project_id
   kms_project_id         = local.kms_project_id

--- a/tf/nodes/patches/acebase-gnss.yaml
+++ b/tf/nodes/patches/acebase-gnss.yaml
@@ -1,0 +1,9 @@
+# AceBase ZED-F9P on USB (discovered 2026-06-07 via talosctl on 10.0.99.14):
+#   idVendor=1546 (u-blox AG), idProduct=01a9 (ZED-F9P), driver=cdc_acm, device=ttyACM0
+machine:
+  kernel:
+    modules:
+      - name: cdc_acm
+  udev:
+    rules:
+      - SUBSYSTEM=="tty", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a9", SYMLINK+="gnss"

--- a/tf/nodes/prod.tfvars
+++ b/tf/nodes/prod.tfvars
@@ -82,11 +82,12 @@ metal_amd_nodes = {}
 # MAC/IP from facts fables/kb/Computers/AceBase.md
 metal_intel_nodes = {
   "acebase" = {
-    name        = "acebase"
-    type        = "worker"
-    mac_address = "00:e0:4c:5f:3d:71"
-    ip_address  = "10.0.99.14"
-    taint       = ""
+    name                   = "acebase"
+    type                   = "worker"
+    mac_address            = "00:e0:4c:5f:3d:71"
+    ip_address             = "10.0.99.14"
+    taint                  = "gnss"
+    machine_config_patches = ["patches/acebase-gnss.yaml"]
   }
 }
 

--- a/tf/nodes/variables.tf
+++ b/tf/nodes/variables.tf
@@ -80,22 +80,24 @@ variable "unifi_network_name" {
 variable "metal_amd_nodes" {
   description = "List of metal AMD nodes in the cluster"
   type = map(object({
-    name        = string
-    type        = string
-    mac_address = string
-    ip_address  = string
-    taint       = string
+    name                   = string
+    type                   = string
+    mac_address            = string
+    ip_address             = string
+    taint                  = string
+    machine_config_patches = optional(list(string), [])
   }))
 }
 
 variable "metal_intel_nodes" {
   description = "List of metal Intel nodes in the cluster"
   type = map(object({
-    name        = string
-    type        = string
-    mac_address = string
-    ip_address  = string
-    taint       = string
+    name                   = string
+    type                   = string
+    mac_address            = string
+    ip_address             = string
+    taint                  = string
+    machine_config_patches = optional(list(string), [])
   }))
 }
 


### PR DESCRIPTION
## Summary

- Add optional `machine_config_patches` to metal node tfvars; paths under `tf/nodes/patches/` are loaded in `cluster.tf` and concatenated into Talos machine config for AMD/Intel metal workers.
- Add `patches/acebase-gnss.yaml` for prod acebase: load `cdc_acm`, udev rule matching **idVendor=1546 / idProduct=01a9** (ZED-F9P discovered on `ttyACM0`), symlink `/dev/gnss`.
- Set acebase `taint = "gnss"` (`dedicated=gnss:NoSchedule`) in prod tfvars.

Closes phase 1 of #488. Phases 2-5 (container, k8s, secrets, validation) are follow-ups.

## USB discovery (2026-06-07)

Checked acebase (`10.0.99.14`) with `talosctl --talosconfig ~/.talos/tiles.yaml`:

| Field | Value |
|-------|-------|
| idVendor | `1546` (u-blox AG) |
| idProduct | `01a9` (ZED-F9P) |
| Current device | `/dev/ttyACM0` (driver `cdc_acm`) |

Issue text mixed these up: **1546 is the vendor ID**, not the product. The udev rule matches both.

`cp210x` / `ch341` modules from the issue draft were omitted -- F9P uses `cdc_acm` only and is already enumerated without them.

## Test plan

- [ ] `terraform validate` in `tf/nodes/` (done locally)
- [ ] `terraform plan -var-file=prod.tfvars` shows acebase config patch + taint change only
- [ ] After apply + acebase reboot: `/dev/gnss` present, points at F9P serial
- [ ] `kubectl describe node acebase` shows `dedicated=gnss:NoSchedule` taint


Made with [Cursor](https://cursor.com)