### PR TITLE
Add always-on MAVProxy ground hub for Rekon10

### DIFF
--- a/.github/workflows/build-mavproxy.yaml
+++ b/.github/workflows/build-mavproxy.yaml
@@ -1,0 +1,70 @@
+name: build-mavproxy
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 9 * * *
+jobs:
+  build-mavproxy:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    name: build-mavproxy
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/symmatree/tiles/mavproxy
+      IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      REGISTRY_USER: ${{ github.actor }}
+      REGISTRY_PASSWORD: ${{ github.token }}
+      MAVPROXY_VERSION: "1.8.74"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Docker Metadata
+        id: docker-metadata
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}
+          context: ./containers/mavproxy
+          containerfiles: |
+            ./containers/mavproxy/Dockerfile
+          build-args: |
+            MAVPROXY_VERSION=${{ env.MAVPROXY_VERSION }}
+          extra-args: |
+            --disable-compression=false
+            --cache-from=${{ env.IMAGE_NAME }}-cache
+            --cache-to=${{ env.IMAGE_NAME }}-cache
+
+      - name: Check images created
+        run: buildah images | grep '${{ env.IMAGE_NAME }}'
+
+      - name: Push To GHCR
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          extra-args: |
+            --disable-content-trust

--- a/charts/argocd-applications/templates/mavproxy-application.helm.yaml
+++ b/charts/argocd-applications/templates/mavproxy-application.helm.yaml
@@ -1,0 +1,1 @@
+../../../tanka/environments/mavproxy/application.helm.yaml

--- a/containers/mavproxy/Dockerfile
+++ b/containers/mavproxy/Dockerfile
@@ -1,0 +1,29 @@
+# Headless MAVProxy for Rekon10 ground proxy (NTRIP + ELRS UDP + TCP fan-out).
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        python3 \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG MAVPROXY_VERSION=1.8.74
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir --upgrade "pip" "setuptools<82" \
+    && /opt/venv/bin/pip install --no-cache-dir "MAVProxy==${MAVPROXY_VERSION}" future
+
+ENV PATH="/opt/venv/bin:${PATH}" \
+    MAVPROXY_LOG_DIR=/var/log/mavproxy \
+    MAVPROXY_STATE_DIR=/var/lib/mavproxy
+
+COPY run-mavproxy.sh /usr/bin/run-mavproxy
+RUN chmod +x /usr/bin/run-mavproxy
+
+WORKDIR /var/lib/mavproxy
+VOLUME ["/var/lib/mavproxy", "/var/log/mavproxy"]
+
+ENTRYPOINT ["run-mavproxy"]
+CMD []

--- a/containers/mavproxy/README.md
+++ b/containers/mavproxy/README.md
@@ -1,0 +1,32 @@
+# MAVProxy (headless)
+
+amd64 image for the Rekon10 always-on ground MAVLink proxy: ELRS UDP in, NTRIP corrections, TCP fan-out to Mission Planner.
+
+Headless `pip install MAVProxy` on Ubuntu 24.04 LTS (no GUI dependencies).
+
+Published to `ghcr.io/symmatree/tiles/mavproxy` by [`.github/workflows/build-mavproxy.yaml`](../../.github/workflows/build-mavproxy.yaml). Version pinned in that workflow and [`Dockerfile`](Dockerfile) (`MAVPROXY_VERSION`).
+
+## Local build
+
+```bash
+docker build -t mavproxy:local \
+  --build-arg MAVPROXY_VERSION=1.8.74 \
+  containers/mavproxy
+```
+
+## Local run (example)
+
+```bash
+docker run --rm -it --network host \
+  -e NTRIP_CASTER=ntrip.tiles.symmatree.com \
+  -e NTRIP_USERNAME=gps \
+  -e NTRIP_PASSWORD=gps \
+  mavproxy:local \
+  --master=udpin:0.0.0.0:14550 \
+  --out=tcpin:0.0.0.0:5760 \
+  --source-system=255 \
+  --source-component=190 \
+  --default-modules=ntrip
+```
+
+Deployed via [`tanka/environments/mavproxy/`](../../tanka/environments/mavproxy/).

