### PR TITLE
Add lancer (Strix Halo) as AMD bare-metal worker in prod

### DIFF
--- a/containers/datascience-notebook-ssh/start-sshd.sh
+++ b/containers/datascience-notebook-ssh/start-sshd.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
-# Started by the Jupyter base image's start.sh, which runs every executable in
-# /usr/local/bin/before-notebook.d/ before launching the notebook server.
+# Sourced (not executed) by the Jupyter base image's run-hooks.sh for every
+# *.sh in /usr/local/bin/before-notebook.d/, so this runs *in* start.sh's shell
+# before the notebook server launches.
 #
 # The Dockerfile installs and `systemctl enable`s sshd, but the container has no
 # init system (the entrypoint is the notebook start script), so the enabled unit
 # never runs. Launch the daemon explicitly here. sshd forks to the background by
 # default, so this returns immediately and the notebook server starts normally.
-set -euo pipefail
+#
+# Because we're sourced, keep all strictness inside a subshell: `set -u` at the
+# top level would leak into start.sh, whose own `set -e` plus its reference to an
+# unset JUPYTER_DOCKER_STACKS_QUIET then aborts container startup. The trailing
+# `|| ...` keeps a broken sshd from taking the whole notebook down — it logs and
+# lets the notebook come up without SSH rather than crashlooping the pod.
+(
+	set -euo pipefail
 
-# Host keys are generated at build time; regenerate any that are missing (e.g.
-# if /etc/ssh was overlaid) so sshd can start.
-ssh-keygen -A
+	# Host keys are generated at build time; regenerate any that are missing (e.g.
+	# if /etc/ssh was overlaid) so sshd can start.
+	ssh-keygen -A
 
-# sshd needs its privilege-separation directory or it exits 255 with "Missing
-# privilege separation directory: /run/sshd". /run is a tmpfs that starts empty
-# and no init system creates it here, so make it ourselves — otherwise this hook
-# fails under `set -e` and takes the whole notebook container down with it.
-mkdir -p /run/sshd
+	# sshd exits 255 with "Missing privilege separation directory: /run/sshd" if
+	# the dir is absent. /run is a tmpfs that starts empty and no init system
+	# creates it here, so make it ourselves.
+	mkdir -p /run/sshd
 
-/usr/sbin/sshd
+	/usr/sbin/sshd
+) || echo "start-sshd.sh: WARNING: sshd failed to start; notebook continues without SSH" >&2

--- a/tf/nodes/prod.tfvars
+++ b/tf/nodes/prod.tfvars
@@ -77,7 +77,19 @@ deploy_synology_alloy = true
 deploy_proxmox_alloy  = true
 
 # Bare-metal workers (see docs/bare-metal-nodes.md)
-metal_amd_nodes = {}
+# MAC/IP from facts fables/Tiles/Lancer.md (GMKtec EVO X2, Ryzen AI Max+ 395,
+# Radeon 8060S / gfx1151, 128 GB). amdgpu firmware ships in the metal_amd
+# schematic; scheduling the iGPU to pods is follow-on work. Single NVMe
+# (nvme0n1, Lexar 2TB) so no disk selector needed.
+metal_amd_nodes = {
+  "lancer" = {
+    name        = "lancer"
+    type        = "worker"
+    mac_address = "84:47:09:75:89:a6"
+    ip_address  = "10.0.128.51"
+    taint       = ""
+  }
+}
 
 # MAC/IP from facts fables/kb/Computers/AceBase.md
 metal_intel_nodes = {


### PR DESCRIPTION
## What

Adds **lancer** to `metal_amd_nodes` in `tf/nodes/prod.tfvars`, joining it to the prod `tiles` cluster as an **untainted AMD bare-metal worker**.

Lancer is a GMKtec EVO X2 mini PC: Ryzen AI Max+ 395 (Strix Halo), Radeon 8060S iGPU (gfx1151, RDNA 3.5), 128 GB unified LPDDR5x. Details in facts `fables/Tiles/Lancer.md`.

## Details

- **IP/MAC/DNS conform to the existing UniFi client** — `10.0.128.51`, `84:47:09:75:89:a6`, `lancer.local.symmatree.com`. The metal module's `allow_existing = true` adopts the pre-existing client rather than recreating it.
- **GPU firmware layer is already covered.** The `metal_amd` schematic bundles `amdgpu` + `amdgpu-firmware` + `amd-ucode`, so firmware + kernel driver land with the install image. Talos 1.13.0 runs **Linux 6.18.33**, past the ≥6.18.4 gfx1151 stability threshold and ≥6.16.9 full-unified-memory threshold.
- **Scheduling the iGPU to pods is deliberate follow-on work** (device plugin / ROCm) — out of scope here, per "take it in layers."
- **No taint** — will revisit if the node gets flooded.
- **Single NVMe** (`nvme0n1`, Lexar 2 TB) confirmed via `talosctl get disks --insecure` in maintenance mode, so no disk-selector patch is needed.

## ⚠️ Destructive on apply

`terraform apply` runs `talos_machine_configuration_apply` against 10.0.128.51 and **installs Talos to `nvme0n1`, wiping the existing Windows 11 / WSL / ODM install** documented in the facts file. Lancer is already booted into the metal-amd ISO maintenance mode, so apply will proceed to disk install.

## Verify

From `tf/nodes/` (prod workspace, env vars per `tf/nodes/README.md`):

1. `terraform plan -var-file=prod.tfvars` — expect a new UniFi client (adopted) + `talos_machine_configuration_apply` for `module.cluster.module.talos-amd-metal["lancer"]`.
2. `terraform apply -var-file=prod.tfvars`.
3. `kubectl get nodes` shows `lancer` Ready; `talosctl -n 10.0.128.51 dmesg | grep amdgpu` confirms the iGPU driver bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)