### PR TITLE
Widen prod kubelet OOM-eviction margin (memory.available 100Mi->512Mi)

### DIFF
--- a/tf/modules/talos-cluster/nodes.tf
+++ b/tf/modules/talos-cluster/nodes.tf
@@ -25,6 +25,26 @@ locals {
     name       = var.control_plane_vip
     link       = var.control_plane_vip_link
   })
+
+  # Widen the within-node OOM safety margin: raise the kubelet hard-eviction
+  # threshold so the kubelet reclaims (evicts low-priority pods) before the
+  # kernel OOM-killer fires. Re-declares the default nodefs/imagefs thresholds
+  # so the extraConfig merge does not drop disk-pressure eviction. Empty list
+  # (no patch) when the knob is unset -- e.g. the test cluster keeps defaults.
+  eviction_patches = var.kubelet_eviction_memory_available == null ? [] : [yamlencode({
+    machine = {
+      kubelet = {
+        extraConfig = {
+          evictionHard = {
+            "memory.available"  = var.kubelet_eviction_memory_available
+            "nodefs.available"  = "10%"
+            "nodefs.inodesFree" = "5%"
+            "imagefs.available" = "15%"
+          }
+        }
+      }
+    }
+  })]
 }
 
 output "config_path" {
@@ -60,6 +80,7 @@ module "talos-vm" {
   config_patches = concat(
     [local.base_config_yaml],
     [local.common_patch_yaml],
+    local.eviction_patches,
     [yamlencode({
       "machine" = {
         "install" = { "image" = local.vm_install_image }
@@ -94,6 +115,7 @@ module "talos-amd-metal" {
   config_patches = concat(
     [local.base_config_yaml],
     [local.common_patch_yaml],
+    local.eviction_patches,
     [yamlencode({
       "machine" = {
         "install" = { "image" = local.metal_amd_install_image }
@@ -135,6 +157,7 @@ module "talos-intel-metal" {
   config_patches = concat(
     [local.base_config_yaml],
     [local.common_patch_yaml],
+    local.eviction_patches,
     [yamlencode({
       "machine" = {
         "install" = { "image" = local.metal_intel_install_image }

--- a/tf/modules/talos-cluster/variables.tf
+++ b/tf/modules/talos-cluster/variables.tf
@@ -152,3 +152,9 @@ variable "admin_user" {
   description = "Admin user email"
   type        = string
 }
+
+variable "kubelet_eviction_memory_available" {
+  description = "kubelet evictionHard `memory.available` threshold, applied to every node in the cluster. This is the free-memory margin the kubelet keeps so it evicts low-priority pods *before* the kernel OOM-killer fires (within-node OOM protection). null = leave kubelet defaults untouched (memory.available<100Mi). When set (e.g. \"512Mi\"), the nodefs/imagefs disk-eviction defaults are re-declared unchanged so the extraConfig merge does not drop disk-pressure eviction."
+  type        = string
+  default     = null
+}

--- a/tf/nodes/cluster.tf
+++ b/tf/nodes/cluster.tf
@@ -46,16 +46,18 @@ module "cluster" {
   metal_amd_nodes        = local.metal_amd_nodes
   metal_intel_nodes      = local.metal_intel_nodes
   metal_apply_mode       = var.metal_apply_mode
-  nodes_to_iso_ids       = local.nodes_to_iso_ids
-  main_project_id        = local.main_project_id
-  kms_project_id         = local.kms_project_id
-  gcp_region             = var.gcp_region
-  cluster_nfs_path       = var.cluster_nfs_path
-  datasets_nfs_path      = var.datasets_nfs_path
-  nfs_server             = var.nfs_server
-  seed_project_id        = var.seed_project_id
-  dns_zone_ad_local      = var.dns_zone_ad_local
-  dns_zone_local         = var.dns_zone_local
+
+  kubelet_eviction_memory_available = var.kubelet_eviction_memory_available
+  nodes_to_iso_ids                  = local.nodes_to_iso_ids
+  main_project_id                   = local.main_project_id
+  kms_project_id                    = local.kms_project_id
+  gcp_region                        = var.gcp_region
+  cluster_nfs_path                  = var.cluster_nfs_path
+  datasets_nfs_path                 = var.datasets_nfs_path
+  nfs_server                        = var.nfs_server
+  seed_project_id                   = var.seed_project_id
+  dns_zone_ad_local                 = var.dns_zone_ad_local
+  dns_zone_local                    = var.dns_zone_local
 }
 
 output "talosconfig" {

--- a/tf/nodes/prod.tfvars
+++ b/tf/nodes/prod.tfvars
@@ -4,6 +4,13 @@
 cluster_name = "tiles"
 cluster_code = "p"
 
+# Widen the kubelet within-node OOM safety margin on prod. The kubelet evicts
+# low-priority pods when free memory drops below this, before the kernel
+# OOM-killer fires. Prod-only: test.tfvars leaves it unset (Talos default
+# 100Mi). Context: facts fables/Tiles/tiles-host-instability.md (guest-level
+# wedge, tiles-wk-1, 2026-07-03).
+kubelet_eviction_memory_available = "512Mi"
+
 # Network configuration for tiles cluster (10.0.128.0/18 block)
 control_plane_vip = "10.0.128.10"
 external_ip_cidr  = "10.0.129.0/24"

--- a/tf/nodes/variables.tf
+++ b/tf/nodes/variables.tf
@@ -117,6 +117,12 @@ variable "metal_apply_mode" {
   }
 }
 
+variable "kubelet_eviction_memory_available" {
+  description = "kubelet evictionHard `memory.available` threshold for every node in the cluster -- the free-memory margin the kubelet keeps so it evicts before the kernel OOM-killer fires. null leaves Talos/kubelet defaults (100Mi). Set on resource-tight clusters (prod) to widen the OOM safety margin; leave unset on test."
+  type        = string
+  default     = null
+}
+
 variable "external_ip_cidr" {
   description = "External IP CIDR for the cluster"
   type        = string


### PR DESCRIPTION
## What

Adds a `kubelet_eviction_memory_available` knob to the `talos-cluster` module and sets it to **`512Mi`** on the **prod** cluster only. It raises the kubelet `evictionHard: memory.available` threshold from the Talos/kubelet default (100Mi) to 512Mi, so the kubelet evicts low-priority pods **before** the kernel OOM-killer fires — widening the within-node OOM safety margin.

Applied to **every prod node** (control-plane + VM workers + metal workers) via the shared `config_patches` in `nodes.tf`. The `evictionHard` block re-declares the default `nodefs`/`imagefs` disk-eviction thresholds so the Talos `extraConfig` merge does not silently drop disk-pressure eviction (the repo already relies on it — see the `disk_size_gb` comment in `talos-vm`).

**Test cluster is untouched:** the module variable defaults to `null` (no patch), and `test.tfvars` leaves it unset, so `tiles-test` keeps kubelet defaults. Dial the value per-cluster in tfvars (e.g. `256Mi`).

## Why

On 2026-07-03 `tiles-wk-1` wedged at the guest level (kubelet stopped posting, every node-local service timing out). Root cause was a **containerd-shim leak** (598 shims vs 3 sandboxes), which no eviction margin would have prevented — see `facts fables/Tiles/tiles-host-instability.md`. This change does **not** fix that; it is **defense-in-depth** for the *other* mode the same fleet is exposed to: memory pressure on the small (4–6 GB) prod workers driving a hard kernel OOM/thrash instead of a graceful kubelet eviction. The default 100Mi margin is far too thin on a 4 GB node for the kernel OOM-killer to lose the race to the kubelet.

## Tradeoff (intended)

Raising the hard-eviction threshold lowers `allocatable` by ~412Mi on every node (512 − 100). On the tight nodes that's ~10–13% of capacity; on wk-3 (~10 GB) it's ~4%. Since almost all pods are BestEffort/requestless, `allocatable` was not the binding constraint anyway — the real effect is *earlier, graceful* reclaim under pressure. This is the deliberate stability-for-density trade, prod-only.

## Apply / blast radius

`machine.kubelet.extraConfig` is a hot-applied kubelet-config change — Talos restarts the kubelet, **no node reboot expected**. Confirm on `terraform plan` against prod that the diff is limited to the kubelet `extraConfig` on each node and that no reboot/replace is triggered before applying.

## Validation

- `terraform fmt` clean; `terraform -chdir=tf/nodes validate` → Success (only the pre-existing `timeout_move_disk` deprecation warning).
- Not yet `plan`-verified against live prod (needs provider auth); please review the plan diff before apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
