### PR TITLE
Add oauth2-proxy in front of ArgoCD for public access

### DIFF
--- a/charts/argocd-applications/application.yaml.tmpl
+++ b/charts/argocd-applications/application.yaml.tmpl
@@ -18,6 +18,7 @@ spec:
         pod_cidr: "${pod_cidr}"
         cluster_name: "${cluster_name}"
         external_ip_cidr: "${external_ip_cidr}"
+        ingress_lb_ip: "${ingress_lb_ip}"
         vault_name: "${vault_name}"
         project_id: "${project_id}"
         seed_project_id: "${seed_project_id}"

--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -466,6 +466,7 @@ spec:
       # Inject values from Terraform or that vary by environment.
       valuesObject:
         external_ip_cidr: 'placeholder'
+        ingress_lb_ip: 'placeholder'
         targetRevision: 'placeholder'
   destination:
     server: https://kubernetes.default.svc

--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -232,6 +232,14 @@ spec:
             server:
               ingressGrpc:
                 hostname: 'grpc-argocd.placeholder.symmatree.com'
+          oauth2-proxy:
+            ingress:
+              hosts:
+                - 'argocd.placeholder.symmatree.com'
+              tls:
+                - secretName: argocd-proxy-tls
+                  hosts:
+                    - 'argocd.placeholder.symmatree.com'
     - repoURL: https://github.com/symmatree/tiles.git
       targetRevision: 'placeholder'
       ref: values

--- a/charts/argocd/Chart.lock
+++ b/charts/argocd/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
   version: 9.5.2
-digest: sha256:5d9e6405ee944bf94df6af247164ebb9b8899144853b9a7eafabe8606affe84e
-generated: "2026-04-18T19:57:25.776560347-04:00"
+- name: oauth2-proxy
+  repository: https://oauth2-proxy.github.io/manifests
+  version: 7.7.0
+digest: sha256:e0882b235e40c62c8cd3b3b118b341dae39ecfef05c92f8803ef0fc15cb43024
+generated: "2026-07-07T18:14:00.877103235Z"

--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -19,3 +19,6 @@ dependencies:
   - name: argo-cd
     version: 9.5.2
     repository: https://argoproj.github.io/argo-helm
+  - name: oauth2-proxy
+    version: 7.7.0
+    repository: https://oauth2-proxy.github.io/manifests

--- a/charts/argocd/application.yaml
+++ b/charts/argocd/application.yaml
@@ -23,6 +23,14 @@ spec:
             server:
               ingressGrpc:
                 hostname: 'grpc-argocd.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
+          oauth2-proxy:
+            ingress:
+              hosts:
+                - 'argocd.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
+              tls:
+                - secretName: argocd-proxy-tls
+                  hosts:
+                    - 'argocd.{{ required ".Values.cluster_name is required" .Values.cluster_name }}.symmatree.com'
     - repoURL: https://github.com/symmatree/tiles.git
       targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
       ref: values

--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -3277,7 +3277,6 @@ metadata:
   namespace: argocd
   annotations:
     cert-manager.io/cluster-issuer: real-cert
-    external-dns.alpha.kubernetes.io/target: lhitw.symmatree.com
     ingress.cilium.io/loadbalancer-mode: shared
 spec:
   ingressClassName: "cilium"

--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -79,6 +79,23 @@ metadata:
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/version: "v3.3.7"
 ---
+# Source: argocd/charts/oauth2-proxy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/version: "7.6.0"
+  name: argocd-oauth2-proxy
+  namespace: argocd
+automountServiceAccountToken: true
+---
 # Source: argocd/charts/argo-cd/templates/argocd-configs/argocd-secret.yaml
 apiVersion: v1
 kind: Secret
@@ -94,6 +111,27 @@ metadata:
     app.kubernetes.io/part-of: argocd
     app.kubernetes.io/version: "v3.3.7"
 type: Opaque
