### PR TITLE
flight-analysis: lower memory request 2Gi -> 1Gi

### DIFF
--- a/tanka/environments/flight-analysis/main.jsonnet
+++ b/tanka/environments/flight-analysis/main.jsonnet
@@ -46,7 +46,7 @@ local serviceAccount = kServiceAccount.new('flight-analysis');
 local container =
   kContainer.new('runner', image='ghcr.io/symmatree/tiles/datascience-notebook-ssh:main')
   + kContainer.withCommand(['python', '/runner/runner.py'])
-  + kContainer.resources.withRequests({ cpu: '500m', memory: '2Gi' })
+  + kContainer.resources.withRequests({ cpu: '500m', memory: '1Gi' })
   + kContainer.resources.withLimits({ memory: '4Gi' })
   + kContainer.withVolumeMountsMixin([
     kVolumeMount.new('flights', '/mnt/flights'),


### PR DESCRIPTION
## Summary

- Lower container memory request from 2Gi to 1Gi (limit stays 4Gi)

## Why

2Gi request couldn't schedule on either worker node during first manual test run (wk-2 at 73% allocated, wk-3 at 96%). 1Gi fits comfortably; the 4Gi limit gives headroom if a large backlog of logs runs at once.

Implements coordinator#39 test plan item: first manual job run.