### PR TITLE
Switch repos from squash merge to rebase merge

### DIFF
--- a/tf/bootstrap/github.tf
+++ b/tf/bootstrap/github.tf
@@ -25,8 +25,8 @@ resource "github_repository" "tiles" {
   has_projects           = false
   allow_merge_commit     = false
   allow_auto_merge       = true
-  allow_rebase_merge     = false
-  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  allow_squash_merge     = false
   delete_branch_on_merge = true
   vulnerability_alerts   = true
   allow_update_branch    = true
@@ -117,8 +117,8 @@ resource "github_repository" "polisher" {
   has_projects           = false
   allow_merge_commit     = false
   allow_auto_merge       = true
-  allow_rebase_merge     = false
-  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  allow_squash_merge     = false
   delete_branch_on_merge = true
   vulnerability_alerts   = true
   allow_update_branch    = true
@@ -210,8 +210,8 @@ resource "github_repository" "fables" {
   has_projects           = false
   allow_merge_commit     = false
   allow_auto_merge       = true
-  allow_rebase_merge     = false
-  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  allow_squash_merge     = false
   delete_branch_on_merge = true
   vulnerability_alerts   = true
   allow_update_branch    = true


### PR DESCRIPTION
## Summary

- Enable `allow_rebase_merge = true` and disable `allow_squash_merge = false` for all three repos (tiles, polisher, fables)

## Motivation

Squash merging causes conflicts when agents re-use an existing branch: the squashed commit on main has a different SHA than the original commits on the branch, so everything conflicts. Rebase merge preserves individual commit history and avoids this problem entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)