### PR TITLE
Fix hub secret formats: hex for cookie_secret, Fernet for CryptKeeper.keys

### DIFF
--- a/containers/datascience-notebook-ssh/install-tools.ansible.yaml
+++ b/containers/datascience-notebook-ssh/install-tools.ansible.yaml
@@ -291,6 +291,8 @@
           - papermill
           # Ardupilot .bin log parsing for flight analysis notebooks.
           - pymavlink
+          # Kubernetes Python client for cluster health notebooks.
+          - kubernetes
         executable: /opt/conda/bin/pip
         state: present
 

--- a/containers/datascience-notebook-ssh/install-tools.ansible.yaml
+++ b/containers/datascience-notebook-ssh/install-tools.ansible.yaml
@@ -284,6 +284,16 @@
         create: yes
         state: present
 
+    - name: Install notebook analysis Python packages
+      pip:
+        name:
+          # Offline notebook execution and parameter injection.
+          - papermill
+          # Ardupilot .bin log parsing for flight analysis notebooks.
+          - pymavlink
+        executable: /opt/conda/bin/pip
+        state: present
+
     - name: Install Homebrew packages
       become: false
       community.general.homebrew:

--- a/containers/datascience-notebook-ssh/install-tools.ansible.yaml
+++ b/containers/datascience-notebook-ssh/install-tools.ansible.yaml
@@ -2,13 +2,25 @@
 - name: Install GitHub CLI and Linux Homebrew
   hosts: all
   become: yes
+  vars:
+    golang_version: "1.26.4"
+    kubernetes_minor: "v1.32"
+    dist_upgrade: false
   tasks:
     - name: Capture dpkg architecture
       command: dpkg --print-architecture
       register: dpkg_arch
       changed_when: false
+      tags: [nodesource]
     - set_fact:
         dpkg_arch: "{{ dpkg_arch.stdout }}"
+      tags: [nodesource]
+    - name: Capture Ubuntu codename
+      command: lsb_release -cs
+      register: ubuntu_codename
+      changed_when: false
+    - set_fact:
+        ubuntu_codename: "{{ ubuntu_codename.stdout }}"
     - name: Install initial packages
       apt:
         name:
@@ -29,8 +41,8 @@
     - name: Kubernetes repository
       deb822_repository:
         name: kubernetes
-        uris: https://pkgs.k8s.io/core:/stable:/v1.32/deb/
-        signed_by: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
+        uris: "https://pkgs.k8s.io/core:/stable:/{{ kubernetes_minor }}/deb/"
+        signed_by: "https://pkgs.k8s.io/core:/stable:/{{ kubernetes_minor }}/deb/Release.key"
         suites:
           - /
         state: present
@@ -59,7 +71,7 @@
         enabled: true
     - name: GitHub CLI repository
       deb822_repository:
-        name: github-cli
+        name: githubcli-archive-keyring
         uris: https://cli.github.com/packages
         signed_by: https://cli.github.com/packages/githubcli-archive-keyring.gpg
         suites:
@@ -68,6 +80,109 @@
           - main
         state: present
         enabled: true
