### PR TITLE
Remove mavproxy liveness probe

### DIFF
--- a/containers/mavproxy/README.md
+++ b/containers/mavproxy/README.md
@@ -2,7 +2,7 @@
 
 amd64 image for the Rekon10 always-on ground MAVLink proxy: ELRS UDP in, NTRIP corrections, TCP fan-out to Mission Planner.
 
-Headless `pip install MAVProxy` on Ubuntu 24.04 LTS (no GUI dependencies).
+Headless `pip install MAVProxy` on Ubuntu 24.04 LTS (no GUI dependencies). Entrypoint writes NTRIP startup commands to `$HOME/.mavproxy/mavinit.scr` (where MAVProxy looks for them).
 
 Published to `ghcr.io/symmatree/tiles/mavproxy` by [`.github/workflows/build-mavproxy.yaml`](../../.github/workflows/build-mavproxy.yaml). Version pinned in that workflow and [`Dockerfile`](Dockerfile) (`MAVPROXY_VERSION`).
 

--- a/containers/mavproxy/run-mavproxy.sh
+++ b/containers/mavproxy/run-mavproxy.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 
 log_dir="${MAVPROXY_LOG_DIR:-/var/log/mavproxy}"
 state_dir="${MAVPROXY_STATE_DIR:-/var/lib/mavproxy}"
-mkdir -p "${log_dir}" "${state_dir}"
+init_dir="${MAVPROXY_INIT_DIR:-${HOME}/.mavproxy}"
+mkdir -p "${log_dir}" "${state_dir}" "${init_dir}"
 
 if [[ -n ${NTRIP_CASTER:-} ]]; then
-	cat >"${state_dir}/mavinit.scr" <<EOF
+	cat >"${init_dir}/mavinit.scr" <<EOF
 module load ntrip
 ntrip set caster ${NTRIP_CASTER}
 ntrip set port ${NTRIP_PORT:-2101}

--- a/tanka/environments/mavproxy/README.md
+++ b/tanka/environments/mavproxy/README.md
@@ -21,7 +21,8 @@ Both hostnames resolve to private **10.x** addresses on site LAN. Mission Planne
 - **Tanka:** [`main.jsonnet`](main.jsonnet)
 - **Argo CD:** [`application.helm.yaml`](application.helm.yaml) (prod only)
 
-Pod uses **hostNetwork** on acebase (privileged namespace, `dedicated=gnss` toleration) so ELRS backpack UDP broadcast on `:14550` reaches the proxy. MAVProxy runs with **`--daemon`** (no interactive console; required in k8s) and **`--nowait`** (open TCP before the drone connects) as GCS **sysid 255**; injects RTCM via the built-in `ntrip` module using credentials from the existing `{cluster}-ntrip-caster-auth` 1Password item.
+Pod uses **hostNetwork** on acebase (privileged namespace, `dedicated=gnss` toleration) so ELRS backpack UDP broadcast on `:14550` reaches the proxy. MAVProxy runs with **`--daemon`** and **`--nowait`** as GCS **sysid 255**. NTRIP is configured via **`$HOME/.mavproxy/mavinit.scr`** written by the container entrypoint. No **liveness** probe -- k8s must not restart this hub. Readiness is **`kill -0 1`** only (never TCP `:5760`; `tcpin` accepts one Mission Planner client).
+
 
 ## Operator notes
 

--- a/tanka/environments/mavproxy/main.jsonnet
+++ b/tanka/environments/mavproxy/main.jsonnet
@@ -50,12 +50,12 @@ local mavproxy = {
     local podLabels = { app: config.name },
     local ntripSecretName = mavproxyObj.ntripSecret.metadata.name,
 
-    local tcpProbe(probe, port) =
+    local execProbe(probe) =
       probe.withInitialDelaySeconds(10)
       + probe.withPeriodSeconds(10)
-      + probe.tcpSocket.withPort(port)
-      + probe.withSuccessThreshold(1),
-    local livenessProbe = kContainer.livenessProbe,
+      + probe.withTimeoutSeconds(1)
+      + probe.withSuccessThreshold(1)
+      + probe.exec.withCommand(['/bin/sh', '-c', 'kill -0 1']),
     local readinessProbe = kContainer.readinessProbe,
 
     deployment:
@@ -82,12 +82,8 @@ local mavproxy = {
           '--daemon',
           '--nowait',
         ])
-        + tcpProbe(readinessProbe, config.tcpPort)
-        + readinessProbe.withFailureThreshold(3)
-        + tcpProbe(livenessProbe, config.tcpPort)
-        + livenessProbe.withInitialDelaySeconds(30)
-        + livenessProbe.withPeriodSeconds(30)
-        + livenessProbe.withFailureThreshold(6),
+        + execProbe(readinessProbe)
+        + readinessProbe.withFailureThreshold(3),
       ], podLabels=podLabels)
       + kDeployment.spec.selector.withMatchLabels(podLabels)
       + kDeployment.spec.strategy.withType('Recreate')


### PR DESCRIPTION
## Summary
- Drop liveness probe entirely (nothing good to check yet; was risking restarts)
- Readiness: exec kill -0 1 only -- never TCP :5760 (single tcpin client slot)
## Test plan
- [ ] Argo sync on tiles
- [ ] Pod stays up without drone connected
- [ ] Mission Planner can hold tcp :5760 exclusively