### PR TITLE
Raise VM disk default 32GB -> 100GB

### DIFF
--- a/tf/modules/talos-vm/variables.tf
+++ b/tf/modules/talos-vm/variables.tf
@@ -39,7 +39,12 @@ variable "ram_mb" {
 variable "disk_size_gb" {
   description = "Disk size in GB for the VM"
   type        = number
-  default     = 32
+  # 100GB: the datascience-notebook-ssh image is ~4GB compressed / ~12GB
+  # unpacked, and pullPolicy: Always briefly holds two copies during an edge
+  # re-pull. 32GB drove the node into kubelet disk-pressure eviction mid-pull.
+  # local-lvm is thin-provisioned so the nominal size only consumes real blocks
+  # as written; 2 VMs/node at 100GB stays well under the per-node pool.
+  default = 100
 }
 
 variable "mac_address" {


### PR DESCRIPTION
## Why

The `datascience-notebook-ssh` image is ~4GB compressed (45 layers, one 2GB zstd layer) / ~12GB unpacked. With `pullPolicy: Always` on the floating `edge` tag, a spawn briefly holds two copies during re-pull.

At the 32GB default, the singleuser spawn drove `tiles-wk-2` into kubelet **disk-pressure eviction mid-pull** — the partially-extracted image was repeatedly evicted and re-pulled, turning a ~1-minute download into a 15-minute thrash loop. Eviction-event deltas showed ~15GB consumed transiently on top of a ~12GB baseline, against only 30GB total.

(A brief CPU thermal-throttle burst on the host at the start of the pull was a secondary contributor, but the eviction loop was the dominant cause.)

## Sizing

- 100GB covers: ~12GB baseline + ~12GB resident image + ~12GB re-pull overlap + eviction headroom + room for local PVCs/scratch.
- `local-lvm` is thin-provisioned (`raw`), so the larger nominal only consumes real blocks as written. 2 VMs/node at 100GB nominal (200GB) stays well under the per-node pool (~400GB-class).
- Changed the **shared default** rather than a prod-only override, keeping all nodes uniform.

## Apply note

Growing `disk_size_gb` resizes the LV in place; Talos auto-expands the EPHEMERAL partition on boot. No VM recreation expected, but worth watching the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018deAzF1pCufrv8m1ixQZMS