### PR TITLE
Pin jupyterhub singleuser to lancer (prod)

### DIFF
--- a/charts/jupyterhub/values-tiles.yaml
+++ b/charts/jupyterhub/values-tiles.yaml
@@ -1,1 +1,10 @@
 # Per-cluster overrides for tiles (prod). Add overrides here as needed.
+
+# Pin the interactive singleuser to lancer (128 GB metal): its image unpacks in
+# containerd (podruntime/runtime) at node level -- not bounded by any pod limit --
+# so it needs a node that can absorb the transient. Prod-only (test has no lancer).
+# Context: facts fables/Tiles/tiles-host-instability.md (T-B1), issue #576.
+jupyterhub:
+  singleuser:
+    nodeSelector:
+      kubernetes.io/hostname: lancer


### PR DESCRIPTION
## What

Adds a prod-only `nodeSelector` pinning the jupyterhub **singleuser** to **lancer** (128 GB metal):

```yaml
# charts/jupyterhub/values-tiles.yaml
jupyterhub:
  singleuser:
    nodeSelector:
      kubernetes.io/hostname: lancer
```

Prod-only (in `values-tiles.yaml`, not the shared `values.yaml`) because the test cluster has no lancer.

## Why

The interactive datascience image (~4.1 GiB stored) is pulled+unpacked by the **CRI containerd** (`podruntime/runtime` cgroup) at the **node level** — before the pod's containers run and *outside* any pod cgroup. So **no pod request/limit bounds it** (and we don't want a limit — it's a full interactive toolset by design). On the tight 5–6 GB g2 workers, that transient (containerd cgroup peaked ~3.6 GiB, mostly reclaimable cache but reclaim-protected) drove node memory pressure and made the Talos OOM manager SIGKILL unrelated pods (grafana, mimir-ingester, kafka…).

The scheduler can't help either — it places by pod *requests*, and there's no request that models the unpack transient. So placement is the fix: put it on the one node that can absorb it.

## Notes / follow-ups

- Hard pin (`kubernetes.io/hostname: lancer`): won't schedule if lancer is down — acceptable ("no notebook when lancer's down" beats "wedges a prod node"). If we add more big nodes later, switch to a `heavy-unpack-ok` label + affinity.
- **#576** — expose the containerd cgroup to Mimir so the unpack spike becomes graphable/alertable (currently only visible via `talosctl cgroups`).
- Full write-up: `facts fables/Tiles/tiles-host-instability.md` (T-B1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)