### PR TITLE
Skip terraform refresh on PR-preview plans (1Password quota, #561)

### DIFF
--- a/.github/actions/terraform-plan-apply/action.yaml
+++ b/.github/actions/terraform-plan-apply/action.yaml
@@ -8,6 +8,15 @@ inputs:
     description: "Whether to apply the plan after creating it"
     required: false
     default: "false"
+  refresh:
+    description: >-
+      Whether terraform plan refreshes state (reads live resources). "false"
+      gives a cheap PR-preview plan against stored state (skips re-reading
+      managed onepassword_item resources -- saves 1Password SA quota, #561),
+      at the cost of not detecting out-of-band drift. "true" (default) does a
+      real reconcile: use it on post-merge/manual runs to catch drift.
+    required: false
+    default: "true"
   plan_file:
     description: "Path to the plan file to produce"
     required: true
@@ -41,8 +50,11 @@ runs:
       run: |
         set -euo pipefail
         mkdir -p "$(dirname "${TXT_OUTPUT_FILE}")"
+        if [ "${{ inputs.refresh }}" = "false" ]; then
+          echo "::notice title=Terraform::Plan ${{ inputs.workspace }} ran with -refresh=false (PR preview against stored state; NOT live drift -- run manually or wait for post-merge for a real reconcile)"
+        fi
         set +e
-        terraform plan -detailed-exitcode -lock-timeout=5m -input=false -var-file="${{ inputs.workspace }}.tfvars" -out="${PLAN_FILE}"
+        terraform plan -detailed-exitcode -lock-timeout=5m -input=false -refresh="${{ inputs.refresh }}" -var-file="${{ inputs.workspace }}.tfvars" -out="${PLAN_FILE}"
         PLAN_EXIT_CODE=$?
         set -e
         echo "Terraform plan exited with code: ${PLAN_EXIT_CODE}"

--- a/.github/workflows/nodes-plan-apply.yaml
+++ b/.github/workflows/nodes-plan-apply.yaml
@@ -220,6 +220,9 @@ jobs:
         with:
           workspace: "test"
           apply: ${{ steps.config.outputs.test_apply }}
+          # Cheap PR-preview plan (skip live refresh) to save 1Password SA
+          # quota (#561); real reconcile/drift on push/dispatch/schedule.
+          refresh: ${{ github.event_name != 'pull_request' }}
           plan_file: "${{ runner.temp }}/tfplan-nodes-test.bin"
           txt_output_file: "${{ runner.temp }}/txt-outputs/plan-nodes-test.txt"
 
@@ -239,6 +242,9 @@ jobs:
         with:
           workspace: "prod"
           apply: ${{ steps.config.outputs.prod_apply }}
+          # Cheap PR-preview plan (skip live refresh) to save 1Password SA
+          # quota (#561); real reconcile/drift on push/dispatch/schedule.
+          refresh: ${{ github.event_name != 'pull_request' }}
           plan_file: "${{ runner.temp }}/tfplan-nodes-prod.bin"
           txt_output_file: "${{ runner.temp }}/txt-outputs/plan-nodes-prod.txt"
 


### PR DESCRIPTION
Passes `-refresh=false` to `terraform plan` on **pull_request** events, and keeps the default `-refresh=true` on **push / workflow_dispatch / schedule**.

## Why

`nodes-plan-apply` plans test+prod on every event. The refresh phase re-reads every managed `onepassword_item` resource (9/workspace × 2 = 18 SA reads/run) just to detect drift. On a PR that's pure preview cost against the **1000/day** 1Password SA quota (#561).

## What changes

- **PR runs:** cheap preview against stored state — skips the 18 managed-resource refresh reads. Provider-config data sources (proxmox/cloudflare tokens, vault) are still read, because the providers are configured from them.
- **Post-merge / manual / scheduled runs:** unchanged — full `-refresh=true` reconcile, so drift is still surfaced. Run the workflow manually (workflow_dispatch) any time to force a live drift check.
- A `::notice` marks any plan that ran with `-refresh=false`, so a PR preview is never mistaken for live state.

## Tradeoff (by design)

A PR preview no longer reflects out-of-band drift in the managed 1Password items — it diffs against stored state. That's the intended split: cheap on the high-frequency PR path, accurate on the paths where it matters. Measured effect will show up in the #563 quota metering (expect PR-run Δ to drop by ~18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)