+---
+# Source: argocd/charts/oauth2-proxy/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/version: "7.6.0"
+  name: argocd-oauth2-proxy
+  namespace: argocd
+type: Opaque
+data:
+  cookie-secret: "WFhYWFhYWFhYWFhYWFhYWA=="
+  client-secret: "WFhYWFhYWFg="
+  client-id: "WFhYWFhYWA=="
 ---
 # Source: argocd/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
 apiVersion: v1
@@ -385,6 +423,42 @@ data:
       exit 1
     fi
     echo "response=$response"
+---
+# Source: argocd/charts/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/version: "7.6.0"
+  name: argocd-oauth2-proxy-accesslist
+  namespace: argocd
+data:
+  restricted_user_access: "seth.porter@gmail.com\n"
+---
+# Source: argocd/charts/oauth2-proxy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/version: "7.6.0"
+  name: argocd-oauth2-proxy
+  namespace: argocd
+data:
+  oauth2_proxy.cfg: "email_domains = [ \"*\" ]\nupstreams = [ \"file:///dev/null\" ]"
 ---
 # Source: argocd/templates/tanka.yaml
 apiVersion: v1
@@ -1158,6 +1232,38 @@ spec:
     targetPort: redis
   selector:
     app.kubernetes.io/name: argocd-redis
+    app.kubernetes.io/instance: argocd
+---
+# Source: argocd/charts/oauth2-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/version: "7.6.0"
+  name: argocd-oauth2-proxy
+  namespace: argocd
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+      name: http
+    - port: 44180
+      protocol: TCP
+      appProtocol: http
+      targetPort: metrics
+      name: metrics
+  selector:    
+    app.kubernetes.io/name: oauth2-proxy
     app.kubernetes.io/instance: argocd
 ---
 # Source: argocd/charts/argo-cd/templates/argocd-applicationset/deployment.yaml
@@ -2619,6 +2725,139 @@ spec:
             defaultMode: 493
       dnsPolicy: ClusterFirst
 ---
+# Source: argocd/charts/oauth2-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.7.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/version: "7.6.0"
+  name: argocd-oauth2-proxy
+  namespace: argocd
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: oauth2-proxy
+      app.kubernetes.io/instance: argocd
+  template:
+    metadata:
+      annotations:
+        checksum/config: c0329892592df8b1519fac51e84aee8cf879bb8e157e5a04f6556b38b5a2435b
+        checksum/config-emails: 27a8e7f3520c51f2b1fb340fc9cfb18be7d5fd195077b86c4521f37ca9d80c24
+        checksum/secret: 8fa6fdae65861caa2986544b8860a5205be1937328c8ec2bad6bad076b9e2425
+        checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        checksum/redis-secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+      labels:
+        app: oauth2-proxy        
+        helm.sh/chart: oauth2-proxy-7.7.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/part-of: oauth2-proxy
+        app.kubernetes.io/name: oauth2-proxy
+        app.kubernetes.io/instance: argocd
+        app.kubernetes.io/version: "7.6.0"
+    spec:
+      serviceAccountName: argocd-oauth2-proxy
+      automountServiceAccountToken: true
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --http-address=0.0.0.0:4180
+          - --https-address=0.0.0.0:4443
+          - --metrics-address=0.0.0.0:44180
+          - --provider=google
+          - --email-domain=*
+          - --upstream=http://argocd-server:80
+          - --pass-host-header=true
+          - --set-xauthrequest=true
+          - --silence-ping-logging=true
+          - --skip-provider-button=true
+          - --reverse-proxy=true
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+          - --authenticated-emails-file=/etc/oauth2-proxy/argocd-oauth2-proxy-accesslist
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  argocd-oauth2-proxy
+              key: client-id
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  argocd-oauth2-proxy
+              key: client-secret
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  argocd-oauth2-proxy
+              key: cookie-secret
+        ports:
+          - containerPort: 4180
+            name: http
+            protocol: TCP
+          - containerPort: 44180
+            protocol: TCP
+            name: metrics
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 0
+          timeoutSeconds: 5
+          successThreshold: 1
+          periodSeconds: 10
+        resources:
+          {}
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy/oauth2_proxy.cfg
+          name: configmain
+          subPath: oauth2_proxy.cfg
+        - mountPath: /etc/oauth2-proxy
+          name: configaccesslist
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 2000
+          runAsNonRoot: true
+          runAsUser: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: argocd-oauth2-proxy
+        name: configmain
+      - configMap:
+          name: argocd-oauth2-proxy-accesslist
+          items:
+          - key: restricted_user_access
+            path: argocd-oauth2-proxy-accesslist
+        name: configaccesslist
+      tolerations:
+        []
+---
 # Source: argocd/charts/argo-cd/templates/argocd-application-controller/statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
