### PR TITLE
Phase 2: RTKBase container image (issue #488)

### DIFF
--- a/.github/workflows/build-rtkbase.yaml
+++ b/.github/workflows/build-rtkbase.yaml
@@ -1,0 +1,69 @@
+name: build-rtkbase
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 9 * * *
+jobs:
+  build-rtkbase:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    name: build-rtkbase
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/symmatree/tiles/rtkbase
+      IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      REGISTRY_USER: ${{ github.actor }}
+      REGISTRY_PASSWORD: ${{ github.token }}
+      RTKBASE_VERSION: v2.7.0
+    steps:
+      - uses: actions/checkout@v6
+      - name: Docker Metadata
+        id: docker-metadata
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}
+          context: ./containers/rtkbase
+          containerfiles: |
+            ./containers/rtkbase/Dockerfile
+          build-args: |
+            RTKBASE_VERSION=${{ env.RTKBASE_VERSION }}
+          extra-args: |
+            --disable-compression=false
+            --cache-from=${{ env.IMAGE_NAME }}-cache
+            --cache-to=${{ env.IMAGE_NAME }}-cache
+
+      - name: Check images created
+        run: buildah images | grep '${{ env.IMAGE_NAME }}'
+
+      - name: Push To GHCR
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --disable-content-trust

--- a/containers/rtkbase/Dockerfile
+++ b/containers/rtkbase/Dockerfile
@@ -1,0 +1,31 @@
+# RTKBase GNSS base + NTRIP caster for amd64 Kubernetes (acebase).
+# Install flow adapted from drakkar-lig/walt-images featured/rpi32-rtk-base (BSD-3-Clause).
+FROM jrei/systemd-debian:bookworm
+
+ARG RTKBASE_VERSION=v2.7.0
+ENV container=docker
+STOPSIGNAL SIGRTMIN+3
+
+WORKDIR /root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends sudo wget lsb-release ca-certificates \
+    && wget -q "https://raw.githubusercontent.com/Stefal/rtkbase/${RTKBASE_VERSION}/tools/install.sh" -O install.sh \
+    && chmod +x install.sh \
+    && ./install.sh --user root --dependencies \
+    && ./install.sh --user root --rtkbase-custom "https://github.com/stefal/rtkbase/releases/download/${RTKBASE_VERSION}/rtkbase.tar.gz" \
+    && ./install.sh --user root --rtkbase-requirements \
+    && ./install.sh --user root --rtklib \
+    && ./install.sh --user root --unit-files \
+    && ./install.sh --user root --gpsd-chrony \
+    && rm -f rtkbase.tar.gz \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rtk-base-on-bootup rtk-base-user-on-bootup /usr/local/bin/
+RUN chmod +x /usr/local/bin/rtk-base-on-bootup /usr/local/bin/rtk-base-user-on-bootup \
+    && sed -i '/^ExecStart=.*/i ExecStartPre=/usr/local/bin/rtk-base-on-bootup' /etc/systemd/system/rtkbase_web.service \
+    && rm -f /usr/sbin/policy-rc.d
+
+# Populated on first boot; mount a PVC at /persist/rtkbase in Kubernetes.
+VOLUME ["/persist/rtkbase"]

