### PR TITLE
feat(datascience-notebook-ssh): add playwright, LaTeX, and folium for PDF export

### DIFF
--- a/containers/datascience-notebook-ssh/Dockerfile
+++ b/containers/datascience-notebook-ssh/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY install-tools.ansible.yaml /tmp/install-tools.ansible.yaml
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 # Fix linuxbrew permissions because we're running as root.
 RUN ansible-playbook -v /tmp/install-tools.ansible.yaml -i localhost, --connection=local \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/datascience-notebook-ssh/install-tools.ansible.yaml
+++ b/containers/datascience-notebook-ssh/install-tools.ansible.yaml
@@ -227,6 +227,9 @@
           - stow
           - sudo
           - terraform
+          - texlive-fonts-recommended
+          - texlive-plain-generic
+          - texlive-xetex
           - tmux
           - tree
           - xdg-utils
@@ -288,8 +291,20 @@
           - pymavlink
           # Kubernetes Python client for cluster health notebooks.
           - kubernetes
+          # PDF export via headless Chromium (playwright provides the browser).
+          - nbconvert[webpdf]
+          # Interactive map tiles in flight analysis notebooks.
+          - folium
         executable: /opt/conda/bin/pip
         state: present
+
+    - name: Install Playwright browsers for webpdf export
+      shell: /opt/conda/bin/playwright install --with-deps chromium
+      environment:
+        PLAYWRIGHT_BROWSERS_PATH: /opt/playwright-browsers
+
+    - name: Allow all users to read/execute Playwright browsers
+      shell: chmod -R o+rx /opt/playwright-browsers
 
     - name: Install Homebrew packages
       become: false


### PR DESCRIPTION
## Summary

- `nbconvert[webpdf]` + `playwright` + Chromium: fixes the `ModuleNotFoundError: No module named 'playwright'` that blocks PDF generation in the flight-analysis CronJob (coordinator#39)
- `ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers` in Dockerfile so the install path is baked in; `chmod -R o+rx` makes it accessible to jovyan at runtime
- `texlive-xetex`, `texlive-fonts-recommended`, `texlive-plain-generic`: LaTeX PDF backend, useful for interactive notebooks and as a fallback
- `folium`: map tile library used in flight-analysis notebooks for path visualization

Without playwright, papermill succeeds but `jupyter nbconvert --to webpdf` fails, so `polisher.json` is never written, causing every log to re-run on every nightly job.

## Test plan

- [ ] Image build CI passes (playwright install + chromium download can be slow -- ~5 min extra)
- [ ] Manually trigger `build-datascience-notebook-ssh` workflow after merge
- [ ] Trigger a flight-analysis CronJob test run; confirm `.ipynb`, `.pdf`, and `polisher.json` all appear alongside a `.bin` log
- [ ] Run a second job; confirm freshness check skips already-processed logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9NpYjoEyPh7VitnUBaLso