--- a/containers/mavproxy/run-mavproxy.sh
+++ b/containers/mavproxy/run-mavproxy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_dir="${MAVPROXY_LOG_DIR:-/var/log/mavproxy}"
+state_dir="${MAVPROXY_STATE_DIR:-/var/lib/mavproxy}"
+mkdir -p "${log_dir}" "${state_dir}"
+
+if [[ -n ${NTRIP_CASTER:-} ]]; then
+	cat >"${state_dir}/mavinit.scr" <<EOF
+module load ntrip
+ntrip set caster ${NTRIP_CASTER}
+ntrip set port ${NTRIP_PORT:-2101}
+ntrip set mountpoint ${NTRIP_MOUNTPOINT:-ATTIC}
+ntrip set username ${NTRIP_USERNAME:?NTRIP_USERNAME required when NTRIP_CASTER is set}
+ntrip set password ${NTRIP_PASSWORD:?NTRIP_PASSWORD required when NTRIP_CASTER is set}
+ntrip set sendalllinks True
+ntrip start
+EOF
+fi
+
+session_name="$(date +%Y-%m-%d_%H-%M-%S)"
+log_file="${log_dir}/${session_name}-mavproxy.log"
+
+exec mavproxy.py \
+	--state-basedir="${state_dir}" \
+	--logfile="${log_file}" \
+	"$@"

--- a/tanka/environments/mavproxy/README.md
+++ b/tanka/environments/mavproxy/README.md
@@ -1,0 +1,36 @@
+# MAVProxy ground proxy (prod acebase)
+
+Always-on MAVLink hub on bare-metal node **acebase**: ELRS backpack UDP in, NTRIP RTCM to the drone, TCP out for Mission Planner.
+
+Prod only (`cluster_name: tiles`); co-located with [ntrip](../ntrip/README.md) on site LAN.
+
+## Endpoints
+
+| Service | Address | Notes |
+|---------|---------|-------|
+| MAVLink UDP (from Boxer backpack) | acebase host `:14550/udp` | `hostNetwork`; receives subnet broadcast |
+| Mission Planner TCP | `mavproxy.tiles.symmatree.com:5760` | LoadBalancer + external-dns |
+| NTRIP corrections source | `ntrip.tiles.symmatree.com:2101/ATTIC` | Same caster as [ntrip](../ntrip/README.md) |
+
+Both hostnames resolve to private **10.x** addresses on site LAN. Mission Planner: **TCP**, system ID **254**.
+
+## Architecture
+
+- **Image:** [`containers/mavproxy/`](../../../containers/mavproxy/)
+- **Build:** [`.github/workflows/build-mavproxy.yaml`](../../../.github/workflows/build-mavproxy.yaml)
+- **Tanka:** [`main.jsonnet`](main.jsonnet)
+- **Argo CD:** [`application.helm.yaml`](application.helm.yaml) (prod only)
+
+Pod uses **hostNetwork** on acebase so ELRS backpack UDP broadcast on `:14550` reaches the proxy. MAVProxy runs as GCS **sysid 255**; injects RTCM via the built-in `ntrip` module using credentials from the existing `{cluster}-ntrip-caster-auth` 1Password item.
+
+## Operator notes
+
+- Boxer backpack GCS target is learned from MAVLink heartbeats; no static destination in backpack UI.
+- Do not connect Mission Planner directly to the backpack while this proxy is running.
+- After first image build, Argo CD needs `ghcr.io/symmatree/tiles/mavproxy:main` available.
+
+## Dependencies
+
+- [external-dns](../../../charts/external-dns/README.md), [OnePassword operator](../../../charts/onepassword/README.md), [Cilium LB pool](../../../charts/cilium-config/)
+- [ntrip](../ntrip/README.md) caster on acebase
+- Acebase node on site LAN (same broadcast domain as `boxer-txbp`)