--- a/containers/rtkbase/README.md
+++ b/containers/rtkbase/README.md
@@ -1,0 +1,39 @@
+# RTKBase container (issue #488)
+
+amd64 image running [Stefal/rtkbase](https://github.com/Stefal/rtkbase) under systemd for the acebase GNSS base + NTRIP caster. Install flow adapted from [drakkar-lig/walt-images `featured/rpi32-rtk-base`](https://github.com/drakkar-lig/walt-images/tree/main/featured/rpi32-rtk-base).
+
+## Image
+
+Published to `ghcr.io/symmatree/tiles/rtkbase` by [`.github/workflows/build-rtkbase.yaml`](../../.github/workflows/build-rtkbase.yaml).
+
+RTKBase release pinned in [`Dockerfile`](Dockerfile) (`RTKBASE_VERSION`, currently v2.7.0). On amd64, RTKlib is compiled during the image build (`install.sh --rtklib`); prebuilt binaries exist only for ARM in the upstream tarball.
+
+## Build locally
+
+```bash
+docker build -t rtkbase:local containers/rtkbase
+```
+
+Run (needs `/dev/gnss`, cgroup, privileged -- see phase 3 tanka sketch in issue #488):
+
+```bash
+docker run --rm -it --privileged \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+  --device /dev/gnss:/dev/gnss \
+  -v rtkbase-persist:/persist/rtkbase \
+  rtkbase:local
+```
+
+## First boot
+
+`rtk-base-on-bootup` (ExecStartPre on `rtkbase_web.service`):
+
+1. Detect/configure the receiver when `/persist/rtkbase` is empty (GNSS device must be present).
+2. Bind-mount `settings.conf` from the persist volume.
+3. Run `/persist/rtkbase/on-bootup` (seeded from `rtk-base-user-on-bootup`).
+
+Default autostart: `str2str_tcp.service` and `str2str_local_ntrip_caster.service`. Coords, mountpoint, and caster auth are configured via the web UI after first boot.
+
+## Kubernetes (phase 3)
+
+Not in this directory yet. Planned: Deployment on acebase with hostPath `/dev/gnss`, PVC at `/persist/rtkbase`, LoadBalancer for NTRIP :2101, Ingress for admin UI.

--- a/containers/rtkbase/rtk-base-on-bootup
+++ b/containers/rtkbase/rtk-base-on-bootup
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Adapted from drakkar-lig/walt-images featured/rpi32-rtk-base/rtk-base-on-bootup (BSD-3-Clause).
+
+PERSIST=/persist/rtkbase
+
+# settings.conf and collected data persist across reboots
+if [ ! -d "${PERSIST}" ]; then
+	# First boot: detect and configure the GNSS receiver (requires /dev/gnss mounted)
+	cd /root || exit 1
+	./install.sh --user root --detect-gnss
+	./install.sh --user root --configure-gnss
+	sed -i -e "s/^datadir=.*$/datadir=${PERSIST}\/data/" rtkbase/settings.conf
+	mkdir -p "${PERSIST}/data"
+	mv /root/rtkbase/settings.conf "${PERSIST}/"
+	touch /root/rtkbase/settings.conf
+	mv /usr/local/bin/rtk-base-user-on-bootup "${PERSIST}/on-bootup"
+fi
+
+mount -o bind "${PERSIST}/settings.conf" /root/rtkbase/settings.conf
+
+if [ -x "${PERSIST}/on-bootup" ]; then
+	"${PERSIST}/on-bootup"
+fi

--- a/containers/rtkbase/rtk-base-user-on-bootup
+++ b/containers/rtkbase/rtk-base-user-on-bootup
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Adapted from drakkar-lig/walt-images featured/rpi32-rtk-base/rtk-base-user-on-bootup (BSD-3-Clause).
+# Default first-boot autostart for acebase NTRIP deployment (issue #488).
+
+systemctl start str2str_tcp.service
+systemctl start str2str_local_ntrip_caster.service


### PR DESCRIPTION
## Summary

- Add `containers/rtkbase/` -- Dockerfile, first-boot scripts (adapted from [walt-images `featured/rpi32-rtk-base`](https://github.com/drakkar-lig/walt-images/tree/main/featured/rpi32-rtk-base)), README.
- Base: `jrei/systemd-debian:bookworm` (systemd PID 1 for k8s phase 3).
- RTKBase **v2.7.0** pinned via build arg; amd64 builds compile RTKlib (`install.sh --rtklib`) since upstream ships prebuilt binaries only for ARM.
- Persist volume at `/persist/rtkbase`; udev on acebase exposes `/dev/gnss` (phase 1).
- Default autostart: `str2str_tcp` + `str2str_local_ntrip_caster` (per issue #488).
- CI: `.github/workflows/build-rtkbase.yaml` publishes to `ghcr.io/symmatree/tiles/rtkbase`.

Part of #488 phase 2. Phase 3 (Tanka/Argo deployment) is next.

## Walt delta (as specified in issue)

| walt (Pi) | this image |
|-----------|------------|
| `waltplatform/rpi32-debian:bookworm` | `jrei/systemd-debian:bookworm` |
| copy `rtklib_*/armv7l` | `install.sh --rtklib` (compile on x86_64) |
| `/persist/rpi-rtk-base` | `/persist/rtkbase` |
| Walt overlays | dropped |
| `ConditionVirtualization=false` | dropped |
| autostart `str2str_tcp` only | also `str2str_local_ntrip_caster` |

## Test plan

- [ ] Merge and run `build-rtkbase` workflow (or workflow_dispatch) -- image build is ~10+ min (RTKlib compile + Python venv)
- [ ] `docker run --privileged` with `/dev/gnss` + cgroup mount: web UI reachable, first boot detects F9P
- [ ] Phase 3: pin image tag in tanka deployment on acebase


Made with [Cursor](https://cursor.com)