### PR TITLE
Don't let the sshd hook leak set -u into start.sh

### DIFF
--- a/containers/datascience-notebook-ssh/start-sshd.sh
+++ b/containers/datascience-notebook-ssh/start-sshd.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
-# Started by the Jupyter base image's start.sh, which runs every executable in
-# /usr/local/bin/before-notebook.d/ before launching the notebook server.
+# Sourced (not executed) by the Jupyter base image's run-hooks.sh for every
+# *.sh in /usr/local/bin/before-notebook.d/, so this runs *in* start.sh's shell
+# before the notebook server launches.
 #
 # The Dockerfile installs and `systemctl enable`s sshd, but the container has no
 # init system (the entrypoint is the notebook start script), so the enabled unit
 # never runs. Launch the daemon explicitly here. sshd forks to the background by
 # default, so this returns immediately and the notebook server starts normally.
-set -euo pipefail
+#
+# Because we're sourced, keep all strictness inside a subshell: `set -u` at the
+# top level would leak into start.sh, whose own `set -e` plus its reference to an
+# unset JUPYTER_DOCKER_STACKS_QUIET then aborts container startup. The trailing
+# `|| ...` keeps a broken sshd from taking the whole notebook down — it logs and
+# lets the notebook come up without SSH rather than crashlooping the pod.
+(
+	set -euo pipefail
 
-# Host keys are generated at build time; regenerate any that are missing (e.g.
-# if /etc/ssh was overlaid) so sshd can start.
-ssh-keygen -A
+	# Host keys are generated at build time; regenerate any that are missing (e.g.
+	# if /etc/ssh was overlaid) so sshd can start.
+	ssh-keygen -A
 
-# sshd needs its privilege-separation directory or it exits 255 with "Missing
-# privilege separation directory: /run/sshd". /run is a tmpfs that starts empty
-# and no init system creates it here, so make it ourselves — otherwise this hook
-# fails under `set -e` and takes the whole notebook container down with it.
-mkdir -p /run/sshd
+	# sshd exits 255 with "Missing privilege separation directory: /run/sshd" if
+	# the dir is absent. /run is a tmpfs that starts empty and no init system
+	# creates it here, so make it ourselves.
+	mkdir -p /run/sshd
 
-/usr/sbin/sshd
+	/usr/sbin/sshd
+) || echo "start-sshd.sh: WARNING: sshd failed to start; notebook continues without SSH" >&2


### PR DESCRIPTION
## Problem

After #546 fixed the crashloop, respawning the singleuser pod hit a new startup failure:

```
/usr/local/bin/start.sh: line 11: JUPYTER_DOCKER_STACKS_QUIET: unbound variable
```

The `before-notebook.d` hook is **sourced** by the Jupyter image's `run-hooks.sh` (`source "${f}"`), so its top-level `set -euo pipefail` executed in **start.sh's own shell**. `start.sh` runs under `set -e` but not `set -u`, and its `_log` references an unset `JUPYTER_DOCKER_STACKS_QUIET` with no default (line 11). The leaked `set -u` turned that into an unbound-variable error, and `set -e` aborted startup.

This is the third and final layer of the same SSH work: #538 started sshd, #546 gave it `/run/sshd`, and this stops the hook from breaking the shell it's sourced into.

## Fix

- Move all strictness into a **subshell** so no shell options leak into `start.sh`.
- Trail with `|| echo "WARNING…" >&2` so a genuinely broken sshd **logs and lets the notebook come up without SSH**, instead of crashlooping the pod.

## Verification

On the built `edge` image, reproducing `run-hooks.sh`'s `source` under `start.sh`'s `set -e`:
- a `_log`-style reference to the unset var **after** sourcing the hook no longer aborts (nounset didn't leak);
- sshd process runs, `/proc/net/tcp` shows LISTEN on :22, and a raw connect returns `SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.1`.

## Rollout

Merge rebuilds the image; respawn the singleuser server to pull it, then `ssh -p 22 <user>@10.0.129.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)