### PR TITLE
Fix #547: bare-metal workers reapply + reboot on cluster rebuild

### DIFF
--- a/.github/workflows/nodes-plan-apply.yaml
+++ b/.github/workflows/nodes-plan-apply.yaml
@@ -24,6 +24,21 @@ on:
         options:
           - test
           - prod
+      metal_apply_mode:
+        # "reboot" is what makes bare-metal workers rejoin after a rebuild: pair
+        # it with a taint-vms run (which taints the metal config-apply) so the
+        # re-applied node reboots into the new etcd instead of staying orphaned.
+        # Leave "auto" for routine applies. Only consumed on workflow_dispatch;
+        # PR/push/schedule always use the "auto" default below.
+        # docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot
+        description: "talosctl apply-config mode for bare-metal nodes (use reboot for a cluster rebuild)"
+        type: choice
+        default: auto
+        options:
+          - auto
+          - reboot
+          - no_reboot
+          - staged
   pull_request: {}
   push:
     branches:
@@ -155,6 +170,9 @@ jobs:
           UNIFI_USERNAME: ${{ steps.load_secrets.outputs.UNIFI_USERNAME }}
           UNIFI_PASSWORD: ${{ steps.load_secrets.outputs.UNIFI_PASSWORD }}
           TF_VAR_proxmox_root_password: ${{ steps.load_secrets.outputs.PROXMOX_ROOT_PASSWORD }}
+          # Rebuild knob: reboot re-applied metal workers so they rejoin the new
+          # etcd. Empty on PR/push/schedule -> "auto" (no behavior change).
+          TF_VAR_metal_apply_mode: ${{ inputs.metal_apply_mode || 'auto' }}
         uses: ./.github/actions/terraform-plan-apply
         with:
           workspace: "test"
@@ -171,6 +189,9 @@ jobs:
           UNIFI_USERNAME: ${{ steps.load_secrets.outputs.UNIFI_USERNAME }}
           UNIFI_PASSWORD: ${{ steps.load_secrets.outputs.UNIFI_PASSWORD }}
           TF_VAR_proxmox_root_password: ${{ steps.load_secrets.outputs.PROXMOX_ROOT_PASSWORD }}
+          # Rebuild knob: reboot re-applied metal workers so they rejoin the new
+          # etcd. Empty on PR/push/schedule -> "auto" (no behavior change).
+          TF_VAR_metal_apply_mode: ${{ inputs.metal_apply_mode || 'auto' }}
         uses: ./.github/actions/terraform-plan-apply
         with:
           workspace: "prod"

--- a/.github/workflows/taint-vms.yaml
+++ b/.github/workflows/taint-vms.yaml
@@ -79,6 +79,17 @@ jobs:
           terraform taint 'module.cluster.module.talos-vm["tiles-test-wk"].proxmox_virtual_environment_vm.main'
           terraform taint 'module.cluster.talos_machine_bootstrap.this'
 
+          # Bare-metal workers are not recreated like VMs: a rebuild re-applies
+          # byte-identical config, so talos_machine_configuration_apply is a no-op
+          # under apply_mode="auto" and the node never rejoins the new etcd. Taint
+          # it (derived from state, so it tracks metal_{amd,intel}_nodes) so it
+          # re-runs, then run nodes-plan-apply with metal_apply_mode=reboot so the
+          # re-apply reboots the node. Empty in workspaces with no metal nodes.
+          # docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot
+          while IFS= read -r addr; do
+            [ -n "$addr" ] && terraform taint "$addr"
+          done < <(terraform state list | grep -E '^module\.cluster\.module\.talos-(amd|intel)-metal\[.*\]\.talos_machine_configuration_apply\.this$' || true)
+
       # Prod cluster VM tainting
       - name: Taint prod cluster VMs
         if: inputs.taint_prod == true
@@ -99,8 +110,19 @@ jobs:
           terraform taint 'module.cluster.module.talos-vm["tiles-wk-1"].proxmox_virtual_environment_vm.main'
           terraform taint 'module.cluster.module.talos-vm["tiles-wk-2"].proxmox_virtual_environment_vm.main'
           terraform taint 'module.cluster.module.talos-vm["tiles-wk-3"].proxmox_virtual_environment_vm.main'
