### PR TITLE
notebook image: add jupyter-collaboration (RTC)

### DIFF
--- a/containers/datascience-notebook-ssh/install-tools.ansible.yaml
+++ b/containers/datascience-notebook-ssh/install-tools.ansible.yaml
@@ -283,6 +283,7 @@
         state: present
 
     - name: Install notebook analysis Python packages
+      tags: [notebook-pip]
       pip:
         name:
           # Offline notebook execution and parameter injection.
@@ -295,6 +296,11 @@
           - nbconvert[webpdf]
           # Interactive map tiles in flight analysis notebooks.
           - folium
+          # Real-time collaboration: shared kernel + live co-editing so an agent
+          # (or a second person) can drive a notebook against the running kernel and
+          # have edits/outputs show up without a reload. Needs a server restart to
+          # activate; 3.x matches JupyterLab 4.4 in this image's base tag.
+          - jupyter-collaboration>=3,<4
         executable: /opt/conda/bin/pip
         state: present
 


### PR DESCRIPTION
Adds `jupyter-collaboration` (>=3,<4, matching JupyterLab 4.4 in the base tag) to the `datascience-notebook-ssh` install playbook, and tags the pip task `notebook-pip` so it can be run in isolation.

## Why
Enables **real-time collaboration** on notebooks: a shared kernel + live co-editing, so an agent (or a second person) can drive a notebook against the running kernel and have edits/outputs appear **without a reload** — instead of cold-writing the `.ipynb` and forcing a reload every iteration.

## Activation
Needs a fresh server on an image built with this change:
- the server loads the collaboration extension only at **startup**, and
- `/opt/conda` is an ephemeral overlay layer, so a live `pip install` does **not** survive a pod restart.

So: merge → CI builds the new `datascience-notebook-ssh` image → deploy → restart the singleuser server → RTC live and persistent.

## Verification
Ran the tagged task live (`ansible-playbook install-tools.ansible.yaml --tags notebook-pip`): installs `jupyter-collaboration 3.1.2`; both extensions register enabled — server `jupyter_server_ydoc` and lab `@jupyter/collaboration-extension`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)