### PR TITLE
Fix NTRIP bring-up: privileged namespace and gps/gps auth (#488)

### DIFF
--- a/containers/rtkbase/README.md
+++ b/containers/rtkbase/README.md
@@ -36,4 +36,4 @@ Default autostart: `str2str_tcp.service` and `str2str_local_ntrip_caster.service
 
 ## Kubernetes (phase 3)
 
-Deployed via [`tanka/environments/ntrip/`](../../tanka/environments/ntrip/). Boot script reads `RTKBASE_WEB_PASSWORD`, `RTKBASE_NTRIP_USER`, and `RTKBASE_NTRIP_PASSWORD` from synced 1Password secrets and writes them into persisted `settings.conf` before RTKBase services start.
+Deployed via [`tanka/environments/ntrip/`](../../tanka/environments/ntrip/). Boot script reads `RTKBASE_NTRIP_USER` and `RTKBASE_NTRIP_PASSWORD` from the synced 1Password caster secret (`gps` / `gps`) and writes them into persisted `settings.conf` before RTKBase services start. Web UI uses the upstream default `admin` / `admin`.

--- a/tanka/environments/ntrip/README.md
+++ b/tanka/environments/ntrip/README.md
@@ -6,29 +6,25 @@ GNSS base + local NTRIP caster on bare-metal node **acebase**. Prod only (`clust
 
 | Service | URL | Auth |
 |---------|-----|------|
-| NTRIP caster | `ntrip.tiles.symmatree.com:2101` / mountpoint `ATTIC` | `{cluster}-ntrip-caster-auth` in 1Password |
-| Admin web UI | `https://ntrip-admin.tiles.symmatree.com` | `{cluster}-ntrip-admin` in 1Password (username `admin`) |
+| NTRIP caster | `ntrip.tiles.symmatree.com:2101` / mountpoint `ATTIC` | `gps` / `gps` (also in 1Password `{cluster}-ntrip-caster-auth`) |
+| Admin web UI | `https://ntrip-admin.tiles.symmatree.com` | RTKBase default `admin` / `admin` |
+
+Both hostnames resolve to **private 10.x addresses** on the site LAN (Cilium LoadBalancer pool `10.0.129.0/24` on prod). external-dns provides convenient names; there is no public internet exposure.
 
 ## Architecture
 
 - **Image:** [`containers/rtkbase/`](../../../containers/rtkbase/)
-- **Terraform secrets:** [`tf/modules/k8s-cluster/ntrip.tf`](../../../tf/modules/k8s-cluster/ntrip.tf)
+- **Terraform:** [`tf/modules/k8s-cluster/ntrip.tf`](../../../tf/modules/k8s-cluster/ntrip.tf) (caster creds reference in 1Password)
 - **Tanka:** [`main.jsonnet`](main.jsonnet)
 - **Argo CD:** [`application.helm.yaml`](application.helm.yaml) (prod only: `cluster_name == tiles`)
 
-Pod runs privileged on acebase with hostPath `/dev/gnss`, PVC `/persist/rtkbase`, and systemd PID 1. NTRIP is exposed via LoadBalancer + external-dns; the web UI via Ingress + cert-manager.
+Pod runs privileged on acebase with hostPath `/dev/gnss`, PVC `/persist/rtkbase`, and systemd PID 1. NTRIP is exposed via LoadBalancer + external-dns; the web UI via Ingress + cert-manager (TLS only).
 
-## Web UI authentication
+## Authentication
 
-RTKBase uses a **single built-in user** with username **`admin`** (hardcoded in upstream Flask app). The password is stored as a werkzeug hash in `settings.conf` (`web_password_hash`); upstream default is the literal password **`admin`** ([Stefal/rtkbase README](https://github.com/Stefal/rtkbase/)).
+**Web UI:** RTKBase ships with username `admin` and password `admin` ([upstream default](https://github.com/Stefal/rtkbase/)). Ingress adds HTTPS; no extra auth layer.
 
-Unlike Apprise, there is no nginx/basic-auth sidecar. Ingress provides TLS only; the app login form is the gate.
-
-Terraform generates a random admin password and stores it in 1Password as a **login** item (`tiles-ntrip-admin`, username `admin`, URL `https://ntrip-admin.tiles.symmatree.com`) so the browser extension can autofill. The 1Password operator syncs it into the cluster; [`rtk-base-on-bootup`](../../../containers/rtkbase/rtk-base-on-bootup) writes `new_web_password` into persisted `settings.conf` before `rtkbase_web` starts, and RTKBase hashes it on service start.
-
-## NTRIP caster authentication
-
-Caster credentials live in `settings.conf` under `[local_ntrip_caster]` as plain `local_ntripc_user` / `local_ntripc_pwd`. Terraform creates `{cluster}-ntrip-caster-auth` (username `gps`, random password) for client reference. Historical field setup used `gps`/`gps`; change via the web UI or update clients after deploy.
+**NTRIP caster:** `gps` / `gps`, injected from the synced 1Password item on each boot via [`rtk-base-on-bootup`](../../../containers/rtkbase/rtk-base-on-bootup). Matches historical field clients (SW Maps, u-center, etc.).
 
 ## Operator follow-up (phase 5)
 

--- a/tanka/environments/ntrip/application.helm.yaml
+++ b/tanka/environments/ntrip/application.helm.yaml
@@ -26,7 +26,6 @@ spec:
             admin_hostname: ntrip-admin.tiles.symmatree.com
             cluster_issuer: real-cert
             image: ghcr.io/symmatree/tiles/rtkbase:sha-80f095e
-            ntrip_admin: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-ntrip-admin'
             ntrip_caster_auth: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-ntrip-caster-auth'
   destination:
     server: https://kubernetes.default.svc
@@ -40,5 +39,6 @@ spec:
       - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
-        pod-security.kubernetes.io/warn: baseline
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/warn: privileged
 {{- end }}

--- a/tanka/environments/ntrip/main.jsonnet
+++ b/tanka/environments/ntrip/main.jsonnet
@@ -39,7 +39,6 @@ local ntrip = {
     ntripPortNumber: 2101,
     ntripHostname: APP.app_settings.ntrip_hostname,
     adminHostname: APP.app_settings.admin_hostname,
-    adminSecret: APP.app_settings.ntrip_admin,
     casterSecret: APP.app_settings.ntrip_caster_auth,
     ingressAnnotations: {
       'cert-manager.io/cluster-issuer': APP.app_settings.cluster_issuer,
@@ -51,7 +50,6 @@ local ntrip = {
     local ntripObj = self,
     local config = defaults + overrides,
 
-    adminSecret: op.item.new(config.adminSecret, 'vaults/' + APP.vault_name + '/items/' + config.adminSecret),
     casterSecret: op.item.new(config.casterSecret, 'vaults/' + APP.vault_name + '/items/' + config.casterSecret),
 
     persistPvc: kPersistentVolumeClaim.new(std.format('%s-persist', config.name))
@@ -69,9 +67,6 @@ local ntrip = {
           kPort.newNamed(config.ntripPortNumber, config.ntripPortName),
         ])
         + kContainer.withEnvMixin([
-          kEnvVar.new('RTKBASE_WEB_PASSWORD', '')
-          + kEnvVar.valueFrom.secretKeyRef.withName(ntripObj.adminSecret.metadata.name)
-          + kEnvVar.valueFrom.secretKeyRef.withKey('password'),
           kEnvVar.new('RTKBASE_NTRIP_USER', '')
           + kEnvVar.valueFrom.secretKeyRef.withName(ntripObj.casterSecret.metadata.name)
           + kEnvVar.valueFrom.secretKeyRef.withKey('username'),

--- a/tf/modules/k8s-cluster/ntrip.tf
+++ b/tf/modules/k8s-cluster/ntrip.tf
@@ -2,51 +2,13 @@
 # Documentation: tanka/environments/ntrip/README.md
 # Application: tanka/environments/ntrip/application.yaml
 
-resource "random_password" "ntrip_admin" {
-  count   = var.cluster_name == "tiles" ? 1 : 0
-  length  = 24
-  special = false
-}
-
-resource "onepassword_item" "ntrip_admin" {
-  count    = var.cluster_name == "tiles" ? 1 : 0
-  vault    = var.onepassword_vault
-  title    = "${var.cluster_name}-ntrip-admin"
-  category = "login"
-  username = "admin"
-  password = random_password.ntrip_admin[0].result
-  url      = "https://ntrip-admin.tiles.symmatree.com"
-
-  section {
-    label = "metadata"
-    field {
-      label = "source"
-      value = "managed by terraform"
-    }
-    field {
-      label = "root_module"
-      value = basename(abspath(path.root))
-    }
-    field {
-      label = "module"
-      value = basename(abspath(path.module))
-    }
-  }
-}
-
-resource "random_password" "ntrip_caster" {
-  count   = var.cluster_name == "tiles" ? 1 : 0
-  length  = 24
-  special = false
-}
-
 resource "onepassword_item" "ntrip_caster_auth" {
   count    = var.cluster_name == "tiles" ? 1 : 0
   vault    = var.onepassword_vault
   title    = "${var.cluster_name}-ntrip-caster-auth"
   category = "login"
   username = "gps"
-  password = random_password.ntrip_caster[0].result
+  password = "gps"
   url      = "ntrip://ntrip.tiles.symmatree.com:2101/ATTIC"
 
   section {


### PR DESCRIPTION
## Summary
- Set `pod-security.kubernetes.io/enforce/warn: privileged` on the `ntrip` namespace so the RTKBase pod (privileged + hostPath `/dev/gnss`, cgroup) can schedule; baseline was blocking pod creation.
- Simplify auth: RTKBase web UI stays default `admin`/`admin` over HTTPS; NTRIP caster pinned to `gps`/`gps` for existing field clients.
- Terraform: drop `tiles-ntrip-admin` and random passwords; only `{cluster}-ntrip-caster-auth` (`gps`/`gps`) remains.

## Context
After #491 merged, the `ntrip` Application synced but stayed Degraded: ReplicaSet `FailedCreate` due to Pod Security baseline. Prod terraform apply for #491 also failed on plan (transient 1Password read errors); items were never created. This PR should unblock both GitOps and a cleaner terraform apply (2 resources instead of 4).

## Test plan
- [ ] Merge and confirm `nodes-plan-apply` prod apply succeeds (creates `tiles-ntrip-caster-auth`)
- [ ] Argo syncs `argocd-applications` then `ntrip`; namespace gets privileged labels
- [ ] Pod schedules on acebase: `kubectl -n ntrip get pods`
- [ ] OnePasswordItem `tiles-ntrip-caster-auth` becomes Ready; caster secret syncs
- [ ] NTRIP reachable at `ntrip.tiles.symmatree.com:2101` / `ATTIC` with `gps`/`gps`
- [ ] Admin UI at `https://ntrip-admin.tiles.symmatree.com` (admin/admin)


Made with [Cursor](https://cursor.com)