### PR TITLE
Enable Mimir mixin: dashboards + recording rules + alerts

### DIFF
--- a/charts/argocd-applications/values/mimir-values.yaml
+++ b/charts/argocd-applications/values/mimir-values.yaml
@@ -56,6 +56,17 @@ metaMonitoring:
     # Let the Alloy pipeline own the `cluster` label; null stops Mimir from
     # stamping its own (which would default to the release name "mimir").
     clusterLabel: null
+  # Deploy the chart's vendored Mimir mixin: dashboards + recording rules +
+  # alerts. Recording rules (cluster_job:cortex_*) feed the dashboards; Alloy's
+  # mimir.rules.kubernetes syncs the generated PrometheusRule into the ruler
+  # (tenant tiles). Job matchers are microservices-flavor and match our live
+  # mimir/<component> labels. See docs/mimir.md.
+  dashboards:
+    enabled: true
+  prometheusRule:
+    enabled: true
+    mimirRules: true
+    mimirAlerts: true
 
 alertmanager:
   resources:


### PR DESCRIPTION
Now that self-monitoring lands `cortex_*` in the `tiles` tenant (#557), turn on the chart's **vendored** Mimir mixin — no hand-maintained rules or alerts.

## Changes (`mimir-values.yaml`)
- `metaMonitoring.dashboards.enabled: true`
- `metaMonitoring.prometheusRule.{enabled, mimirRules, mimirAlerts}: true`

The recording rules emit `cluster_job:cortex_*` (what the dashboards query); Alloy's existing `mimir.rules.kubernetes` syncs the generated PrometheusRule into the ruler for tenant `tiles`. Verified the shipped rules use **microservices** job matchers (`.*/(ingester.*|distributor.*|querier.*|…)`), which match our live `mimir/<component>` labels.

## Rendered diff vs main
- +27 dashboard ConfigMaps, +3 PrometheusRules
- alertmanager `alert-forward` sidecar unchanged

## Post-merge (after promotion + Argo hard-refresh)
- `cluster_job:cortex_*` recording rules appear in the `tiles` tenant
- Mimir dashboards render; `Mimir*` alerts show in Alertmanager
- Note: promoted values changes may need an Argo hard-refresh to take (moved-tag resolution caching) — same as the #567 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)