### PR TITLE
Allow privileged pods in jupyterhub namespace

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -691,7 +691,8 @@ spec:
       - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
-        pod-security.kubernetes.io/warn: baseline
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/warn: privileged
 ---
 # Source: argocd-applications/templates/kubernetes-mixin-application.yaml
 apiVersion: argoproj.io/v1alpha1

--- a/charts/jupyterhub/application.yaml
+++ b/charts/jupyterhub/application.yaml
@@ -41,4 +41,5 @@ spec:
       - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
+        pod-security.kubernetes.io/enforce: privileged
         pod-security.kubernetes.io/warn: baseline

--- a/charts/jupyterhub/application.yaml
+++ b/charts/jupyterhub/application.yaml
@@ -42,4 +42,4 @@ spec:
     managedNamespaceMetadata:
       labels:
         pod-security.kubernetes.io/enforce: privileged
-        pod-security.kubernetes.io/warn: baseline
+        pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Singleuser pod launch was failing with:

```
violates PodSecurity "baseline:latest": non-default capabilities (container "notebook" must not include "DAC_READ_SEARCH", "SYS_ADMIN"), privileged must not be true
```

The cluster enforces `baseline` by default at the apiserver level. The jupyterhub namespace needs `enforce: privileged` so the singleuser pod can use `SYS_ADMIN` + `DAC_READ_SEARCH` + `privileged` (required for bind mounts and FUSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018deAzF1pCufrv8m1ixQZMS