### PR TITLE
Fix ansible_user undefined with local connection

### DIFF
--- a/containers/datascience-notebook-ssh/install-tools.ansible.yaml
+++ b/containers/datascience-notebook-ssh/install-tools.ansible.yaml
@@ -244,7 +244,7 @@
         state: present
     - name: Add Ansible connection user to docker group
       user:
-        name: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"
+        name: "{{ ansible_env.SUDO_USER | default(ansible_user_id) }}"
         groups: docker
         append: true
 


### PR DESCRIPTION
`ansible_user` is only populated for SSH connections; with `--connection=local` (used during container builds) it is undefined. `ansible_user_id` reflects the actual running user in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018deAzF1pCufrv8m1ixQZMS