### PR TITLE
Fix #549: drop `terraform init -upgrade` to stop poisoning the TF provider cache

### DIFF
--- a/.github/workflows/nodes-plan-apply.yaml
+++ b/.github/workflows/nodes-plan-apply.yaml
@@ -132,12 +132,18 @@ jobs:
           path: tf/nodes/.terraform
           key: ${{ runner.os }}-nodes-tf-v2-${{ steps.stamps.outputs.DATESTAMP }}-${{ hashFiles('tf/nodes/.terraform.lock.hcl', 'tf-cache-poison.txt') }}
 
+      # Plain `terraform init` (no -upgrade): install exactly the versions pinned in the
+      # committed .terraform.lock.hcl, so .terraform always matches the lockfile hash used
+      # in the cache key above. `-upgrade` would install newest-available and rewrite the
+      # lockfile, decoupling .terraform from the key and poisoning the cache (see #549).
+      # Deliberate upgrades: run `terraform init -upgrade` locally and commit the new
+      # lockfile; the changed hash busts this cache automatically.
       - name: Terraform init
         if: steps.charts_only.outputs.run_terraform == 'true' && steps.tf-cache.outputs.cache-hit != 'true'
         working-directory: "tf/nodes"
         run: |
           set -euo pipefail
-          terraform init -upgrade
+          terraform init
 
       - uses: ./.github/actions/wg-quick
         id: wireguard

--- a/.github/workflows/nodes-plan-apply.yaml
+++ b/.github/workflows/nodes-plan-apply.yaml
@@ -132,14 +132,20 @@ jobs:
           path: tf/nodes/.terraform
           key: ${{ runner.os }}-nodes-tf-v2-${{ steps.stamps.outputs.DATESTAMP }}-${{ hashFiles('tf/nodes/.terraform.lock.hcl', 'tf-cache-poison.txt') }}
 
-      # Plain `terraform init` (no -upgrade): install exactly the versions pinned in the
-      # committed .terraform.lock.hcl, so .terraform always matches the lockfile hash used
-      # in the cache key above. `-upgrade` would install newest-available and rewrite the
-      # lockfile, decoupling .terraform from the key and poisoning the cache (see #549).
-      # Deliberate upgrades: run `terraform init -upgrade` locally and commit the new
-      # lockfile; the changed hash busts this cache automatically.
+      # Always run plain `terraform init` (no -upgrade). The cache above is a warm start,
+      # not a substitute for init:
+      #   - Providers: already restored and matching the committed .terraform.lock.hcl, so
+      #     init verifies them without re-downloading. `-upgrade` would install
+      #     newest-available and rewrite the lockfile, decoupling .terraform from the cache
+      #     key (which hashes the lockfile) and poisoning the cache -- see #549.
+      #   - Modules: init reconciles .terraform/modules/modules.json against the current
+      #     config every run, so adding/removing/moving a module block is picked up. Module
+      #     versions are not tracked in the lockfile, so a cache keyed on the lockfile can't
+      #     see them; skipping init on a cache hit would run plan against a stale manifest.
+      # Deliberate provider upgrades: run `terraform init -upgrade` locally and commit the
+      # new lockfile; the changed hash busts this cache automatically.
       - name: Terraform init
-        if: steps.charts_only.outputs.run_terraform == 'true' && steps.tf-cache.outputs.cache-hit != 'true'
+        if: steps.charts_only.outputs.run_terraform == 'true'
         working-directory: "tf/nodes"
         run: |
           set -euo pipefail

--- a/.github/workflows/nodes-plan-apply.yaml
+++ b/.github/workflows/nodes-plan-apply.yaml
@@ -132,24 +132,32 @@ jobs:
           path: tf/nodes/.terraform
           key: ${{ runner.os }}-nodes-tf-v2-${{ steps.stamps.outputs.DATESTAMP }}-${{ hashFiles('tf/nodes/.terraform.lock.hcl', 'tf-cache-poison.txt') }}
 
