### PR TITLE
[superseded] Add external-dns annotation to ArgoCD ingress

### DIFF
--- a/charts/argocd/application.yaml
+++ b/charts/argocd/application.yaml
@@ -21,6 +21,9 @@ spec:
             global:
               domain: 'argocd.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
             server:
+              ingress:
+                annotations:
+                  external-dns.alpha.kubernetes.io/hostname: 'argocd.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
               ingressGrpc:
                 hostname: 'grpc-argocd.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
     - repoURL: https://github.com/symmatree/tiles.git


### PR DESCRIPTION
## What

Adds `external-dns.alpha.kubernetes.io/hostname` to the ArgoCD server Ingress so Cloud DNS creates an A record for `argocd.{cluster}.symmatree.com` pointing at the Cilium ingress controller's L2-announced LoadBalancer IP.

## Why no oauth2-proxy

ArgoCD already has Dex configured with Google OIDC (`dex.config` in `configs.cm` → `google-oauth-secret`). Dex IS the through-proxy auth layer: unauthenticated requests are redirected to Google before ArgoCD touches them. Adding oauth2-proxy in front would:
- Break `argocd login --sso` (CLI can't drive oauth2-proxy's browser redirect flow)
- Create double-auth friction (oauth2-proxy cookie + Dex/ArgoCD session)

The annotation is placed in `application.yaml`'s `valuesObject` (not `values.yaml`) because it needs the templated cluster name, matching the pattern already used for `global.domain` and `ingressGrpc.hostname`.

## What's still needed (out of band)

- **UniFi port forward**: 443 → Cilium ingress controller LoadBalancer IP (one-time, covers all services on this ingress)
- **rendered.yaml**: needs `helm template` regeneration after merge

## Test plan

- [ ] After merge + ArgoCD sync, confirm `kubectl get ingress -n argocd` shows the annotation
- [ ] Confirm external-dns logs show DNS record creation for `argocd.{cluster}.symmatree.com`
- [ ] Confirm `https://argocd.{cluster}.symmatree.com` redirects to Google login from outside VPN
- [ ] Confirm `argocd login argocd.{cluster}.symmatree.com --sso` works from outside VPN