+    - name: HashiCorp repository
+      deb822_repository:
+        name: hashicorp
+        uris: https://apt.releases.hashicorp.com
+        signed_by: https://apt.releases.hashicorp.com/gpg
+        suites:
+          - "{{ ubuntu_codename }}"
+        components:
+          - main
+        state: present
+        enabled: true
+    - name: Grafana APT repository (e.g. mimirtool binary packages)
+      deb822_repository:
+        name: grafana
+        uris:
+          - https://apt.grafana.com
+        signed_by: https://apt.grafana.com/gpg.key
+        suites:
+          - stable
+        components:
+          - main
+        state: present
+        enabled: true
+    - name: Docker Engine repository
+      deb822_repository:
+        name: docker
+        uris: https://download.docker.com/linux/ubuntu
+        signed_by: https://download.docker.com/linux/ubuntu/gpg
+        suites:
+          - "{{ ubuntu_codename }}"
+        components:
+          - stable
+        architectures:
+          - "{{ dpkg_arch }}"
+        state: present
+        enabled: true
+    # - name: Helm APT repository (community Debian packages hosted on Buildkite)
+    #   deb822_repository:
+    #     name: helm
+    #     uris:
+    #       - https://packages.buildkite.com/helm-linux/helm-debian/any/
+    #     signed_by: https://packages.buildkite.com/helm-linux/helm-debian/gpgkey
+    #     suites:
+    #       - any
+    #     components:
+    #       - main
+    #     state: present
+    #     enabled: true
+    - name: Remove legacy NodeSource one-line APT list if present
+      file:
+        path: /etc/apt/sources.list.d/nodesource.list
+        state: absent
+    - name: NodeSource repository (Node.js LTS deb822 .sources)
+      deb822_repository:
+        name: nodesource
+        uris:
+          - https://deb.nodesource.com/node_22.x
+        signed_by: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+        suites:
+          - nodistro
+        components:
+          - main
+        architectures:
+          - "{{ dpkg_arch }}"
+        state: present
+        enabled: true
+      when: dpkg_arch in ['amd64', 'arm64']
+    - name: Prefer NodeSource nodejs over distro packages
+      copy:
+        dest: /etc/apt/preferences.d/nodejs
+        mode: "0644"
+        content: |
+          Package: nodejs
+          Pin: origin deb.nodesource.com
+          Pin-Priority: 600
+      when: dpkg_arch in ['amd64', 'arm64']
+    - name: VS Code repository
+      deb822_repository:
+        name: vscode
+        uris: https://packages.microsoft.com/repos/code
+        signed_by: https://packages.microsoft.com/keys/microsoft.asc
+        suites:
+          - stable
+        components:
+          - main
+        architectures:
+          - "{{ dpkg_arch }}"
+        state: present
+        enabled: true
+
+    - name: Claude Code APT repository
+      deb822_repository:
+        name: claude-code
+        uris:
+          - https://downloads.claude.ai/claude-code/apt/stable
+        signed_by: https://downloads.claude.ai/keys/claude-code.asc
+        suites:
+          - stable
+        components:
+          - main
+        state: present
+        enabled: true
+
     - name: Install software
       apt:
         name:
@@ -77,24 +192,41 @@
           - apt-transport-https
           - apt-utils
           - aspell
+          - binfmt-support
           - bsdmainutils
           - buildah
           - ca-certificates
+          - claude-code
+          - code
+          - containerd.io
           - dialog
           - dnsutils
+          - docker-buildx-plugin
+          - docker-ce
+          - docker-ce-cli
+          - docker-compose-plugin
           - file
           - gh
           - git
           - google-cloud-cli
+          # - helm
           - htop
           - jq
           - kubectl
+          - kubectx
           # vscode wants libasound2 but that is a virtual package.
           - libasound2t64
+          - mimirtool
+          - nodejs
+          - pandoc
           - procps
+          - pre-commit
+          - qemu-user-static
+          - rclone
           - shellcheck
           - stow
           - sudo
+          - terraform
           - tmux
           - tree
           - xdg-utils
@@ -105,6 +237,35 @@
         state: present
         # No cache_valid_time since we just changed the repos.
         update_cache: yes
+
+    - name: Enable and start Docker Engine
+      systemd:
+        name: docker
+        enabled: true
+        state: started
+    - name: Ensure docker group exists
+      group:
+        name: docker
+        state: present
+    - name: Add Ansible connection user to docker group
+      user:
+        name: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"
+        groups: docker
+        append: true
+
+    - name: Check installed Go version
+      command: /usr/local/go/bin/go version
+      register: go_installed
+      changed_when: false
+      failed_when: false
+    - name: Install Go {{ golang_version }}
+      shell: |
+        curl -LO "https://go.dev/dl/go{{ golang_version }}.linux-{{ dpkg_arch }}.tar.gz"
+        rm -rf /usr/local/go
+        tar -C /usr/local -xzf go{{ golang_version }}.linux-{{ dpkg_arch }}.tar.gz
+        rm go{{ golang_version }}.linux-{{ dpkg_arch }}.tar.gz
+      when: "'go' + golang_version not in go_installed.stdout"
+
     - name: Check if Homebrew is already installed
       stat:
         path: /home/linuxbrew/.linuxbrew/bin/brew
@@ -122,48 +283,18 @@
         line: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         create: yes
         state: present