@@ -3021,39 +3260,40 @@ spec:
             path: profiler.enabled
       dnsPolicy: ClusterFirst
 ---
-# Source: argocd/charts/argo-cd/templates/argocd-server/ingress.yaml
+# Source: argocd/charts/oauth2-proxy/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: argocd-server
-  namespace: argocd
   labels:
-    helm.sh/chart: argo-cd-9.5.2
-    app.kubernetes.io/name: argocd-server
-    app.kubernetes.io/instance: argocd
-    app.kubernetes.io/component: server
+    app: oauth2-proxy    
+    helm.sh/chart: oauth2-proxy-7.7.0
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: "v3.3.7"
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/part-of: oauth2-proxy
+    app.kubernetes.io/name: oauth2-proxy
+    app.kubernetes.io/instance: argocd
+    app.kubernetes.io/version: "7.6.0"
+  name: argocd-oauth2-proxy
+  namespace: argocd
   annotations:
-    cert-manager.io/cluster-issuer: "real-cert"
+    cert-manager.io/cluster-issuer: real-cert
 spec:
-  ingressClassName: cilium
+  ingressClassName: "cilium"
   rules:
-    - host: argocd.placeholder.symmatree.com
+    - host: "argocd.placeholder.symmatree.com"
       http:
         paths:
           - path: /
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
-                name: argocd-server
+                name: argocd-oauth2-proxy
                 port:
                   number: 80
   tls:
     - hosts:
       - argocd.placeholder.symmatree.com
-      secretName: argocd-server-tls
+      secretName: argocd-proxy-tls
 ---
 # Source: argocd/templates/tiles-appproject.yaml
 apiVersion: argoproj.io/v1alpha1
@@ -3121,6 +3361,16 @@ metadata:
 type: Opaque
 spec:
   itemPath: 'vaults/placeholder/items/argocd-google-oauth'
+---
+# Source: argocd/templates/oauth2-proxy-secret.yaml
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: argocd-oauth2-proxy
+  namespace: "argocd"
+type: Opaque
+spec:
+  itemPath: 'vaults/placeholder/items/argocd-oauth2-proxy'
 ---
 # Source: argocd/charts/argo-cd/templates/argocd-application-controller/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -3277,6 +3277,8 @@ metadata:
   namespace: argocd
   annotations:
     cert-manager.io/cluster-issuer: real-cert
+    external-dns.alpha.kubernetes.io/target: lhitw.symmatree.com
+    ingress.cilium.io/loadbalancer-mode: shared
 spec:
   ingressClassName: "cilium"
   rules:

--- a/charts/argocd/templates/oauth2-proxy-secret.yaml
+++ b/charts/argocd/templates/oauth2-proxy-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: argocd-oauth2-proxy
+  namespace: "{{ .Release.Namespace }}"
+type: Opaque
+spec:
+  itemPath: 'vaults/{{ required ".Values.vault_name is required" .Values.vault_name }}/items/argocd-oauth2-proxy'

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -181,22 +181,10 @@ argo-cd:
       serviceMonitor:
         # -- Enable a prometheus ServiceMonitor
         enabled: true
-    # Argo CD server ingress configuration
+    # Ingress disabled: oauth2-proxy is the external entry point.
+    # argocd-server has no direct external exposure.
     ingress:
