### PR TITLE
Pin lancer install disk + wipe so Talos actually installs

### DIFF
--- a/tf/nodes/patches/lancer-install-disk.yaml
+++ b/tf/nodes/patches/lancer-install-disk.yaml
@@ -1,0 +1,10 @@
+# Lancer (GMKtec EVO X2) has a single 2TB Lexar NVMe (nvme0n1) that shipped
+# with Windows. The shared install config sets no disk selector, so the first
+# config-apply (run 28708501422) was accepted but the node never installed --
+# it's still in maintenance with the Windows GPT intact. Pin the install disk
+# to the only disk it has, and wipe it (defaults true, set explicitly so it's
+# clear this overwrites Windows). See docs/bare-metal-nodes.md.
+machine:
+  install:
+    disk: /dev/nvme0n1
+    wipe: true

--- a/tf/nodes/prod.tfvars
+++ b/tf/nodes/prod.tfvars
@@ -80,14 +80,16 @@ deploy_proxmox_alloy  = true
 # MAC/IP from facts fables/Tiles/Lancer.md (GMKtec EVO X2, Ryzen AI Max+ 395,
 # Radeon 8060S / gfx1151, 128 GB). amdgpu firmware ships in the metal_amd
 # schematic; scheduling the iGPU to pods is follow-on work. Single NVMe
-# (nvme0n1, Lexar 2TB) so no disk selector needed.
+# (nvme0n1, Lexar 2TB, shipped with Windows) -- the install patch pins that
+# disk + wipe so Talos actually installs (first apply left it in maintenance).
 metal_amd_nodes = {
   "lancer" = {
-    name        = "lancer"
-    type        = "worker"
-    mac_address = "84:47:09:75:89:a6"
-    ip_address  = "10.0.128.51"
-    taint       = ""
+    name                   = "lancer"
+    type                   = "worker"
+    mac_address            = "84:47:09:75:89:a6"
+    ip_address             = "10.0.128.51"
+    taint                  = ""
+    machine_config_patches = ["patches/lancer-install-disk.yaml"]
   }
 }
 


### PR DESCRIPTION
## Why

Lancer's first config-apply (CI run 28708501422, 14:01 today) was **accepted** but the node **never installed** — it's still in Talos `maintenance` mode with the original **Windows GPT intact** on its only disk (`nvme0n1`, 2 TB Lexar). The shared install config sets no `disk`/`diskSelector`, so Talos didn't install onto the occupied disk, and `talos_machine_configuration_apply` returns in 0s without waiting, so the CI apply looked green.

## What

Adds a per-node `machine_config_patch` (mirrors the `acebase-gnss.yaml` mechanism) pinning:

```yaml
machine:
  install:
    disk: /dev/nvme0n1
    wipe: true   # defaults true; explicit so it's clear this overwrites Windows
```

Wiring it into lancer's `metal_amd_nodes` entry via `machine_config_patches`. Changing `config_patches` makes Terraform re-apply the config-apply on the next prod apply, re-triggering the install **with a target disk** this time.

## This is the experiment we agreed on

It converts the guess into a result: on apply, lancer either **installs** (confirming the missing disk selector was the blocker) or boots far enough to finally surface a **readable** failure. ⚠️ It **wipes Windows** on `nvme0n1` — the irreversible step already signed off.

## After merge

- `terraform validate` passes.
- On the prod apply, watch the node leave maintenance and install.
- Boot note: the USB ISO (`sr0`) is still inserted. Our schematic drops `talos.halt_if_installed`, so the ISO should hand off to the disk install after install rather than re-entering maintenance — if it doesn't, pull the USB / set BIOS boot order to the Lexar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)