### PR TITLE
Wire the mounted SSH key into sshd's AuthorizedKeysFile

### DIFF
--- a/containers/datascience-notebook-ssh/sshd_config
+++ b/containers/datascience-notebook-ssh/sshd_config
@@ -2,6 +2,12 @@ Include /etc/ssh/sshd_config.d/*.conf
 
 PermitRootLogin no
 PasswordAuthentication no
+# The authorized key comes from the jupyterhub-ssh-key 1Password item, mounted
+# at /mnt/keys/authorized_keys. Nothing populates any user's ~/.ssh, and sshd's
+# StrictModes refuses to read it straight from the world-writable (1777) secret
+# mount dir, so start-sshd.sh copies it to this root-owned path. Absolute path
+# applies to every login user (e.g. jovyan; root login is denied above).
+AuthorizedKeysFile /etc/ssh/authorized_keys
 KbdInteractiveAuthentication no
 UsePAM yes
 X11Forwarding yes

--- a/containers/datascience-notebook-ssh/start-sshd.sh
+++ b/containers/datascience-notebook-ssh/start-sshd.sh
@@ -25,5 +25,12 @@
 	# creates it here, so make it ourselves.
 	mkdir -p /run/sshd
 
+	# The 1Password-managed key is mounted at /mnt/keys/authorized_keys, but its
+	# secret-mount dir is world-writable (1777) so sshd's StrictModes refuses to
+	# read authorized_keys from there. Copy it to the root-owned path sshd is
+	# configured to trust (AuthorizedKeysFile in sshd_config). This hook runs as
+	# root during start.sh setup, before the drop to jovyan.
+	install -m 0644 /mnt/keys/authorized_keys /etc/ssh/authorized_keys
+
 	/usr/sbin/sshd
 ) || echo "start-sshd.sh: WARNING: sshd failed to start; notebook continues without SSH" >&2


### PR DESCRIPTION
## Problem

With sshd finally running (#538 → #546 → #553), pubkey auth as `jovyan` is still rejected — sshd never finds the authorized key:

- The `jupyterhub-ssh-key` 1Password item mounts its public key at `/mnt/keys/authorized_keys`.
- But `AuthorizedKeysFile` was sshd's default `~/.ssh/authorized_keys`, nothing populates `jovyan`'s `~/.ssh`, and `PermitRootLogin no`.
- Pointing `AuthorizedKeysFile` directly at `/mnt/keys/authorized_keys` **also** fails: the k8s secret mount dir is world-writable (`drwxrwxrwt`, 1777), so `StrictModes` refuses it:
  ```
  Authentication refused: bad ownership or modes for directory /mnt/keys
  ```

## Fix

Rather than disable `StrictModes` (a real security loosening), copy the mounted key into a **root-owned** path sshd will trust. `start-sshd.sh` already runs as root during `start.sh` setup, so it `install`s `/mnt/keys/authorized_keys` → `/etc/ssh/authorized_keys`, and `sshd_config` sets `AuthorizedKeysFile /etc/ssh/authorized_keys`.

## Verification

On the built `edge` image with the real `ssh-secret` mounted:
- the copied `/etc/ssh/authorized_keys` (root:root 0644) passes `StrictModes`;
- a loopback `ssh jovyan@127.0.0.1` authenticates — `Accepted publickey for jovyan`, lands in `/home/jovyan`.

## Rollout

Final rebuild in this SSH series. Merge rebuilds the image; respawn the singleuser server, then `ssh jovyan@notebook-ssh.tiles.symmatree.com` (no `-p 22`; key from the `jupyterhub-ssh-key` 1Password item) should finally get a shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)