### PR TITLE
Fix mavproxy scheduling on acebase

### DIFF
--- a/tanka/environments/mavproxy/README.md
+++ b/tanka/environments/mavproxy/README.md
@@ -21,7 +21,7 @@ Both hostnames resolve to private **10.x** addresses on site LAN. Mission Planne
 - **Tanka:** [`main.jsonnet`](main.jsonnet)
 - **Argo CD:** [`application.helm.yaml`](application.helm.yaml) (prod only)
 
-Pod uses **hostNetwork** on acebase so ELRS backpack UDP broadcast on `:14550` reaches the proxy. MAVProxy runs as GCS **sysid 255**; injects RTCM via the built-in `ntrip` module using credentials from the existing `{cluster}-ntrip-caster-auth` 1Password item.
+Pod uses **hostNetwork** on acebase (privileged namespace, `dedicated=gnss` toleration) so ELRS backpack UDP broadcast on `:14550` reaches the proxy. MAVProxy runs as GCS **sysid 255**; injects RTCM via the built-in `ntrip` module using credentials from the existing `{cluster}-ntrip-caster-auth` 1Password item.
 
 ## Operator notes
 

--- a/tanka/environments/mavproxy/application.helm.yaml
+++ b/tanka/environments/mavproxy/application.helm.yaml
@@ -39,6 +39,6 @@ spec:
       - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
-        pod-security.kubernetes.io/enforce: baseline
-        pod-security.kubernetes.io/warn: baseline
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/warn: privileged
 {{- end }}

--- a/tanka/environments/mavproxy/main.jsonnet
+++ b/tanka/environments/mavproxy/main.jsonnet
@@ -19,6 +19,13 @@ local mavproxy = {
   local kPort = k.core.v1.containerPort,
   local kEnvVar = k.core.v1.envVar,
 
+  local gnssToleration = {
+    key: 'dedicated',
+    operator: 'Equal',
+    value: 'gnss',
+    effect: 'NoSchedule',
+  },
+
   local defaults = {
     name: 'mavproxy',
     image: APP.app_settings.image,
@@ -54,6 +61,7 @@ local mavproxy = {
     deployment:
       kDeployment.new(config.name, replicas=1, containers=[
         kContainer.new(config.name, config.image)
+        + kContainer.withImagePullPolicy('Always')
         + kContainer.withPortsMixin([
           kPort.newNamedUDP(config.mavlinkUdpPort, 'mavlink-udp'),
           kPort.newNamed(config.tcpPort, 'mavlink-tcp'),
@@ -83,7 +91,8 @@ local mavproxy = {
       + kDeployment.spec.strategy.withType('Recreate')
       + kDeployment.spec.template.spec.withHostNetwork(true)
       + kDeployment.spec.template.spec.withDnsPolicy('ClusterFirstWithHostNet')
-      + kDeployment.spec.template.spec.withNodeSelector({ 'kubernetes.io/hostname': config.nodeHostname }),
+      + kDeployment.spec.template.spec.withNodeSelector({ 'kubernetes.io/hostname': config.nodeHostname })
+      + kDeployment.spec.template.spec.withTolerationsMixin([gnssToleration]),
 
     tcpService: {
       apiVersion: 'v1',


### PR DESCRIPTION
## Summary

- Set `mavproxy` namespace PodSecurity to **privileged** (required for `hostNetwork` / host ports; matches [ntrip](../tanka/environments/ntrip/application.helm.yaml))
- Add **`dedicated=gnss:NoSchedule` toleration** so the pod can schedule on acebase (same taint ntrip uses)
- Set **`imagePullPolicy: Always`** for the `:main` tag (matches ntrip)

Prod symptom before this change: deployment stuck at 0/1 with `FailedCreate` -- PodSecurity baseline rejected `hostNetwork`; even after that fix the gnss taint would block scheduling.

## Test plan

- [ ] Merge and let Argo sync `mavproxy` on `tiles`
- [ ] Confirm namespace labels update to `pod-security.kubernetes.io/enforce: privileged`
- [ ] Confirm pod schedules on acebase and reaches Ready
- [ ] Confirm TCP LB `mavproxy.tiles.symmatree.com:5760` gets endpoints


Made with [Cursor](https://cursor.com)