### PR TITLE
Declare lancer taint in tf (heavy:PreferNoSchedule) + per-node taint_effect

### DIFF
--- a/charts/jupyterhub/values-tiles.yaml
+++ b/charts/jupyterhub/values-tiles.yaml
@@ -1,13 +1,14 @@
 # Per-cluster overrides for tiles (prod).
 
 # lancer (128 GB metal) is reserved for memory-intensive / big-image workloads
-# via the taint `dedicated=heavy:NoSchedule`, so routine workload stays on
-# wk-1/2/3 and lancer's headroom is kept free for notebooks / ODM. The singleuser
-# belongs on lancer -- its ~4 GB image unpacks in containerd (podruntime/runtime)
-# at node level, not bounded by any pod limit (see facts fables/Tiles/
-# tiles-host-instability.md T-B1, issue #576) -- so it needs BOTH the nodeSelector
-# (put it there) and the toleration (get past the taint). Prod-only (test has no
-# lancer). NB: durable taint should live in tf (metal_amd_nodes.lancer.taint).
+# via a soft taint `dedicated=heavy:PreferNoSchedule` (declared in tf:
+# metal_amd_nodes.lancer.taint / .taint_effect), so routine workload prefers
+# wk-1/2/3 while lancer stays free for notebooks / ODM but still takes overflow.
+# The singleuser belongs on lancer -- its ~4 GB image unpacks in containerd
+# (podruntime/runtime) at node level, not bounded by any pod limit (see facts
+# fables/Tiles/tiles-host-instability.md T-B1, issue #576) -- so it gets the
+# nodeSelector (put it there) plus a matching toleration. Prod-only (test has no
+# lancer).
 jupyterhub:
   singleuser:
     nodeSelector:
@@ -16,4 +17,4 @@ jupyterhub:
       - key: dedicated
         operator: Equal
         value: heavy
-        effect: NoSchedule
+        effect: PreferNoSchedule

--- a/tf/modules/talos-cluster/nodes.tf
+++ b/tf/modules/talos-cluster/nodes.tf
@@ -126,7 +126,7 @@ module "talos-amd-metal" {
       "machine" = {
         "kubelet" = {
           "extraArgs" = {
-            "register-with-taints" = "dedicated=${each.value.taint}:NoSchedule"
+            "register-with-taints" = "dedicated=${each.value.taint}:${each.value.taint_effect}"
           }
         }
       }
@@ -168,7 +168,7 @@ module "talos-intel-metal" {
       "machine" = {
         "kubelet" = {
           "extraArgs" = {
-            "register-with-taints" = "dedicated=${each.value.taint}:NoSchedule"
+            "register-with-taints" = "dedicated=${each.value.taint}:${each.value.taint_effect}"
           }
         }
       }

--- a/tf/modules/talos-cluster/variables.tf
+++ b/tf/modules/talos-cluster/variables.tf
@@ -31,6 +31,7 @@ variable "metal_amd_nodes" {
     mac_address            = string
     ip_address             = string
     taint                  = string
+    taint_effect           = optional(string, "NoSchedule")
     machine_config_patches = optional(list(string), [])
   }))
 }
@@ -43,6 +44,7 @@ variable "metal_intel_nodes" {
     mac_address            = string
     ip_address             = string
     taint                  = string
+    taint_effect           = optional(string, "NoSchedule")
     machine_config_patches = optional(list(string), [])
   }))
   default = {}

--- a/tf/nodes/prod.tfvars
+++ b/tf/nodes/prod.tfvars
@@ -95,7 +95,8 @@ metal_amd_nodes = {
     type                   = "worker"
     mac_address            = "84:47:09:75:89:a6"
     ip_address             = "10.0.128.51"
-    taint                  = ""
+    taint                  = "heavy"
+    taint_effect           = "PreferNoSchedule"
     machine_config_patches = ["patches/lancer-install-disk.yaml"]
   }
 }

--- a/tf/nodes/variables.tf
+++ b/tf/nodes/variables.tf
@@ -85,6 +85,7 @@ variable "metal_amd_nodes" {
     mac_address            = string
     ip_address             = string
     taint                  = string
+    taint_effect           = optional(string, "NoSchedule")
     machine_config_patches = optional(list(string), [])
   }))
 }
@@ -97,6 +98,7 @@ variable "metal_intel_nodes" {
     mac_address            = string
     ip_address             = string
     taint                  = string
+    taint_effect           = optional(string, "NoSchedule")
     machine_config_patches = optional(list(string), [])
   }))
 }


### PR DESCRIPTION
## What

- Add an optional per-node **`taint_effect`** (default `NoSchedule`) to the metal node object types and wire it into `register-with-taints`, which was hardcoded to `:NoSchedule`.
- Declare **lancer** with `taint = "heavy"`, `taint_effect = "PreferNoSchedule"` so a rebuild restores the same taint.
- Hard-pin the jupyterhub singleuser to lancer (`nodeSelector`) and align its toleration to the soft taint; document why.

acebase's `taint = "gnss"` is unchanged — it inherits the `NoSchedule` default.

## Why soft (`PreferNoSchedule`) for the node, hard pin for the notebook

lancer (128 GB metal) exists for memory-intensive / big-image jobs — notebooks, ODM — whose image unpack balloons the **containerd** cgroup at node level, unbounded by any pod request/limit (see `facts fables/Tiles/tiles-host-instability.md` T-B1, #576). Placement, not a pod limit, is the lever.

- A hard `NoSchedule` on the node would wall lancer off and leave it idle.
- With no taint, the scheduler consolidates routine workload onto the big empty node, defeating the point of spreading across the cheap nodes.

`PreferNoSchedule` threads it: routine stays spread on wk-1/2/3, lancer stays free for big jobs but still takes overflow.

The notebook itself is **hard-pinned** to lancer via `nodeSelector` (a required constraint) — it schedules on lancer or stays **Pending**, never on another node. That's intended: its image would OOM any of the small nodes, so Pending is the correct outcome, not something to route around.

## Rollout note

The node taint is soft: it only biases **new** scheduling decisions — it does **not** evict or move pods already running on lancer. The one cluster-visible effect of this PR is that a **rebuild restores the taint** (`register-with-taints` is applied at kubelet registration); it's the declarative twin of the taint already live on the running node. Rebalancing the pods currently bin-packed onto lancer is a separate step (recreate them so they reschedule off it); the notebook stays put either way.

Independent of #578 (already merged); touches no other in-flight branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)