### PR TITLE
Lower Argo CD manifest cache TTL to 30m

### DIFF
--- a/charts/argocd/README.md
+++ b/charts/argocd/README.md
@@ -37,6 +37,7 @@ Configuration is managed through `values.yaml` and overridden via the Applicatio
 - **Cluster Name**: Passed as `cluster_name` value
 - **Vault Name**: Passed as `vault_name` value for 1Password integration
 - **Target Revision**: Git branch/tag to track (passed as `targetRevision`)
+- **Repo manifest cache TTL**: `reposerver.repo.cache.expiration` in `values.yaml` (30m). Tag-based deploy timing is documented in `docs/environment-strategy.md`.
 
 ### Environment-Specific Settings
 

--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -258,6 +258,7 @@ data:
   reposerver.log.format: text
   reposerver.log.level: trace
   reposerver.parallelism.limit: "4"
+  reposerver.repo.cache.expiration: 30m
   server.dex.server: https://argocd-dex-server:5556
   server.dex.server.strict.tls: "false"
   server.insecure: "true"
@@ -1183,7 +1184,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
+        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-applicationset-controller
@@ -1477,7 +1478,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
+        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -1936,7 +1937,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
+        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2399,7 +2400,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
+        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2643,7 +2644,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: 6b1cc450528c63af650e75033c05f55c3c9f6fe96faa13770f8646c109ac9b9a
+        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
         checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
       labels:
         helm.sh/chart: argo-cd-9.5.2

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -133,6 +133,11 @@ argo-cd:
       # is propagated as a context deadline through the repo-server into the
       # CMP-server gRPC call, so this also widens the cmp-server side window.
       controller.repo.server.timeout.seconds: "300"
+      # Manifest cache TTL (commit SHA -> generated manifests). Default 24h is too long for
+      # tag-based deploys and in-repo Helm when generation inputs change without a new
+      # chart version. Separate from timeout.reconciliation (revision/ref cache).
+      # https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/
+      reposerver.repo.cache.expiration: 30m
       # Diagnosing 30-60s MatchRepository / GenerateManifest stalls against the Tanka
       # CMP sidecar. At debug we observe the repo-server log going silent for ~48s
       # between accepting a CMP GenerateManifest and the deadline-driven failure --

--- a/docs/environment-strategy.md
+++ b/docs/environment-strategy.md
@@ -27,16 +27,19 @@ This document describes the strategy for managing two parallel Terraform environ
      - Update the `prod` tag to point to the current commit
      - Deploy to the production environment (Terraform apply)
 
-4. **ArgoCD Deployment**
-   - ArgoCD is configured to point at the `test` and `prod` Git tags
-   - When tags are updated, ArgoCD automatically syncs the changes to the clusters
-   - Test cluster tracks the `test` tag
-   - Production cluster tracks the `prod` tag
+4. **ArgoCD deployment**
+   - Child Applications track the `test` and `prod` Git tags with automated sync enabled (`syncPolicy.automated` on each Application).
+   - **Tag updates do not apply instantly.** ArgoCD reconciles on a timer and caches Git work in two layers ([Argo CD HA / performance docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/)):
+     - **Revision cache** (symbolic ref such as `prod` -> commit SHA): expiration matches `timeout.reconciliation` plus `timeout.reconciliation.jitter` in `argocd-cm` (see `charts/argocd/rendered.yaml`; currently 120s + up to 60s jitter per app).
+     - **Manifest cache** (commit SHA -> generated manifests, including Helm renders): `reposerver.repo.cache.expiration` in `charts/argocd/values.yaml` (set to **30m**; upstream default is **24h**, which is a poor fit for tag-based deploys and in-repo Helm).
+   - After moving `test` or `prod`, expect child apps to go OutOfSync and auto-sync within a few minutes in the normal case. If nothing moves, use **Refresh** in the Argo CD UI (ordinary refresh is enough; Hard Refresh is not required) or sync the Application manually.
+   - **Git webhooks** to Argo CD are the recommended way to avoid polling and cache latency at scale; not configured on these clusters yet.
+   - Test cluster tracks the `test` tag; production tracks the `prod` tag.
 
 **Workflow Summary:**
 
 ```text
-PR → main → auto-deploy to test (test tag) → manual deploy to prod (prod tag) → ArgoCD syncs
+PR -> main -> auto-deploy to test (test tag) -> manual deploy to prod (prod tag) -> Argo CD picks up tag within reconcile/cache bounds (minutes, not instant)
 ```
 
 ## Current State
@@ -61,7 +64,7 @@ The repository currently implements:
 1. **Parallel Environments**: Test and production are managed as separate Terraform workspaces
 2. **Shared Bootstrap**: The bootstrap Terraform (`tf/bootstrap`) remains shared since it initializes resources for both environments
 3. **Side-by-Side Configuration**: Both environment configurations live in the same source tree for easy diffing in PRs
-4. **Tag-Based Deployment**: Git tags (`test` and `prod`) track what's deployed and trigger redeployments
+4. **Tag-Based Deployment**: Git tags (`test` and `prod`) track what's deployed; Argo CD child Applications follow those tags with automated sync, subject to reconcile interval and repo-server cache TTL (see procedures above)
 5. **Promotion Workflow**: Production deployments can be promoted from test-tagged commits or deployed directly
 6. **Shared Code, Different Variables**: Most differences between environments are represented as different `.tfvars` files
 


### PR DESCRIPTION
## Summary
- Set `reposerver.repo.cache.expiration` to 30m in `charts/argocd/values.yaml` (upstream default is 24h).
- Document how Argo CD actually picks up moved `test`/`prod` tags: revision cache (`timeout.reconciliation` + jitter) vs manifest cache, expected delay of minutes not instant, and that ordinary UI Refresh is sufficient when stuck.
- Note webhooks as the recommended long-term fix; not configured yet.

## Test plan
- [ ] Merge and move `prod` tag (or sync `argocd` Application on tiles after deploy)
- [ ] Confirm `argocd-cmd-params-cm` has `reposerver.repo.cache.expiration: 30m` and repo-server pod rolled
- [ ] After next tag bump, verify child apps go OutOfSync within a few minutes without manual refresh