-          # terraform taint 'module.cluster.module.talos-amd-metal["lancer"].talos_machine_configuration_apply.this'
           terraform taint 'module.cluster.talos_machine_bootstrap.this'
+
+          # Bare-metal workers (e.g. acebase) are not recreated like VMs: a rebuild
+          # re-applies byte-identical config, so talos_machine_configuration_apply
+          # is a no-op under apply_mode="auto" and the node never rejoins the new
+          # etcd. Taint it (derived from state, so it tracks metal_{amd,intel}_nodes
+          # -- replaces the old hardcoded, commented-out "lancer" line) so it
+          # re-runs, then run nodes-plan-apply with metal_apply_mode=reboot so the
+          # re-apply reboots the node.
+          # docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot
+          while IFS= read -r addr; do
+            [ -n "$addr" ] && terraform taint "$addr"
+          done < <(terraform state list | grep -E '^module\.cluster\.module\.talos-(amd|intel)-metal\[.*\]\.talos_machine_configuration_apply\.this$' || true)
 
       - name: De-wireguard
         if: always()
@@ -121,16 +143,16 @@ jobs:
             echo "## Taint VM Workflow Complete"
             echo ""
             if [ "${{ inputs.taint_test }}" == "true" ]; then
-              echo "✅ Test cluster tainted (Talos schematics, Proxmox ISOs, VMs, bootstrap)"
+              echo "✅ Test cluster tainted (Talos schematics, Proxmox ISOs, VMs, bootstrap, metal config-apply)"
             fi
             if [ "${{ inputs.taint_prod }}" == "true" ]; then
-              echo "✅ Prod cluster tainted (Talos schematics, Proxmox ISOs, VMs, bootstrap)"
+              echo "✅ Prod cluster tainted (Talos schematics, Proxmox ISOs, VMs, bootstrap, metal config-apply)"
             fi
             if [ "${{ inputs.taint_test }}" != "true" ] && [ "${{ inputs.taint_prod }}" != "true" ]; then
               echo "ℹ️ Nothing tainted (both options were false)"
             fi
             echo ""
             echo "**Next steps:**"