--- a/tanka/environments/mavproxy/application.helm.yaml
+++ b/tanka/environments/mavproxy/application.helm.yaml
@@ -1,0 +1,44 @@
+{{- if eq .Values.cluster_name "tiles" }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mavproxy
+spec:
+  project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+    path: tanka
+    plugin:
+      env:
+        - name: TK_ENV
+          value: mavproxy
+      parameters:
+        - name: cluster_name
+          string: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+        - name: vault_name
+          string: '{{ required ".Values.vault_name is required" .Values.vault_name }}'
+        - name: project_id
+          string: '{{ required ".Values.project_id is required" .Values.project_id }}'
+        - name: app_settings
+          map:
+            image: ghcr.io/symmatree/tiles/mavproxy:main
+            tcp_hostname: mavproxy.tiles.symmatree.com
+            ntrip_caster: ntrip.tiles.symmatree.com
+            ntrip_mountpoint: ATTIC
+            ntrip_caster_auth: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-ntrip-caster-auth'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mavproxy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/enforce: baseline
+        pod-security.kubernetes.io/warn: baseline
+{{- end }}

--- a/tanka/environments/mavproxy/main.jsonnet
+++ b/tanka/environments/mavproxy/main.jsonnet
@@ -1,0 +1,113 @@
+local k_util = import 'github.com/grafana/jsonnet-libs/ksonnet-util/util.libsonnet';
+local k = import 'k.libsonnet';
+local op = import 'op.libsonnet';
+
+local APP_VARS = std.parseJson(std.extVar('ARGOCD_APP_PARAMETERS'));
+local isString(v) = std.objectHas(v, 'string');
+local isMap(v) = std.objectHas(v, 'map');
+local APP = {
+  [v.name]: v.string
+  for v in std.filter(isString, APP_VARS)
+} + {
+  [v.name]: v.map
+  for v in std.filter(isMap, APP_VARS)
+};
+
+local mavproxy = {
+  local kDeployment = k.apps.v1.deployment,
+  local kContainer = k.core.v1.container,
+  local kPort = k.core.v1.containerPort,
+  local kEnvVar = k.core.v1.envVar,
+
+  local defaults = {
+    name: 'mavproxy',
+    image: APP.app_settings.image,
+    nodeHostname: 'acebase',
+    mavlinkUdpPort: 14550,
+    tcpPort: 5760,
+    tcpHostname: APP.app_settings.tcp_hostname,
+    ntripCaster: APP.app_settings.ntrip_caster,
+    ntripMountpoint: APP.app_settings.ntrip_mountpoint,
+    ntripPort: 2101,
+    ntripSecret: APP.app_settings.ntrip_caster_auth,
+    sourceSystem: 255,
+    sourceComponent: 190,
+  },
+
+  new(overrides):: {
+    local mavproxyObj = self,
+    local config = defaults + overrides,
+
+    ntripSecret: op.item.new(config.ntripSecret, 'vaults/' + APP.vault_name + '/items/' + config.ntripSecret),
+
+    local podLabels = { app: config.name },
+    local ntripSecretName = mavproxyObj.ntripSecret.metadata.name,
+
+    local tcpProbe(probe, port) =
+      probe.withInitialDelaySeconds(10)
+      + probe.withPeriodSeconds(10)
+      + probe.tcpSocket.withPort(port)
+      + probe.withSuccessThreshold(1),
+    local livenessProbe = kContainer.livenessProbe,
+    local readinessProbe = kContainer.readinessProbe,
+
+    deployment:
+      kDeployment.new(config.name, replicas=1, containers=[
+        kContainer.new(config.name, config.image)
+        + kContainer.withPortsMixin([
+          kPort.newNamedUDP(config.mavlinkUdpPort, 'mavlink-udp'),
+          kPort.newNamed(config.tcpPort, 'mavlink-tcp'),
+        ])
+        + kContainer.withEnvMixin([
+          kEnvVar.new('NTRIP_CASTER', config.ntripCaster),
+          kEnvVar.new('NTRIP_PORT', std.toString(config.ntripPort)),
+          kEnvVar.new('NTRIP_MOUNTPOINT', config.ntripMountpoint),
+          kEnvVar.fromSecretRef('NTRIP_USERNAME', ntripSecretName, 'username'),
+          kEnvVar.fromSecretRef('NTRIP_PASSWORD', ntripSecretName, 'password'),
+        ])
+        + kContainer.withArgs([
+          std.format('--master=udpin:0.0.0.0:%s', config.mavlinkUdpPort),
+          std.format('--out=tcpin:0.0.0.0:%s', config.tcpPort),
+          std.format('--source-system=%s', config.sourceSystem),
+          std.format('--source-component=%s', config.sourceComponent),
+          '--default-modules=ntrip',
+        ])
+        + tcpProbe(readinessProbe, config.tcpPort)
+        + readinessProbe.withFailureThreshold(3)
+        + tcpProbe(livenessProbe, config.tcpPort)
+        + livenessProbe.withInitialDelaySeconds(30)
+        + livenessProbe.withPeriodSeconds(30)
+        + livenessProbe.withFailureThreshold(6),
+      ], podLabels=podLabels)
+      + kDeployment.spec.selector.withMatchLabels(podLabels)
+      + kDeployment.spec.strategy.withType('Recreate')
+      + kDeployment.spec.template.spec.withHostNetwork(true)
+      + kDeployment.spec.template.spec.withDnsPolicy('ClusterFirstWithHostNet')
+      + kDeployment.spec.template.spec.withNodeSelector({ 'kubernetes.io/hostname': config.nodeHostname }),
+
+    tcpService: {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: 'mavproxy-tcp',
+        annotations: {
+          'external-dns.alpha.kubernetes.io/hostname': config.tcpHostname,
+        },
+        labels: podLabels,
+      },
+      spec: {
+        type: 'LoadBalancer',
+        externalTrafficPolicy: 'Local',
+        selector: podLabels,
+        ports: [{
+          name: 'mavlink-tcp',
+          port: config.tcpPort,
+          targetPort: config.tcpPort,
+          protocol: 'TCP',
+        }],
+      },
+    },
+  },
+};
+
+mavproxy.new({})