-    - name: Install golang 1.24.1
-      shell: |
-        curl -LO "https://go.dev/dl/go1.24.1.linux-{{ dpkg_arch }}.tar.gz"
-        tar -C /usr/local -xzf go1.24.1.linux-{{ dpkg_arch }}.tar.gz
-        rm go1.24.1.linux-{{ dpkg_arch }}.tar.gz
-      args:
-        creates: /usr/local/go/bin/go
+
     - name: Install Homebrew packages
       become: false
       community.general.homebrew:
+        # No first-party DEB822/repo for these: use brew, or swap to pinned release tarballs / go install later.
         name:
           - argocd
-          - helm
+          - cilium-cli
           - go-jsonnet
           - jsonnet-bundler
-          - kubectx
           - talosctl
           - tanka
-          - mimirtool
-          # - minio/stable/mc
-          - cilium-cli
-          - yq
         state: present
-        # update_homebrew: true
-        # upgrade_all: true
-    - name: Check if VSCode is already installed
-      stat:
-        path: /usr/bin/code
-      register: code_stat
-    - name: Install vscode
-      when: not code_stat.stat.exists
-      block:
-        - name: Add Microsoft repository
-          shell: |
-            echo "code code/add-microsoft-repo boolean true" | sudo debconf-set-selections
-          changed_when: false
-        - name: Install packages
-          apt:
-            deb: https://go.microsoft.com/fwlink/?LinkID=760868
-            state: present
-    - name: Install pip modules
-      pip:
-        name:
-          - pre-commit
-        state: present
+        update_homebrew: true
+        upgrade_all: true

--- a/tf/modules/k8s-cluster/k8s-jupyterhub.tf
+++ b/tf/modules/k8s-cluster/k8s-jupyterhub.tf
@@ -7,14 +7,16 @@
 # proxy.secretToken (auth_token) is left to chart auto-generation; it is
 # stable across upgrades via lookup() and cannot be overridden via existingSecret.
 
-resource "random_password" "jupyterhub_cookie_secret" {
-  length  = 64
-  special = false
+# cookie_secret: JupyterHub parses this as hex and decodes to 32 bytes → must
+# be 64 lowercase hex characters. random_id.hex gives exactly that.
+resource "random_id" "jupyterhub_cookie_secret" {
+  byte_length = 32
 }
 
-resource "random_password" "jupyterhub_crypt_key" {
-  length  = 64
-  special = false
+# CryptKeeper.keys: Fernet key format — 32 random bytes, URL-safe base64 with
+# padding. random_id.b64_url is 43 chars (no padding); 32 bytes needs one '='.
+resource "random_id" "jupyterhub_crypt_key" {
+  byte_length = 32
 }
 
 resource "onepassword_item" "jupyterhub_hub_credentials" {
@@ -26,12 +28,12 @@ resource "onepassword_item" "jupyterhub_hub_credentials" {
     label = "credentials"
     field {
       label = "hub.config.JupyterHub.cookie_secret"
-      value = random_password.jupyterhub_cookie_secret.result
+      value = random_id.jupyterhub_cookie_secret.hex
       type  = "CONCEALED"
     }
     field {
       label = "hub.config.CryptKeeper.keys"
-      value = random_password.jupyterhub_crypt_key.result
+      value = "${random_id.jupyterhub_crypt_key.b64_url}="
       type  = "CONCEALED"
     }
   }


### PR DESCRIPTION
## Problem

Hub pod crashes on startup:

```
ValueError: cookie_secret set as a string must contain an even amount of hexadecimal characters.
```

`random_password` with `special = false` generates alphanumeric chars (a-z, A-Z, 0-9), which includes non-hex characters (g-z, G-Z). JupyterHub requires `cookie_secret` to be a valid hex string that decodes to exactly 32 bytes.

## Fix

Switch both resources from `random_password` to `random_id`:

- **`cookie_secret`**: `random_id` with `byte_length = 32`, output as `.hex` → 64 lowercase hex characters, decodes to exactly 32 bytes ✓  
- **`CryptKeeper.keys`**: `random_id` with `byte_length = 32`, output as `.b64_url + "="` → valid Fernet key (URL-safe base64, 32 bytes, with correct `=` padding) ✓

## Deploy

Merging triggers `nodes-plan-apply` which destroys the old `random_password` resources, generates new `random_id` values, and updates the `{cluster_name}-jupyterhub-hub-credentials` items in 1Password. The 1Password operator will then reconcile `hub-credentials` and the hub pod will restart with the correct secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018deAzF1pCufrv8m1ixQZMS