-      # Always run plain `terraform init` (no -upgrade). The cache above is a warm start,
-      # not a substitute for init:
-      #   - Providers: already restored and matching the committed .terraform.lock.hcl, so
-      #     init verifies them without re-downloading. `-upgrade` would install
-      #     newest-available and rewrite the lockfile, decoupling .terraform from the cache
-      #     key (which hashes the lockfile) and poisoning the cache -- see #549.
-      #   - Modules: init reconciles .terraform/modules/modules.json against the current
-      #     config every run, so adding/removing/moving a module block is picked up. Module
-      #     versions are not tracked in the lockfile, so a cache keyed on the lockfile can't
-      #     see them; skipping init on a cache hit would run plan against a stale manifest.
+      # The cache key hashes the committed .terraform.lock.hcl, which fully pins providers.
+      # So a cache hit means providers are already correct, and re-running init's provider
+      # phase (a registry round-trip per provider -- the slow part) is pure waste. Modules
+      # are NOT tracked by the lockfile, so a hit can still carry a stale module manifest.
+      # Split the work by what the cache can and can't vouch for:
+      #   - cache miss: full `terraform init` to download providers per the lockfile. No
+      #     -upgrade -- that installs newest-available and rewrites the lockfile, decoupling
+      #     .terraform from the cache key and poisoning the cache (see #549).
+      #   - cache hit: `terraform get -update` to reconcile modules only (add/remove/move a
+      #     block, and re-fetch remote modules), skipping the provider/backend network. This
+      #     is the module-refresh that -upgrade used to provide, without the provider side
+      #     effect; for the current all-local modules it is effectively free.
       # Deliberate provider upgrades: run `terraform init -upgrade` locally and commit the
       # new lockfile; the changed hash busts this cache automatically.
-      - name: Terraform init
-        if: steps.charts_only.outputs.run_terraform == 'true'
+      - name: Terraform init (cache miss)
+        if: steps.charts_only.outputs.run_terraform == 'true' && steps.tf-cache.outputs.cache-hit != 'true'
         working-directory: "tf/nodes"
         run: |
           set -euo pipefail
           terraform init
+      - name: Terraform get (warm cache)
+        if: steps.charts_only.outputs.run_terraform == 'true' && steps.tf-cache.outputs.cache-hit == 'true'
+        working-directory: "tf/nodes"
+        run: |
+          set -euo pipefail
+          terraform get -update
 
       - uses: ./.github/actions/wg-quick
         id: wireguard

--- a/tf-cache-poison.txt
+++ b/tf-cache-poison.txt
@@ -1,3 +1,4 @@
 # Terraform cache poison file
 # Modify this file to force Terraform cache invalidation
 # Last updated: 2026-07-01 (bust stale provider cache after #527 lock bump to google/google-beta 7.38.0, kubernetes 3.2.0)
+# Last updated: 2026-07-03 (#549: drop `terraform init -upgrade`; bust the -upgrade-poisoned cache one final time)


### PR DESCRIPTION
Fixes #549.

## Problem

`nodes-plan-apply` intermittently fails at `terraform plan`:

```
Error: Required plugins are not installed
  - hashicorp/google: there is no package for ...google 7.38.0 cached in .terraform/providers
  ...
```

(e.g. run 28663687230 on PR #548.)

## Root cause

The `Terraform cache` key hashes the **committed** `tf/nodes/.terraform.lock.hcl`, but init ran `terraform init -upgrade` **only on a cache miss**. `-upgrade` was originally there to refresh modules (back when tf/nodes used registry/google modules) but it also ignores the lockfile's selected provider versions, installs newest-available, and rewrites the lockfile — so the cached `.terraform` diverges from the lockfile hash that names it. A later cache **hit skips init**, and `plan` runs against providers that don't satisfy the committed lockfile.

`tf-cache-poison.txt` + commit 6dab93c (after #527) were manual firefighting for this.

## Design

Split the work by what the cache key can actually vouch for:

- **Providers** are fully pinned by the lockfile, which is in the cache key. So a cache hit *guarantees* providers are correct — re-running init's provider phase (a registry round-trip per provider, the slow part the cache-hit skip was added to avoid) is pure waste.
- **Modules** are *not* tracked by any lockfile, and remote module state can't be represented by a file hash at all — so they must be reconciled by running terraform every time.

Therefore:

| | command |
|---|---|
| cache **miss** | `terraform init` (no `-upgrade`) — download providers per the lockfile |
| cache **hit** | `terraform get -update` — reconcile modules only (add/remove/move, re-fetch remote), skipping the provider/backend network |

`terraform get -update` restores exactly the module-refresh that `-upgrade` used to provide, without the provider-upgrade side effect that poisoned the cache. For today's all-local modules it's effectively free; if a remote module is re-added, it picks up changes each run.

Also bumps `tf-cache-poison.txt` once more to clear the already-poisoned same-day entry so this goes green immediately.

Deliberate **provider** upgrades: run `terraform init -upgrade` locally and commit the new lockfile; the changed hash busts the CI cache automatically.

## Verification

By construction: providers are installed strictly per the lockfile the cache key hashes; modules are reconciled every run. CI on this PR exercises the real path — worth a glance at the `Terraform get (warm cache)` step timing on a warm-cache run to confirm it's cheap (I can't reproduce the GHA cache locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)