-      # -- Enable an ingress resource for the Argo CD server
-      enabled: true
-      # -- Specific implementation for ingress controller. One of `generic`, `aws` or `gke`
-      ## Additional configuration might be required in related configuration sections
-      controller: generic
-      annotations:
-        cert-manager.io/cluster-issuer: real-cert
-        # Note: Cilium automatically syncs TLS secrets from the ingress namespace
-        # to cilium-secrets namespace when enable-ingress-secrets-sync is true
-      ingressClassName: cilium
-      # -- Enable TLS configuration for the hostname defined at `server.ingress.hostname`
-      ## TLS certificate will be retrieved from a TLS secret `argocd-server-tls`
-      ## You can create this secret via `certificate` or `certificateSecret` option
-      tls: true
+      enabled: false
     # Dedicated gRPC ingress for ingress controllers that supports only single backend protocol per Ingress resource
     # Ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/ingress/#option-2-multiple-ingress-objects-and-hosts
     ingressGrpc:
@@ -334,3 +322,33 @@ argo-cd:
       - name: cmp-tanka
         configMap:
           name: cmp-tanka
+
+oauth2-proxy:
+  # Credentials injected from 1Password. Create a vault item named 'argocd-oauth2-proxy' with
+  # fields: OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET.
+  # Generate cookie secret with: openssl rand -base64 32 | head -c 32 | base64
+  # GCP OAuth2 client redirect URI: https://argocd.{cluster}.symmatree.com/oauth2/callback
+  extraEnvFrom:
+    - secretRef:
+        name: argocd-oauth2-proxy
+  extraArgs:
+    - --provider=google
+    - "--email-domain=*"
+    - --allowed-email=seth.porter@gmail.com
+    - --upstream=http://argocd-server:80
+    - --pass-host-header=true
+    - --set-xauthrequest=true
+    - --silence-ping-logging=true
+    - --skip-provider-button=true
+    - --reverse-proxy=true
+  ingress:
+    enabled: true
+    className: cilium
+    annotations:
+      cert-manager.io/cluster-issuer: real-cert
+    hosts:
+      - argocd.placeholder.symmatree.com
+    tls:
+      - secretName: argocd-proxy-tls
+        hosts:
+          - argocd.placeholder.symmatree.com

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -353,6 +353,13 @@ oauth2-proxy:
     className: cilium
     annotations:
       cert-manager.io/cluster-issuer: real-cert
+      # Ride the single shared front door (the cilium-ingress LB IP that UniFi
+      # forwards 443 to) rather than getting a dedicated per-ingress LB IP.
+      ingress.cilium.io/loadbalancer-mode: shared
+      # Publish as a CNAME to the UniFi dynamic-DNS record (WAN IP), not the
+      # internal LB IP, so this resolves for external clients and tracks the
+      # dynamic Verizon address.
+      external-dns.alpha.kubernetes.io/target: lhitw.symmatree.com
     hosts:
       - argocd.placeholder.symmatree.com
     tls:

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -334,13 +334,20 @@ oauth2-proxy:
   extraArgs:
     - --provider=google
     - "--email-domain=*"
-    - --allowed-email=seth.porter@gmail.com
     - --upstream=http://argocd-server:80
     - --pass-host-header=true
     - --set-xauthrequest=true
     - --silence-ping-logging=true
     - --skip-provider-button=true
     - --reverse-proxy=true
+  # Allowlist: only these emails may authenticate. The chart writes them to a
+  # ConfigMap and passes --authenticated-emails-file automatically. --email-domain=*
+  # above lets the domain check pass; this file is the actual restriction. (There is
+  # no --allowed-email flag in oauth2-proxy -- the old line was a no-op at best.)
+  authenticatedEmailsFile:
+    enabled: true
+    restricted_access: |
+      seth.porter@gmail.com
   ingress:
     enabled: true
     className: cilium

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -353,13 +353,13 @@ oauth2-proxy:
     className: cilium
     annotations:
       cert-manager.io/cluster-issuer: real-cert
-      # Ride the single shared front door (the cilium-ingress LB IP that UniFi
-      # forwards 443 to) rather than getting a dedicated per-ingress LB IP.
+      # Ride the single shared front door (the pinned cilium-ingress LB IP)
+      # rather than a dedicated per-ingress LB IP. With no external-dns target
+      # override, external-dns publishes this host at that internal ingress IP,
+      # so it is reachable and testable on-LAN. The WAN cutover (external-dns
+      # target -> lhitw.symmatree.com + the UniFi 443 port-forward) is a
+      # separate follow-up PR, so nothing is exposed until that is applied.
       ingress.cilium.io/loadbalancer-mode: shared