--- a/tanka/environments/mavproxy/spec.json
+++ b/tanka/environments/mavproxy/spec.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "environments/mavproxy"
+  },
+  "spec": {
+    "namespace": "mavproxy",
+    "resourceDefaults": {},
+    "expectVersions": {}
+  }
+}


### PR DESCRIPTION
## Summary

- Add headless MAVProxy container (Ubuntu 24.04, venv, MAVProxy 1.8.74) with NTRIP init script for ATTIC corrections
- Add `build-mavproxy` CI workflow publishing to `ghcr.io/symmatree/tiles/mavproxy`
- Deploy on acebase via Tanka/Argo: hostNetwork UDP 14550 (ELRS downlink), TCP LoadBalancer `mavproxy.tiles.symmatree.com:5760` (Mission Planner), sysid 255 for GCS failsafe heartbeats

## Test plan

- [ ] Merge and run `build-mavproxy` workflow (or wait for schedule) to publish `:main` image
- [ ] Argo sync `mavproxy` app on prod `tiles` cluster
- [ ] Confirm pod listens on acebase UDP 14550 and TCP 5760
- [ ] Connect Mission Planner via `tcp:mavproxy.tiles.symmatree.com:5760`
- [ ] Verify NTRIP RTCM flows with backpack MAVLink active


Made with [Cursor](https://cursor.com)