### PR TITLE
Create /run/sshd before starting sshd in singleuser container

### DIFF
--- a/containers/datascience-notebook-ssh/start-sshd.sh
+++ b/containers/datascience-notebook-ssh/start-sshd.sh
@@ -12,4 +12,10 @@ set -euo pipefail
 # if /etc/ssh was overlaid) so sshd can start.
 ssh-keygen -A
 
+# sshd needs its privilege-separation directory or it exits 255 with "Missing
+# privilege separation directory: /run/sshd". /run is a tmpfs that starts empty
+# and no init system creates it here, so make it ourselves — otherwise this hook
+# fails under `set -e` and takes the whole notebook container down with it.
+mkdir -p /run/sshd
+
 /usr/sbin/sshd


### PR DESCRIPTION
## Problem

#538 added a `before-notebook.d/start-sshd.sh` hook to launch sshd, but the singleuser pod now **crashloops** and the spawn fails.

Root cause (reproduced on the freshly-built `edge` image):
- `/usr/sbin/sshd` exits **255** with `Missing privilege separation directory: /run/sshd`.
- `/run` is a tmpfs that starts empty, and with no init system nothing creates `/run/sshd`.
- Under `set -euo pipefail`, that non-zero exit aborts the hook → aborts Jupyter's `start.sh` → the container exits → CrashLoopBackOff → spawn failure.

Before #538 sshd never ran, so the notebook still came up (just no SSH). Starting it surfaced this.

## Fix

`mkdir -p /run/sshd` before launching sshd. Kept `set -e` so genuine sshd failures still surface rather than being silently swallowed.

## Verification

On the built `edge` image, with the fix applied:
- hook exits 0, no crash;
- sshd process running, `/proc/net/tcp` shows a LISTEN on :22;
- a raw TCP connect to `127.0.0.1:22` returns `SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.1`.

## Rollout

Merge rebuilds the image (`containers/datascience-notebook-ssh/**` trigger); then respawn the singleuser server (Stop/Start) to pull it. Final check: `ssh -p 22 <user>@10.0.129.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)