-            echo "- Coordinate any bare-metal node resets if needed"
-            echo "- Run nodes-plan-apply with apply for the workspace you tainted"
+            echo "- Run **nodes-plan-apply** with **apply** for the workspace you tainted, and set **\`metal_apply_mode = reboot\`** so re-applied bare-metal workers reboot and rejoin the freshly bootstrapped etcd (a plain re-apply is a no-op and leaves them orphaned)."
+            echo "- See [docs/bare-metal-nodes.md](../blob/main/docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot) for the full rebuild runbook."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Each cluster uses `/18` allocation (64 /24s). Pods use `/20` with `node-cidr-mas
 
 Use this when you want **new Proxmox VMs** (fresh disks / reinstall Talos), for example after a major Talos pin change. Workspaces are **`test`** and **`prod`**; pick one and stay consistent through the apply. This flow uses GitHub Actions (service account, VPN, secrets) end to end.
 
-1. Run **[`taint-vms`](.github/workflows/taint-vms.yaml)** in Actions. Enable **taint test** and/or **taint prod** (each taints the Talos VM resources for that workspace and **`talos_machine_bootstrap`** so bootstrap runs again after disks are new).
-2. Run **`nodes-plan-apply`** with **apply** for the workspace you tainted: a push to **`main`** applies **test** by default; use **`workflow_dispatch`** with apply and **prod** for production.
+1. Run **[`taint-vms`](.github/workflows/taint-vms.yaml)** in Actions. Enable **taint test** and/or **taint prod** (each taints the Talos VM resources for that workspace, **`talos_machine_bootstrap`** so bootstrap runs again after disks are new, and each bare-metal **`talos_machine_configuration_apply`** so metal workers re-apply).
+2. Run **`nodes-plan-apply`** with **apply** for the workspace you tainted, and set **`metal_apply_mode = reboot`**: a push to **`main`** applies **test** by default; use **`workflow_dispatch`** with apply and **prod** for production.
 
-After apply, Terraform recreates the VMs, applies machine config, and bootstraps the cluster.
+After apply, Terraform recreates the VMs, applies machine config, and bootstraps the cluster. **Bare-metal workers need `metal_apply_mode = reboot`** to rejoin the new etcd -- a plain re-apply is a no-op and leaves them orphaned. See [docs/bare-metal-nodes.md](docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot).
 
 See `docs/environment-strategy.md` for workspace behavior.
 

--- a/docs/bare-metal-nodes.md
+++ b/docs/bare-metal-nodes.md
@@ -101,7 +101,28 @@ Replace placeholders from Terraform outputs or plan. Generic Talos bare-metal co
 
 ## Full-cluster rebuilds and VMs
 
-If you are destroying and recreating **Proxmox VMs** with Terraform at the same time as bare metal, see [README.md -- Recreating cluster](../README.md#recreating-cluster). Bare-metal nodes are **not** destroyed by that flow; reset or reinstall them using [Wipe and reinstall](#3-wipe-and-reinstall-talos-on-the-same-machine).
+The [Recreating cluster](../README.md#recreating-cluster) flow taints the Proxmox **VMs** and **`talos_machine_bootstrap`**, so Terraform builds new VM disks and **re-bootstraps etcd** -- a brand-new cluster. Bare-metal nodes are **not** VMs and are **not** recreated by that flow, which is exactly where they get stranded.
+
+### Rebuilds: metal reapply + reboot
+
+**The trap.** A metal worker's machine config is derived from `talos_machine_secrets`, which a bootstrap recreate does **not** change. Re-applying it therefore produces byte-identical config, and `talos_machine_configuration_apply` under the default `apply_mode = "auto"` is a **no-op -- no reboot**. The node keeps its old in-memory etcd/kubelet identity, its Node object was wiped with the old etcd, and the long-running kubelet loops `nodes "<name>" not found`; `NodeRestriction` then denies every pod pinned there. (Observed 2026-06-30 -> 07-01: `acebase` -- the GNSS base -- sat orphaned ~35h, so `ntrip/rtkbase` + `mavproxy` were `Pending` and **RTK was down**. See [tiles#547](https://github.com/symmatree/tiles/issues/547).)
+
+A config *apply* is not a *reset*. PKI is preserved across the recreate (both apid mTLS and the kubelet client cert still authenticate), so the node needs neither new certs nor a reinstall -- it only needs to **reboot** (or at minimum `talosctl -n <NODE_IP> service kubelet restart`) to rejoin. Since `auto` won't reboot on unchanged config, we force it.
+
+**The mechanism -- two knobs, both required:**
+
+1. **[`taint-vms`](../.github/workflows/taint-vms.yaml)** taints each metal `talos_machine_configuration_apply` (derived from state, so it tracks `metal_{amd,intel}_nodes` automatically) so the apply re-runs on the next Terraform apply.
+2. **[`nodes-plan-apply`](../.github/workflows/nodes-plan-apply.yaml)** takes a **`metal_apply_mode`** input, threaded via `TF_VAR_metal_apply_mode` into the metal module's `apply_mode`. Set it to **`reboot`** for a rebuild: the re-applied node reboots and rejoins the new etcd. The metal modules `depends_on` `talos_machine_bootstrap`, so the reboot lands **after** the new etcd exists.
+
+Routine applies (PR / push / daily schedule) leave `metal_apply_mode = "auto"`, so this is inert outside a deliberate rebuild. The same `reboot` knob is also the general way to push a machine-config change that needs a reboot to a metal node.
+
+> **apply-config modes** ([Talos v1.13](https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration)): `auto` reboots only if a changed field requires it; `no_reboot` fails if a reboot would be needed; `reboot` always reboots to apply; `staged` applies on next reboot. Changes Terraform apply cannot make at all (install disk, disk encryption, wiping state) need a **reset**, not an apply -- see [Wipe and reinstall](#3-wipe-and-reinstall-talos-on-the-same-machine).
+
+**Rebuild runbook**
+
+1. Run **`taint-vms`** for the workspace (taints VMs, `talos_machine_bootstrap`, and metal config-apply).
+2. Run **`nodes-plan-apply`** with **apply** for that workspace and **`metal_apply_mode = reboot`**.
+3. Verify: `talosctl -n <NODE_IP> get members` and `kubectl get nodes` show the metal node; any pinned pods (e.g. `ntrip`, `mavproxy`) return to `Running`.
 
 ## Related docs
 

--- a/tf/modules/talos-cluster/nodes.tf
+++ b/tf/modules/talos-cluster/nodes.tf
@@ -111,6 +111,12 @@ module "talos-amd-metal" {
     })] : [],
     each.value.machine_config_patches
   )
+
+  apply_mode = var.metal_apply_mode
+
+  # Order the metal (re)apply after the etcd bootstrap so an apply_mode="reboot"
+  # rebuild reboots the node into the *new* cluster rather than the old one.
+  depends_on = [talos_machine_bootstrap.this]
 }
 
 module "talos-intel-metal" {
@@ -146,4 +152,10 @@ module "talos-intel-metal" {
     })] : [],
     each.value.machine_config_patches
   )
+
+  apply_mode = var.metal_apply_mode
+
+  # Order the metal (re)apply after the etcd bootstrap so an apply_mode="reboot"
+  # rebuild reboots the node into the *new* cluster rather than the old one.
+  depends_on = [talos_machine_bootstrap.this]
 }

--- a/tf/modules/talos-cluster/variables.tf
+++ b/tf/modules/talos-cluster/variables.tf
@@ -48,6 +48,17 @@ variable "metal_intel_nodes" {
   default = {}
 }
 
+variable "metal_apply_mode" {
+  description = "talosctl apply-config mode for bare-metal nodes (auto | no_reboot | reboot | staged). Use \"reboot\" during a cluster rebuild so re-applied metal workers reboot and rejoin the new etcd. See docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot."
+  type        = string
+  default     = "auto"
+
+  validation {
+    condition     = contains(["auto", "no_reboot", "reboot", "staged"], var.metal_apply_mode)
+    error_message = "metal_apply_mode must be one of: auto, no_reboot, reboot, staged."
+  }
+}
+
 variable "cluster_name" {
   description = "Talos cluster name"
   type        = string

--- a/tf/modules/talos-metal/main.tf
+++ b/tf/modules/talos-metal/main.tf
@@ -15,5 +15,11 @@ resource "talos_machine_configuration_apply" "this" {
   node                        = var.ip_address
   config_patches              = var.config_patches
 
+  # "auto" (default) applies live and reboots only when a field requires it. A
+  # cluster rebuild re-applies byte-identical config, so "auto" is a no-op and
+  # the node never rejoins the new etcd -- set apply_mode="reboot" for rebuilds.
+  # docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot
+  apply_mode = var.apply_mode
+
   depends_on = [unifi_user.metal_client]
 }

--- a/tf/modules/talos-metal/variables.tf
+++ b/tf/modules/talos-metal/variables.tf
@@ -53,3 +53,20 @@ variable "config_patches" {
   type        = list(string)
   default     = []
 }
+
+# Apply mode for talos_machine_configuration_apply. Default "auto" reboots only
+# when a changed field requires it -- and is a no-op (no reboot) when the config
+# is byte-identical, which is what leaves metal workers orphaned after a cluster
+# re-bootstrap. Set to "reboot" (via metal_apply_mode) during a rebuild so a
+# re-applied metal node reboots and rejoins the new etcd. See
+# docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot.
+variable "apply_mode" {
+  description = "talosctl apply-config mode for the metal node: auto | no_reboot | reboot | staged"
+  type        = string
+  default     = "auto"
+
+  validation {
+    condition     = contains(["auto", "no_reboot", "reboot", "staged"], var.apply_mode)
+    error_message = "apply_mode must be one of: auto, no_reboot, reboot, staged."
+  }
+}

--- a/tf/nodes/cluster.tf
+++ b/tf/nodes/cluster.tf
@@ -45,6 +45,7 @@ module "cluster" {
   vms                    = var.virtual_machines
   metal_amd_nodes        = local.metal_amd_nodes
   metal_intel_nodes      = local.metal_intel_nodes
+  metal_apply_mode       = var.metal_apply_mode
   nodes_to_iso_ids       = local.nodes_to_iso_ids
   main_project_id        = local.main_project_id
   kms_project_id         = local.kms_project_id

--- a/tf/nodes/variables.tf
+++ b/tf/nodes/variables.tf
@@ -101,6 +101,22 @@ variable "metal_intel_nodes" {
   }))
 }
 
+# Normally "auto". Set to "reboot" (via the nodes-plan-apply workflow input, or
+# TF_VAR_metal_apply_mode) during a cluster rebuild so re-applied bare-metal
+# workers reboot and rejoin the freshly bootstrapped etcd instead of silently
+# staying orphaned on the old one. See
+# docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot.
+variable "metal_apply_mode" {
+  description = "talosctl apply-config mode for bare-metal nodes (auto | no_reboot | reboot | staged)"
+  type        = string
+  default     = "auto"
+
+  validation {
+    condition     = contains(["auto", "no_reboot", "reboot", "staged"], var.metal_apply_mode)
+    error_message = "metal_apply_mode must be one of: auto, no_reboot, reboot, staged."
+  }
+}
+
 variable "external_ip_cidr" {
   description = "External IP CIDR for the cluster"
   type        = string


### PR DESCRIPTION
Closes #547.

## Problem
`taint-vms` recreates the cluster (new VM disks + re-bootstrapped etcd) but leaves **bare-metal** workers orphaned. A metal worker's machine config derives from `talos_machine_secrets`, which a bootstrap recreate does **not** change — so re-applying it is byte-identical and `talos_machine_configuration_apply` under the default `apply_mode = "auto"` is a **no-op, no reboot**. The node keeps its old etcd/kubelet identity, its Node object is gone with the old etcd, kubelet loops `nodes "<name>" not found`, and `NodeRestriction` denies every pinned pod. This stranded **acebase** (GNSS base) ~35h → **RTK down** (2026-06-30→07-01).

A config *apply* is **not** a *reset*: PKI is preserved, so the node needs no new certs/reinstall — only a **reboot** to rejoin. `auto` won't reboot on unchanged config, so we force it.

## Fix (terraform-native — no `talosctl`/`local-exec` in the runner)
- **`apply_mode` / `metal_apply_mode` variable** (default `"auto"`), threaded root → `module.cluster` → both metal modules.
- **Order the metal (re)apply after `talos_machine_bootstrap`** (`depends_on`), so a `reboot` lands on the *new* etcd.
- **`taint-vms`**: taint each metal `talos_machine_configuration_apply`, **derived from `terraform state list`** (tracks `metal_{amd,intel}_nodes`) — replaces the stale hardcoded commented-out `lancer` line. Fixed the "Next steps" summary.
- **`nodes-plan-apply`**: new `metal_apply_mode` dispatch input → `TF_VAR_metal_apply_mode`. `"auto"` on PR/push/schedule (**no behavior change**), `"reboot"` for a rebuild.
- **Docs**: `docs/bare-metal-nodes.md` (`#rebuilds-metal-reapply--reboot`) documents the trap + runbook; referenced from both workflows, the tf module, and README.

