### PR TITLE
Fix: restore alertmanager block clobbered in #557

### DIFF
--- a/charts/argocd-applications/values/mimir-values.yaml
+++ b/charts/argocd-applications/values/mimir-values.yaml
@@ -56,6 +56,8 @@ metaMonitoring:
     # Let the Alloy pipeline own the `cluster` label; null stops Mimir from
     # stamping its own (which would default to the release name "mimir").
     clusterLabel: null
+
+alertmanager:
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## Regression (introduced by #557)

#557 replaced the `alertmanager:` key when inserting `metaMonitoring:` and never restored it. The alertmanager config (resources, `zoneAwareReplication`, `statefulSet`, `terminationGracePeriodSeconds`, and the **`alert-forward` apprise webhook sidecar**) became ignored keys nested under `metaMonitoring:`.

**Live impact (verified):** `mimir-alertmanager-0` went **2/2 → 1/1** when #557 synced (~18h ago). The `alert-forward` sidecar that forwards Alertmanager notifications to apprise was dropped — Mimir alert notifications stopped being forwarded.

## Fix

Restore `alertmanager:` as its own top-level key. Fix-only — no feature changes.

## Rendered-diff confirmation

`helm template` (mimir-distributed 6.0.5), main vs this branch — the **entire** delta is inside the `mimir-alertmanager` StatefulSet:

```
- terminationGracePeriodSeconds: 900   ->  60
+ alert-forward sidecar container (apprise webhook) restored
- memory: 32Mi                         ->  85Mi
```

No other rendered object changes.

## Post-merge check

`mimir-alertmanager-0` back to 2/2 with the `alert-forward` container.

The Mimir mixin enablement (dashboards + rules + alerts) will follow as a separate PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)