### PR TITLE
Fix RTKBase settings bind mount and always pull :main

### DIFF
--- a/containers/rtkbase/rtk-base-user-on-bootup
+++ b/containers/rtkbase/rtk-base-user-on-bootup
@@ -2,5 +2,15 @@
 # Adapted from drakkar-lig/walt-images featured/rpi32-rtk-base/rtk-base-user-on-bootup (BSD-3-Clause).
 # Default first-boot autostart for acebase NTRIP deployment (issue #488).
 
+PERSIST=/persist/rtkbase
+
+# PVC holds settings.conf; bind-mount it over the image copy at the path RTKBase reads.
+# (Kubernetes subPath file mounts fail here with "not a directory" on acebase/kubelet.)
+if [ ! -f "${PERSIST}/settings.conf" ]; then
+	echo "missing ${PERSIST}/settings.conf (init container should have seeded it)" >&2
+	exit 1
+fi
+mount --bind "${PERSIST}/settings.conf" /root/rtkbase/settings.conf
+
 systemctl start str2str_tcp.service
 systemctl start str2str_local_ntrip_caster.service

--- a/tanka/environments/ntrip/README.md
+++ b/tanka/environments/ntrip/README.md
@@ -18,7 +18,7 @@ Both hostnames resolve to **private 10.x addresses** on the site LAN (Cilium Loa
 - **Tanka:** [`main.jsonnet`](main.jsonnet)
 - **Argo CD:** [`application.helm.yaml`](application.helm.yaml) (prod only: `cluster_name == tiles`)
 
-Pod runs privileged on acebase with hostPath `/dev/gnss`, PVC `/persist/rtkbase` (RTK data + `settings.conf` via subPath at `/root/rtkbase/settings.conf`), and systemd PID 1. NTRIP is exposed via LoadBalancer + external-dns; the web UI via Ingress + cert-manager (TLS only).
+Pod runs privileged on acebase with hostPath `/dev/gnss`, PVC `/persist/rtkbase` (RTK data + persisted `settings.conf`, bind-mounted into `/root/rtkbase/settings.conf` on boot), and systemd PID 1. NTRIP is exposed via LoadBalancer + external-dns; the web UI via Ingress + cert-manager (TLS only).
 
 ## Authentication
 

--- a/tanka/environments/ntrip/main.jsonnet
+++ b/tanka/environments/ntrip/main.jsonnet
@@ -69,13 +69,11 @@ local ntrip = {
     local persistPvcName = ntripObj.persistPvc.metadata.name,
     local settingsConfigMapName = ntripObj.settingsConfigMap.metadata.name,
     local settingsConfigMapHash = std.md5(importstr 'settings.conf'),
-    local settingsConfMount =
-      kVolumeMount.new(persistPvcName, '/root/rtkbase/settings.conf')
-      + kVolumeMount.withSubPath('settings.conf'),
 
     deployment:
       kDeployment.new(config.name, replicas=1, containers=[
         kContainer.new(config.name, config.image)
+        + kContainer.withImagePullPolicy('Always')
         + kContainer.withPortsMixin([
           config.webPort,
           kPort.newNamed(config.ntripPortNumber, config.ntripPortName),
@@ -90,8 +88,6 @@ local ntrip = {
         [std.format('%s-hash', settingsConfigMapName)]: settingsConfigMapHash,
       })
       + k_util.pvcVolumeMount(persistPvcName, '/persist/rtkbase')
-      + kDeployment.mapContainers(function(c)
-          c + kContainer.withVolumeMountsMixin([settingsConfMount]))
       + kDeployment.mixin.spec.template.spec.withVolumesMixin([
         kVolume.fromConfigMap(settingsConfigMapName, settingsConfigMapName),
       ])
@@ -101,6 +97,9 @@ local ntrip = {
         + kContainer.withArgsMixin([
           |||
             mkdir -p /persist/rtkbase/data
+            if [ -d /persist/rtkbase/settings.conf ]; then
+              rm -rf /persist/rtkbase/settings.conf
+            fi
             if [ ! -f /persist/rtkbase/settings.conf ]; then
               cp /seed/settings.conf /persist/rtkbase/settings.conf
             fi


### PR DESCRIPTION
## Summary

- **Problem:** PVC `subPath` mount of `settings.conf` at `/root/rtkbase/settings.conf` fails on acebase with `OCI runtime create failed: ... not a directory`. RTKBase hardcodes that path and cannot be reconfigured.
- **Fix:** Drop the subPath mount. Init container seeds `settings.conf` on the PVC from the ConfigMap (and removes a stale directory if a prior failed mount left one). `rtk-base-user-on-bootup` bind-mounts the PVC file over `/root/rtkbase/settings.conf` before starting str2str services.
- **Image workflow:** Set `imagePullPolicy: Always` on the rtkbase container so `ghcr.io/symmatree/tiles/rtkbase:main` picks up new builds from the **build-rtkbase** workflow without a follow-up sha-bump PR.

## Test plan

- [ ] Merge and sync ntrip Tanka env (Argo CD)
- [ ] Run **build-rtkbase** on `main` after merge
- [ ] If PVC has a bad `settings.conf` directory, delete it once: `kubectl -n ntrip exec deploy/rtkbase -- rm -rf /persist/rtkbase/settings.conf` then restart
- [ ] Confirm pod starts (no subPath mount error)
- [ ] Confirm bind mount: settings changes survive pod restart
- [ ] Push a new rtkbase image to `:main`, restart pod, confirm new image is pulled without editing Argo params


Made with [Cursor](https://cursor.com)