## Rebuild runbook
1. `taint-vms` for the workspace (taints VMs, bootstrap, metal config-apply).
2. `nodes-plan-apply` with **apply** + **`metal_apply_mode = reboot`**.
3. Verify: `talosctl -n <ip> get members`, `kubectl get nodes`, pinned pods (`ntrip`, `mavproxy`) `Running`.

## Validation done
- `terraform fmt -check` ✅, `terraform validate` ✅ (only a pre-existing `talos-vm` deprecation warning).
- pre-commit ✅ incl. actionlint + check-yaml.

## Please confirm on tiles-**test** before prod (can't validate against real state from here)
1. **Provider reboots on tainted recreate with identical config** — I'm ~85% that `talos_machine_configuration_apply` issues the reboot RPC when `apply_mode="reboot"` and the resource is force-recreated even though config bytes are unchanged. The taint is what guarantees the resource re-runs; `apply_mode=reboot` is what makes that run reboot. Needs a real test-cluster rebuild to confirm.
2. **`depends_on = [talos_machine_bootstrap.this]`** on the metal modules is the one non-obvious ordering change — please eyeball the plan for unintended churn.
3. **Step-env → composite action**: `TF_VAR_metal_apply_mode` is set as step-level env on the `uses:` step, mirroring the existing `TF_VAR_proxmox_root_password` pattern.

Follow-up (separate issue): collapse taint + apply + bootstrap into one lifecycle workflow and flatten `bootstrap-cluster` into TF.