### PR TITLE
fix(flight-analysis): strip .pdf suffix before passing to nbconvert --output

### DIFF
--- a/tanka/environments/flight-analysis/runner.py
+++ b/tanka/environments/flight-analysis/runner.py
@@ -80,7 +80,7 @@ def process(bin_path: Path, notebook_path: Path, notebook_sha: str) -> None:
         [
             "jupyter", "nbconvert", "--to", "webpdf",
             "--no-input",
-            "--output", str(out_pdf),
+            "--output", str(out_pdf.with_suffix("")),
             str(out_ipynb),
         ],
         check=True,


### PR DESCRIPTION
## Summary

`nbconvert --to webpdf` always appends `.pdf` to whatever path you pass via `--output`. The runner was passing the full intended output path (e.g. `flight-analysis-2026-06-10-20-44-03.pdf`), causing nbconvert to write `flight-analysis-2026-06-10-20-44-03.pdf.pdf`. The runner then fails when trying to read `flight-analysis-2026-06-10-20-44-03.pdf` to write `polisher.json`.

Fix: pass `out_pdf.with_suffix("")` so nbconvert receives the bare stem and appends `.pdf` itself.

Found during first successful test run after playwright was added (coordinator#39) -- papermill and PDF generation both worked, but polisher.json was still not being written due to this error.

## Test plan

- [ ] Merge + ArgoCD sync (no image rebuild needed -- runner.py is in a ConfigMap)
- [ ] Trigger manual job; confirm `.ipynb`, `.pdf`, and `polisher.json` all appear
- [ ] Second run confirms freshness check skips already-processed logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9NpYjoEyPh7VitnUBaLso