### PR TITLE
Tune NTRIP seed config for ELRS rover link

### DIFF
--- a/tanka/environments/ntrip/settings.conf
+++ b/tanka/environments/ntrip/settings.conf
@@ -45,7 +45,7 @@ svr_port_a='2101'
 svr_pwd_a=''
 mnt_name_a='Your_mount_name'
 rtcm_msg_a='1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230'
-ntrip_a_receiver_options=''
+ntrip_a_receiver_options='-TADJ=1'
 
 [ntrip_B]
 svr_addr_b='caster.centipede.fr'
@@ -53,20 +53,20 @@ svr_port_b='2101'
 svr_pwd_b=''
 mnt_name_b='Your_mount_name'
 rtcm_msg_b='1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230'
-ntrip_b_receiver_options=''
+ntrip_b_receiver_options='-TADJ=1'
 
 [local_ntrip_caster]
 local_ntripc_user='gps'
 local_ntripc_pwd='gps'
 local_ntripc_port='2101'
 local_ntripc_mnt_name='ATTIC'
-local_ntripc_msg='1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230'
-local_ntripc_receiver_options=''
+local_ntripc_msg='1005(10),1074,1084,1094,1124,1230(10)'
+local_ntripc_receiver_options='-TADJ=1'
 
 [rtcm_svr]
 rtcm_svr_port='5016'
 rtcm_svr_msg='1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230'
-rtcm_receiver_options=''
+rtcm_receiver_options='-TADJ=1'
 
 [rtcm_client]
 rtcm_client_addr=''
@@ -74,24 +74,24 @@ rtcm_client_port='80'
 rtcm_client_user=''
 rtcm_client_pwd=''
 rtcm_client_msg='1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230'
-rtcm_client_receiver_options=''
+rtcm_client_receiver_options='-TADJ=1'
 
 [rtcm_udp_svr]
 rtcm_udp_svr_port=''
 rtcm_udp_svr_msg='1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230'
-rtcm_udp_svr_receiver_options=''
+rtcm_udp_svr_receiver_options='-TADJ=1'
 
 [rtcm_udp_client]
 rtcm_udp_client_addr=''
 rtcm_udp_client_port=''
 rtcm_udp_client_msg='1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230'
-rtcm_udp_client_receiver_options=''
+rtcm_udp_client_receiver_options='-TADJ=1'
 
 [rtcm_serial]
 out_com_port=''
 out_com_port_settings='115200:8:n:1'
 rtcm_serial_msg='1004,1005(10),1006,1008(10),1012,1019,1020,1033(10),1042,1045,1046,1077,1087,1097,1107,1127,1230'
-rtcm_serial_receiver_options=''
+rtcm_serial_receiver_options='-TADJ=1'
 
 [log]
 logdir='/root/rtkbase/logs'


### PR DESCRIPTION
## Summary
- Trim `local_ntrip_caster` RTCM seed messages to MSM4-only set (`1005(10),1074,1084,1094,1124,1230(10)`) sized for the ELRS telemetry budget and u-blox F9P guidance (no legacy + MSM7 mix).
- Add `-TADJ=1` to all str2str `*_receiver_options` fields for u-blox UBX-to-RTCM timestamp alignment.

## Test plan
- [ ] Confirm live `/persist/rtkbase/settings.conf` on acebase already has the trimmed message set from the UI (seed does not overwrite existing PVC file).
- [ ] After merge, verify new installs seed with the updated `settings.conf`.
- [ ] Field check: rover reaches RTK Fixed with ATTIC mount over ELRS path.