### PR TITLE
Fix alertmanager block clobbered in #557; enable Mimir mixin

### DIFF
--- a/charts/argocd-applications/values/mimir-values.yaml
+++ b/charts/argocd-applications/values/mimir-values.yaml
@@ -56,6 +56,19 @@ metaMonitoring:
     # Let the Alloy pipeline own the `cluster` label; null stops Mimir from
     # stamping its own (which would default to the release name "mimir").
     clusterLabel: null
+  # Deploy the chart's vendored Mimir mixin: dashboards + recording rules +
+  # alerts. Recording rules (cluster_job:cortex_*) feed the dashboards; Alloy's
+  # mimir.rules.kubernetes syncs the generated PrometheusRule into the ruler
+  # (tenant tiles). Job matchers are the microservices flavor and match our
+  # mimir/<component> labels. See docs/mimir.md.
+  dashboards:
+    enabled: true
+  prometheusRule:
+    enabled: true
+    mimirRules: true
+    mimirAlerts: true
+
+alertmanager:
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## 🔴 Regression fix (introduced by #557)

While enabling the Mimir mixin I found #557 had a bug: inserting the `metaMonitoring:` block **replaced the `alertmanager:` key and never restored it**. YAML-wise, the entire alertmanager config (resources, `zoneAwareReplication`, `statefulSet`, `terminationGracePeriodSeconds`, and the `alert-forward` apprise webhook sidecar) became ignored keys nested under `metaMonitoring:`.

**Live impact (verified in prod):** `mimir-alertmanager-0` went from **2/2 → 1/1** when #557 synced (~18h ago) — the `alert-forward` sidecar that forwards Alertmanager notifications to apprise was dropped. So Mimir alert notifications weren't being forwarded.

This PR restores `alertmanager:` as its own top-level key. My mistake in #557; caught it because I was editing the same block.

## Enable the Mimir mixin (the actual task)

Now that self-monitoring feeds `cortex_*` into the `tiles` tenant, turn on the chart's **vendored** mixin — no hand-maintained rules:

- `metaMonitoring.dashboards.enabled: true`
- `metaMonitoring.prometheusRule.{enabled, mimirRules, mimirAlerts}: true`

The recording rules emit `cluster_job:cortex_*` (what the dashboards query); Alloy's existing `mimir.rules.kubernetes` syncs the generated PrometheusRule into the ruler for tenant `tiles`. Verified the shipped rules use the **microservices** job matchers (`.*/(ingester.*|distributor.*|querier.*|…)`), which match our live `mimir/<component>` labels.

## Validation

`helm template` (mimir-distributed 6.0.5) with these values:
- alert-forward sidecar present in the alertmanager StatefulSet ✅
- 11 ServiceMonitors, **3 PrometheusRules**, 27 dashboard ConfigMaps ✅

**Post-merge checks:** alertmanager back to 2/2; `cluster_job:cortex_*` recording rules appear in the `tiles` tenant; Mimir dashboards render; `Mimir*` alerts show up in Alertmanager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)