### PR TITLE
NTRIP Tanka deployment and Terraform secrets (issue #488 phases 3-4)

### DIFF
--- a/charts/argocd-applications/templates/ntrip-application.helm.yaml
+++ b/charts/argocd-applications/templates/ntrip-application.helm.yaml
@@ -1,0 +1,1 @@
+../../../tanka/environments/ntrip/application.helm.yaml

--- a/containers/rtkbase/README.md
+++ b/containers/rtkbase/README.md
@@ -36,4 +36,4 @@ Default autostart: `str2str_tcp.service` and `str2str_local_ntrip_caster.service
 
 ## Kubernetes (phase 3)
 
-Not in this directory yet. Planned: Deployment on acebase with hostPath `/dev/gnss`, PVC at `/persist/rtkbase`, LoadBalancer for NTRIP :2101, Ingress for admin UI.
+Deployed via [`tanka/environments/ntrip/`](../../tanka/environments/ntrip/). Boot script reads `RTKBASE_WEB_PASSWORD`, `RTKBASE_NTRIP_USER`, and `RTKBASE_NTRIP_PASSWORD` from synced 1Password secrets and writes them into persisted `settings.conf` before RTKBase services start.

--- a/containers/rtkbase/rtk-base-on-bootup
+++ b/containers/rtkbase/rtk-base-on-bootup
@@ -18,6 +18,27 @@ fi
 
 mount -o bind "${PERSIST}/settings.conf" /root/rtkbase/settings.conf
 
+# Inject credentials from Kubernetes secrets (synced from 1Password via operator).
+# RTKBase hashes new_web_password on rtkbase_web start; caster creds are plain text in settings.conf.
+set_conf_value() {
+	local key="$1"
+	local value="$2"
+	local file="${PERSIST}/settings.conf"
+	[ -f "${file}" ] || return 0
+	[ -n "${value}" ] || return 0
+	local escaped
+	escaped=$(printf '%s' "${value}" | sed "s/'/'\\\\''/g")
+	if grep -q "^${key}=" "${file}"; then
+		sed -i "s|^${key}=.*|${key}='${escaped}'|" "${file}"
+	else
+		echo "${key}='${escaped}'" >>"${file}"
+	fi
+}
+
+set_conf_value new_web_password "${RTKBASE_WEB_PASSWORD:-}"
+set_conf_value local_ntripc_user "${RTKBASE_NTRIP_USER:-}"
+set_conf_value local_ntripc_pwd "${RTKBASE_NTRIP_PASSWORD:-}"
+
 if [ -x "${PERSIST}/on-bootup" ]; then
 	"${PERSIST}/on-bootup"
 fi

--- a/tanka/environments/ntrip/README.md
+++ b/tanka/environments/ntrip/README.md
@@ -1,0 +1,40 @@
+# NTRIP / RTKBase (prod acebase)
+
+GNSS base + local NTRIP caster on bare-metal node **acebase**. Prod only (`cluster_name: tiles`); no acebase on test.
+
+## Endpoints
+
+| Service | URL | Auth |
+|---------|-----|------|
+| NTRIP caster | `ntrip.tiles.symmatree.com:2101` / mountpoint `ATTIC` | `{cluster}-ntrip-caster-auth` in 1Password |
+| Admin web UI | `https://ntrip-admin.tiles.symmatree.com` | `{cluster}-ntrip-admin` in 1Password (username `admin`) |
+
+## Architecture
+
+- **Image:** [`containers/rtkbase/`](../../../containers/rtkbase/)
+- **Terraform secrets:** [`tf/modules/k8s-cluster/ntrip.tf`](../../../tf/modules/k8s-cluster/ntrip.tf)
+- **Tanka:** [`main.jsonnet`](main.jsonnet)
+- **Argo CD:** [`application.helm.yaml`](application.helm.yaml) (prod only: `cluster_name == tiles`)
+
+Pod runs privileged on acebase with hostPath `/dev/gnss`, PVC `/persist/rtkbase`, and systemd PID 1. NTRIP is exposed via LoadBalancer + external-dns; the web UI via Ingress + cert-manager.
+
+## Web UI authentication
+
+RTKBase uses a **single built-in user** with username **`admin`** (hardcoded in upstream Flask app). The password is stored as a werkzeug hash in `settings.conf` (`web_password_hash`); upstream default is the literal password **`admin`** ([Stefal/rtkbase README](https://github.com/Stefal/rtkbase/)).
+
+Unlike Apprise, there is no nginx/basic-auth sidecar. Ingress provides TLS only; the app login form is the gate.
+
+Terraform generates a random admin password and stores it in 1Password as a **login** item (`tiles-ntrip-admin`, username `admin`, URL `https://ntrip-admin.tiles.symmatree.com`) so the browser extension can autofill. The 1Password operator syncs it into the cluster; [`rtk-base-on-bootup`](../../../containers/rtkbase/rtk-base-on-bootup) writes `new_web_password` into persisted `settings.conf` before `rtkbase_web` starts, and RTKBase hashes it on service start.
+
+## NTRIP caster authentication
+
+Caster credentials live in `settings.conf` under `[local_ntrip_caster]` as plain `local_ntripc_user` / `local_ntripc_pwd`. Terraform creates `{cluster}-ntrip-caster-auth` (username `gps`, random password) for client reference. Historical field setup used `gps`/`gps`; change via the web UI or update clients after deploy.
+
+## Operator follow-up (phase 5)
+
+After first boot with the F9P attached: set fixed base coordinates, mountpoint `ATTIC`, RTCM message set, and verify NTRIP on `:2101`. See issue #488 and `facts/geospatial/sparkfun-gps-collection.md`.
+
+## Dependencies
+
+- [cert-manager](../../../charts/cert-manager/README.md), [external-dns](../../../charts/external-dns/README.md), [OnePassword operator](../../../charts/onepassword/README.md), [Cilium LB pool](../../../charts/cilium-config/)
+- Acebase Talos GNSS patch and `dedicated=gnss:NoSchedule` taint (phase 1)

--- a/tanka/environments/ntrip/application.helm.yaml
+++ b/tanka/environments/ntrip/application.helm.yaml
@@ -1,0 +1,44 @@
+{{- if eq .Values.cluster_name "tiles" }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ntrip
+spec:
+  project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+    path: tanka
+    plugin:
+      env:
+        - name: TK_ENV
+          value: ntrip
+      parameters:
+        - name: cluster_name
+          string: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+        - name: vault_name
+          string: '{{ required ".Values.vault_name is required" .Values.vault_name }}'
+        - name: project_id
+          string: '{{ required ".Values.project_id is required" .Values.project_id }}'
+        - name: app_settings
+          map:
+            ntrip_hostname: ntrip.tiles.symmatree.com
+            admin_hostname: ntrip-admin.tiles.symmatree.com
+            cluster_issuer: real-cert
+            image: ghcr.io/symmatree/tiles/rtkbase:0a66c21
+            ntrip_admin: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-ntrip-admin'
+            ntrip_caster_auth: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-ntrip-caster-auth'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ntrip
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/warn: baseline
+{{- end }}

--- a/tanka/environments/ntrip/application.helm.yaml
+++ b/tanka/environments/ntrip/application.helm.yaml
@@ -25,7 +25,7 @@ spec:
             ntrip_hostname: ntrip.tiles.symmatree.com
             admin_hostname: ntrip-admin.tiles.symmatree.com
             cluster_issuer: real-cert
-            image: ghcr.io/symmatree/tiles/rtkbase:0a66c21
+            image: ghcr.io/symmatree/tiles/rtkbase:sha-80f095e
             ntrip_admin: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-ntrip-admin'
             ntrip_caster_auth: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-ntrip-caster-auth'
   destination:

--- a/tanka/environments/ntrip/main.jsonnet
+++ b/tanka/environments/ntrip/main.jsonnet
@@ -1,0 +1,136 @@
+local k_util = import 'github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonnet';
+local k = import 'k.libsonnet';
+local op = import 'op.libsonnet';
+
+local APP_VARS = std.parseJson(std.extVar('ARGOCD_APP_PARAMETERS'));
+local isString(v) = std.objectHas(v, 'string');
+local isMap(v) = std.objectHas(v, 'map');
+local APP = {
+  [v.name]: v.string
+  for v in std.filter(isString, APP_VARS)
+} + {
+  [v.name]: v.map
+  for v in std.filter(isMap, APP_VARS)
+};
+
+local ntrip = {
+  local kDeployment = k.apps.v1.deployment,
+  local kContainer = k.core.v1.container,
+  local kPort = k.core.v1.containerPort,
+  local kPersistentVolumeClaim = k.core.v1.persistentVolumeClaim,
+  local kIngress = k.networking.v1.ingress,
+  local kEnvVar = k.core.v1.envVar,
+  local kIngressRule = k.networking.v1.ingressRule,
+  local kHttpIngressPath = k.networking.v1.httpIngressPath,
+  local kIngressTLS = k.networking.v1.ingressTLS,
+
+  local gnssToleration = {
+    key: 'dedicated',
+    operator: 'Equal',
+    value: 'gnss',
+    effect: 'NoSchedule',
+  },
+
+  local defaults = {
+    name: 'rtkbase',
+    image: APP.app_settings.image,
+    webPort: kPort.newNamed(80, 'http'),
+    ntripPortName: 'ntrip',
+    ntripPortNumber: 2101,
+    ntripHostname: APP.app_settings.ntrip_hostname,
+    adminHostname: APP.app_settings.admin_hostname,
+    adminSecret: APP.app_settings.ntrip_admin,
+    casterSecret: APP.app_settings.ntrip_caster_auth,
+    ingressAnnotations: {
+      'cert-manager.io/cluster-issuer': APP.app_settings.cluster_issuer,
+    },
+    ingressClassName: 'cilium',
+  },
+
+  new(overrides):: {
+    local ntripObj = self,
+    local config = defaults + overrides,
+
+    adminSecret: op.item.new(config.adminSecret, 'vaults/' + APP.vault_name + '/items/' + config.adminSecret),
+    casterSecret: op.item.new(config.casterSecret, 'vaults/' + APP.vault_name + '/items/' + config.casterSecret),
+
+    persistPvc: kPersistentVolumeClaim.new(std.format('%s-persist', config.name))
+                + kPersistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
+                + kPersistentVolumeClaim.spec.resources.withRequestsMixin({ storage: '5Gi' })
+                + kPersistentVolumeClaim.spec.withStorageClassName('local-path'),
+
+    local podLabels = { app: config.name },
+
+    deployment:
+      kDeployment.new(config.name, replicas=1, containers=[
+        kContainer.new(config.name, config.image)
+        + kContainer.withPortsMixin([
+          config.webPort,
+          kPort.newNamed(config.ntripPortNumber, config.ntripPortName),
+        ])
+        + kContainer.withEnvMixin([
+          kEnvVar.new('RTKBASE_WEB_PASSWORD', '')
+          + kEnvVar.valueFrom.secretKeyRef.withName(ntripObj.adminSecret.metadata.name)
+          + kEnvVar.valueFrom.secretKeyRef.withKey('password'),
+          kEnvVar.new('RTKBASE_NTRIP_USER', '')
+          + kEnvVar.valueFrom.secretKeyRef.withName(ntripObj.casterSecret.metadata.name)
+          + kEnvVar.valueFrom.secretKeyRef.withKey('username'),
+          kEnvVar.new('RTKBASE_NTRIP_PASSWORD', '')
+          + kEnvVar.valueFrom.secretKeyRef.withName(ntripObj.casterSecret.metadata.name)
+          + kEnvVar.valueFrom.secretKeyRef.withKey('password'),
+        ])
+        + kContainer.securityContext.withPrivileged(true),
+      ], podLabels=podLabels)
+      + kDeployment.spec.selector.withMatchLabels(podLabels)
+      + kDeployment.spec.strategy.withType('Recreate')
+      + kDeployment.spec.template.spec.withNodeSelector({ 'kubernetes.io/hostname': 'acebase' })
+      + kDeployment.spec.template.spec.withTolerationsMixin([gnssToleration])
+      + k_util.pvcVolumeMount(ntripObj.persistPvc.metadata.name, '/persist/rtkbase')
+      + k_util.hostVolumeMount('gnss', '/dev/gnss', '/dev/gnss')
+      + k_util.hostVolumeMount('cgroup', '/sys/fs/cgroup', '/sys/fs/cgroup', readOnly=false),
+
+    webService: k_util.serviceFor(self.deployment),
+
+    ntripCasterService: {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: 'ntrip-caster',
+        annotations: {
+          'external-dns.alpha.kubernetes.io/hostname': config.ntripHostname,
+        },
+        labels: podLabels,
+      },
+      spec: {
+        type: 'LoadBalancer',
+        selector: podLabels,
+        ports: [{
+          name: 'ntrip',
+          port: config.ntripPortNumber,
+          targetPort: config.ntripPortNumber,
+          protocol: 'TCP',
+        }],
+      },
+    },
+
+    ingress:
+      kIngress.new(std.format('%s-admin', config.name))
+      + kIngress.metadata.withAnnotations(config.ingressAnnotations)
+      + kIngress.spec.withIngressClassName(config.ingressClassName)
+      + kIngress.spec.withRulesMixin([
+        kIngressRule.withHost(config.adminHostname)
+        + kIngressRule.http.withPathsMixin(
+          kHttpIngressPath.withPath('/')
+          + kHttpIngressPath.withPathType('Prefix')
+          + kHttpIngressPath.backend.service.withName(ntripObj.webService.metadata.name)
+          + kHttpIngressPath.backend.service.port.withName(ntripObj.webService.spec.ports[0].name)
+        ),
+      ])
+      + kIngress.spec.withTlsMixin([
+        kIngressTLS.withHosts([config.adminHostname])
+        + kIngressTLS.withSecretName(std.format('%s-admin-tls', config.name)),
+      ]),
+  },
+};
+
+ntrip.new({})

--- a/tanka/environments/ntrip/spec.json
+++ b/tanka/environments/ntrip/spec.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "environments/ntrip"
+  },
+  "spec": {
+    "namespace": "ntrip",
+    "resourceDefaults": {},
+    "expectVersions": {}
+  }
+}

--- a/tf/modules/k8s-cluster/ntrip.tf
+++ b/tf/modules/k8s-cluster/ntrip.tf
@@ -1,0 +1,67 @@
+# Component: NTRIP / RTKBase on acebase (prod only)
+# Documentation: tanka/environments/ntrip/README.md
+# Application: tanka/environments/ntrip/application.yaml
+
+resource "random_password" "ntrip_admin" {
+  count   = var.cluster_name == "tiles" ? 1 : 0
+  length  = 24
+  special = false
+}
+
+resource "onepassword_item" "ntrip_admin" {
+  count    = var.cluster_name == "tiles" ? 1 : 0
+  vault    = var.onepassword_vault
+  title    = "${var.cluster_name}-ntrip-admin"
+  category = "login"
+  username = "admin"
+  password = random_password.ntrip_admin[0].result
+  url      = "https://ntrip-admin.tiles.symmatree.com"
+
+  section {
+    label = "metadata"
+    field {
+      label = "source"
+      value = "managed by terraform"
+    }
+    field {
+      label = "root_module"
+      value = basename(abspath(path.root))
+    }
+    field {
+      label = "module"
+      value = basename(abspath(path.module))
+    }
+  }
+}
+
+resource "random_password" "ntrip_caster" {
+  count   = var.cluster_name == "tiles" ? 1 : 0
+  length  = 24
+  special = false
+}
+
+resource "onepassword_item" "ntrip_caster_auth" {
+  count    = var.cluster_name == "tiles" ? 1 : 0
+  vault    = var.onepassword_vault
+  title    = "${var.cluster_name}-ntrip-caster-auth"
+  category = "login"
+  username = "gps"
+  password = random_password.ntrip_caster[0].result
+  url      = "ntrip://ntrip.tiles.symmatree.com:2101/ATTIC"
+
+  section {
+    label = "metadata"
+    field {
+      label = "source"
+      value = "managed by terraform"
+    }
+    field {
+      label = "root_module"
+      value = basename(abspath(path.root))
+    }
+    field {
+      label = "module"
+      value = basename(abspath(path.module))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add prod-only Argo CD / Tanka environment for RTKBase on acebase (NTRIP LoadBalancer + admin Ingress)
- Add Terraform 1Password items for web admin and NTRIP caster credentials
- Inject credentials into persisted `settings.conf` at boot via `rtk-base-on-bootup`

## Test plan
- [ ] Merge PR and run `build-rtkbase` workflow on this branch (needs branch for GH Actions)
- [ ] Bump `image` tag in `application.helm.yaml` to the new build SHA
- [ ] `terraform apply` prod workspace (creates `tiles-ntrip-admin`, `tiles-ntrip-caster-auth`)
- [ ] Argo sync `ntrip` on prod; verify pod schedules on acebase with `/dev/gnss`
- [ ] Confirm `ntrip.tiles.symmatree.com:2101` and `https://ntrip-admin.tiles.symmatree.com` (1Password autofill for admin login)

Closes phases 3-4 of #488.


Made with [Cursor](https://cursor.com)