### PR TITLE
docs: document metal-rebuild reboot behavior + fix rebuild runbook link

### DIFF
--- a/.github/workflows/taint-vms.yaml
+++ b/.github/workflows/taint-vms.yaml
@@ -154,5 +154,5 @@ jobs:
             echo ""
             echo "**Next steps:**"
             echo "- Run **nodes-plan-apply** with **apply** for the workspace you tainted, and set **\`metal_apply_mode = reboot\`** so re-applied bare-metal workers reboot and rejoin the freshly bootstrapped etcd (a plain re-apply is a no-op and leaves them orphaned)."
-            echo "- See [docs/bare-metal-nodes.md](../blob/main/docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot) for the full rebuild runbook."
+            echo "- See [docs/bare-metal-nodes.md](https://github.com/symmatree/tiles/blob/main/docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot) for the full rebuild runbook."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/bare-metal-nodes.md
+++ b/docs/bare-metal-nodes.md
@@ -117,6 +117,8 @@ A config *apply* is not a *reset*. PKI is preserved across the recreate (both ap
 Routine applies (PR / push / daily schedule) leave `metal_apply_mode = "auto"`, so this is inert outside a deliberate rebuild. The same `reboot` knob is also the general way to push a machine-config change that needs a reboot to a metal node.
 
 > **apply-config modes** ([Talos v1.13](https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration)): `auto` reboots only if a changed field requires it; `no_reboot` fails if a reboot would be needed; `reboot` always reboots to apply; `staged` applies on next reboot. Changes Terraform apply cannot make at all (install disk, disk encryption, wiping state) need a **reset**, not an apply -- see [Wipe and reinstall](#3-wipe-and-reinstall-talos-on-the-same-machine).
+>
+> Why `reboot` works on unchanged config: in v1.13 machined's `ApplyConfiguration` REBOOT case persists the config and **unconditionally** sequences a reboot -- there is no config-diff short-circuit ([v1alpha1_server.go](https://github.com/siderolabs/talos/blob/v1.13.0/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go)). **Forward-compat:** the deprecated `REBOOT` gRPC mode is slated for removal on Talos `main` ("use AUTO or NO_REBOOT"), so **re-verify this mechanism when bumping `talos_version`** past 1.13.
 
 **Rebuild runbook**
 

--- a/docs/talos.md
+++ b/docs/talos.md
@@ -36,4 +36,5 @@ Bare-metal installers and ISO URLs use **metal** schematics: `metal_amd` (AMD) a
 ## Upgrading or rebuilding clusters
 
 - **VM replace:** Destroy targeted `proxmox_virtual_environment_vm` resources and `terraform apply` (see [README.md](../README.md#recreating-cluster)).
+- **Bare-metal rebuild:** Metal workers are not VMs and are not recreated by that flow. A re-apply of unchanged config is a no-op (no reboot), so a rebuild must run with `metal_apply_mode = reboot` or the node stays orphaned on the old etcd. See [bare-metal-nodes.md](bare-metal-nodes.md#rebuilds-metal-reapply--reboot).
 - **In-place OS upgrade:** Upstream procedure uses `talosctl upgrade` with the same installer image as in machine config; this repo usually drives version via Terraform and full VM refresh. See [Sidero upgrade docs](https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/lifecycle-management/upgrading-talos).


### PR DESCRIPTION
Docs-only follow-up to #547 / #551. No terraform or behavior change.

- **`docs/bare-metal-nodes.md`** — record that in v1.13 `machined`, an `ApplyConfiguration` REBOOT persists config and **unconditionally** reboots (no config-diff short-circuit), with the source ref; plus a forward-compat caveat that the deprecated `REBOOT` gRPC mode is being removed on Talos `main`, so re-verify on a `talos_version` bump.
- **`docs/talos.md`** — "Upgrading or rebuilding clusters" was silent on bare metal; add a bullet pointing at the reapply+reboot section.
- **`.github/workflows/taint-vms.yaml`** — the step-summary runbook link was relative (`../blob/main/...`) and doesn't resolve on an Actions run page; make it an absolute `github.com` URL.