### PR TITLE
jupyterhub: bump singleuser image to sha-a8d3e40 (RTC)

### DIFF
--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -87,7 +87,7 @@ jupyterhub:
       # IfNotPresent still fetches genuinely new builds (the tag changes) without
       # re-pulling an unchanged image. Roll forward by bumping this to the newer
       # sha-<...> tag from the build-datascience-notebook-ssh run.
-      tag: sha-0e2a461
+      tag: sha-a8d3e40
       pullPolicy: IfNotPresent
     storage:
       # Static shared NFS volume (templates/home-nfs.yaml) instead of a dynamic


### PR DESCRIPTION
Rolls the `datascience-notebook-ssh` singleuser pin forward to `sha-a8d3e40` — the build from #586 (add `jupyter-collaboration`). Once deployed and the server is restarted, the singleuser environment comes up with **real-time collaboration** active.

- One-line change in `charts/jupyterhub/values.yaml` (`sha-0e2a461` → `sha-a8d3e40`).
- Depends on the `build-datascience-notebook-ssh` run for a8d3e40 finishing and pushing `sha-a8d3e40` to GHCR (in progress at PR time).
- Activation: after this deploys, restart the singleuser server to pull the new image and load the collaboration extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)