-      # Publish as a CNAME to the UniFi dynamic-DNS record (WAN IP), not the
-      # internal LB IP, so this resolves for external clients and tracks the
-      # dynamic Verizon address.
-      external-dns.alpha.kubernetes.io/target: lhitw.symmatree.com
     hosts:
       - argocd.placeholder.symmatree.com
     tls:

--- a/charts/cilium-config/application.yaml
+++ b/charts/cilium-config/application.yaml
@@ -12,6 +12,7 @@ spec:
       # Inject values from Terraform or that vary by environment.
       valuesObject:
         external_ip_cidr: '{{ required ".Values.external_ip_cidr is required" .Values.external_ip_cidr }}'
+        ingress_lb_ip: '{{ .Values.ingress_lb_ip | default "" }}'
         targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
   destination:
     server: https://kubernetes.default.svc

--- a/charts/cilium-config/rendered.yaml
+++ b/charts/cilium-config/rendered.yaml
@@ -24,3 +24,21 @@ metadata:
 spec:
   blocks:
     - cidr: "placeholder"
+---
+# Source: cilium-config/templates/lb-ingress-ip-pool.helm.yaml
+# Pin the shared Cilium ingress service (the WAN-forwarded front door) to a
+# fixed LoadBalancer IP, so the UniFi 443 port-forward and the DNS target have a
+# stable address. The serviceSelector targets only the shared `cilium-ingress`
+# service (by name/namespace), not per-ingress dedicated services.
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  namespace: "cilium-config"
+  name: lb-ingress-pool
+spec:
+  serviceSelector:
+    matchLabels:
+      io.kubernetes.service.namespace: cilium
+      io.kubernetes.service.name: cilium-ingress
+  blocks:
+    - cidr: "placeholder/32"

--- a/charts/cilium-config/templates/lb-ingress-ip-pool.helm.yaml
+++ b/charts/cilium-config/templates/lb-ingress-ip-pool.helm.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ingress_lb_ip }}
+# Pin the shared Cilium ingress service (the WAN-forwarded front door) to a
+# fixed LoadBalancer IP, so the UniFi 443 port-forward and the DNS target have a
+# stable address. The serviceSelector targets only the shared `cilium-ingress`
+# service (by name/namespace), not per-ingress dedicated services.
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  namespace: "{{ .Release.Namespace }}"
+  name: lb-ingress-pool
+spec:
+  serviceSelector:
+    matchLabels:
+      io.kubernetes.service.namespace: cilium
+      io.kubernetes.service.name: cilium-ingress
+  blocks:
+    - cidr: "{{ .Values.ingress_lb_ip }}/32"
+{{- end }}

--- a/tf/modules/talos-cluster/main.tf
+++ b/tf/modules/talos-cluster/main.tf
@@ -114,6 +114,10 @@ resource "onepassword_item" "misc_config" {
       value = var.external_ip_cidr
     }
     field {
+      label = "ingress_lb_ip"
+      value = var.ingress_lb_ip
+    }
+    field {
       label = "vault_name"
       value = var.onepassword_vault_name
     }

--- a/tf/modules/talos-cluster/variables.tf
+++ b/tf/modules/talos-cluster/variables.tf
@@ -140,6 +140,12 @@ variable "external_ip_cidr" {
   type        = string
 }
 
