### PR TITLE
Run MAVProxy in daemon mode on acebase

### DIFF
--- a/containers/mavproxy/README.md
+++ b/containers/mavproxy/README.md
@@ -26,7 +26,9 @@ docker run --rm -it --network host \
   --out=tcpin:0.0.0.0:5760 \
   --source-system=255 \
   --source-component=190 \
-  --default-modules=ntrip
+  --default-modules=ntrip \
+  --daemon \
+  --nowait
 ```
 
 Deployed via [`tanka/environments/mavproxy/`](../../tanka/environments/mavproxy/).

--- a/tanka/environments/mavproxy/README.md
+++ b/tanka/environments/mavproxy/README.md
@@ -21,7 +21,7 @@ Both hostnames resolve to private **10.x** addresses on site LAN. Mission Planne
 - **Tanka:** [`main.jsonnet`](main.jsonnet)
 - **Argo CD:** [`application.helm.yaml`](application.helm.yaml) (prod only)
 
-Pod uses **hostNetwork** on acebase (privileged namespace, `dedicated=gnss` toleration) so ELRS backpack UDP broadcast on `:14550` reaches the proxy. MAVProxy runs as GCS **sysid 255**; injects RTCM via the built-in `ntrip` module using credentials from the existing `{cluster}-ntrip-caster-auth` 1Password item.
+Pod uses **hostNetwork** on acebase (privileged namespace, `dedicated=gnss` toleration) so ELRS backpack UDP broadcast on `:14550` reaches the proxy. MAVProxy runs with **`--daemon`** (no interactive console; required in k8s) and **`--nowait`** (open TCP before the drone connects) as GCS **sysid 255**; injects RTCM via the built-in `ntrip` module using credentials from the existing `{cluster}-ntrip-caster-auth` 1Password item.
 
 ## Operator notes
 

--- a/tanka/environments/mavproxy/main.jsonnet
+++ b/tanka/environments/mavproxy/main.jsonnet
@@ -79,6 +79,8 @@ local mavproxy = {
           std.format('--source-system=%s', config.sourceSystem),
           std.format('--source-component=%s', config.sourceComponent),
           '--default-modules=ntrip',
+          '--daemon',
+          '--nowait',
         ])
         + tcpProbe(readinessProbe, config.tcpPort)
         + readinessProbe.withFailureThreshold(3)


### PR DESCRIPTION
## Summary

- Add `--daemon` so MAVProxy stays up in k8s (interactive mode exits on closed stdin)
- Add `--nowait` so `tcpin:5760` opens before a drone heartbeat (readiness/liveness + Mission Planner)

Prod symptom: pod CrashLoopBackOff with logs ending in `MAV>` then module unload (~1s).

## Test plan

- [ ] Merge and Argo sync `mavproxy` on `tiles`
- [ ] Pod reaches Ready without drone connected
- [ ] `mavproxy.tiles.symmatree.com:5760` accepts TCP
- [ ] MAVLink/RTCM flow once backpack is active


Made with [Cursor](https://cursor.com)