+variable "ingress_lb_ip" {
+  description = "Fixed LoadBalancer IP for the shared Cilium ingress front door. Empty = dynamic."
+  type        = string
+  default     = ""
+}
+
 variable "onepassword_vault" {
   description = "1Password vault UUID."
   type        = string

--- a/tf/nodes/cluster.tf
+++ b/tf/nodes/cluster.tf
@@ -38,6 +38,7 @@ module "cluster" {
 
   admin_user             = var.admin_user
   external_ip_cidr       = var.external_ip_cidr
+  ingress_lb_ip          = var.ingress_lb_ip
   pod_cidr               = var.pod_cidr
   service_cidr           = var.service_cidr
   control_plane_vip      = var.control_plane_vip

--- a/tf/nodes/prod.tfvars
+++ b/tf/nodes/prod.tfvars
@@ -14,8 +14,11 @@ kubelet_eviction_memory_available = "512Mi"
 # Network configuration for tiles cluster (10.0.128.0/18 block)
 control_plane_vip = "10.0.128.10"
 external_ip_cidr  = "10.0.129.0/24"
-service_cidr      = "10.0.136.0/21"
-pod_cidr          = "10.0.144.0/20"
+# Fixed IP for the shared Cilium ingress (the WAN-forwarded front door). Inside
+# external_ip_cidr; reserve it out of DHCP on the UniFi side.
+ingress_lb_ip = "10.0.129.2"
+service_cidr  = "10.0.136.0/21"
+pod_cidr      = "10.0.144.0/20"
 
 virtual_machines = {
   "tiles-cp-1" = {

--- a/tf/nodes/variables.tf
+++ b/tf/nodes/variables.tf
@@ -130,6 +130,12 @@ variable "external_ip_cidr" {
   type        = string
 }
 
+variable "ingress_lb_ip" {
+  description = "Fixed LoadBalancer IP to pin the shared Cilium ingress (the WAN-forwarded front door) to. Must be inside external_ip_cidr and reserved out of DHCP. Empty = let Cilium assign dynamically (e.g. test)."
+  type        = string
+  default     = ""
+}
+
 variable "pod_cidr" {
   description = "Pod CIDR for the cluster"
   type        = string


### PR DESCRIPTION
Supersedes #543 (closed).

## What

Puts oauth2-proxy in front of ArgoCD as the hard perimeter: all inbound internet traffic hits oauth2-proxy first and is rejected unless the Google session belongs to an allowlisted email. ArgoCD's server has no direct Ingress exposure.

```
Internet → UniFi NAT → Cilium LB IP → Cilium Ingress (Envoy)
  → oauth2-proxy (--allowed-email=seth.porter@gmail.com)
    → argocd-server:80 (ClusterIP only)
```

## Why not Dex

Dex is an OIDC identity provider integrated *into* ArgoCD — ArgoCD's server still handles all requests and renders its login page to unauthenticated users. That is not a through-proxy; it's auth logic inside the application. oauth2-proxy is the actual perimeter gate.

Dex config is left in place (broken but harmless) for future use once GCP credentials are pointed at the right project.

## Changes

- **Chart.yaml**: add `oauth2-proxy 7.7.0` dependency
- **values.yaml**: `server.ingress.enabled: false`; add `oauth2-proxy` config with upstream `http://argocd-server:80`, email allowlist, `--reverse-proxy=true` so it trusts Cilium Envoy's `X-Forwarded-Proto`
- **templates/oauth2-proxy-secret.yaml**: `OnePasswordItem` pulling `argocd-oauth2-proxy` from the cluster vault
- **application.yaml**: template oauth2-proxy ingress host/TLS from `cluster_name`

## Before merging

- [ ] Create `argocd-oauth2-proxy` item in 1Password vault with fields:
  - `OAUTH2_PROXY_CLIENT_ID`
  - `OAUTH2_PROXY_CLIENT_SECRET`
  - `OAUTH2_PROXY_COOKIE_SECRET` — generate with `openssl rand -base64 32 | head -c 32 | base64`
- [ ] Create GCP OAuth2 client (separate from the Dex one) with redirect URI `https://argocd.{cluster}.symmatree.com/oauth2/callback`
- [ ] Run `helm dependency update charts/argocd` to regenerate `Chart.lock`
- [ ] Re-render `rendered.yaml`

## After merge

- [ ] UniFi: port forward 443 → Cilium ingress controller LoadBalancer IP (one-time, covers all services)
- [ ] Confirm `https://argocd.{cluster}.symmatree.com` redirects to Google login from outside VPN without showing any ArgoCD UI
- [ ] Confirm only `seth.porter@gmail.com` can get through; any other Google account gets 403