### PR TITLE
jupyterhub: run notebook as NB_UID 1024 to match NFS squash

### DIFF
--- a/containers/datascience-notebook-ssh/Dockerfile
+++ b/containers/datascience-notebook-ssh/Dockerfile
@@ -5,6 +5,16 @@ FROM $BASE_IMAGE:$BASE_TAG
 
 USER root
 
+# Bake the notebook user's uid to the cluster NFS export's all-squash target
+# (1024 = the raconteur NAS admin uid) so home/repo ownership is consistent and
+# git's ownership check passes without a safe.directory workaround. gid stays
+# 100 (users), which is what the export preserves. ENV NB_UID must match, or
+# docker-stacks start.sh resets jovyan back to 1000 at runtime. The base env
+# (/opt/conda) stays group-writable via gid 100, so installs still work without
+# a chown. See home-skel/AGENTS.md.
+RUN usermod -u 1024 jovyan && chown -R 1024:100 /home/jovyan
+ENV NB_UID=1024
+
 RUN apt-get update \
     && apt-get dist-upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -18,7 +28,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 # Fix linuxbrew permissions because we're running as root.
 RUN ansible-playbook -v /tmp/install-tools.ansible.yaml -i localhost, --connection=local \
     && rm -rf /var/lib/apt/lists/* \
-    && chown -R 1000:100 /home/linuxbrew
+    && chown -R 1024:100 /home/linuxbrew
 
 COPY fix-permissions /usr/local/bin/fix-permissions
 RUN chmod a+rx /usr/local/bin/fix-permissions
@@ -33,3 +43,10 @@ RUN systemctl enable ssh
 # before-notebook.d/ before starting the notebook server; start sshd there.
 COPY start-sshd.sh /usr/local/bin/before-notebook.d/start-sshd.sh
 RUN chmod a+rx /usr/local/bin/before-notebook.d/start-sshd.sh
+
+# Home is an NFS mount that masks anything baked at /home/jovyan, so stage the
+# home-dir docs at an unmasked path and copy them in via a before-notebook.d
+# hook at startup. See home-skel/AGENTS.md.
+COPY home-skel/AGENTS.md /opt/home-skel/AGENTS.md
+COPY seed-home-docs.sh /usr/local/bin/before-notebook.d/seed-home-docs.sh
+RUN chmod a+rx /usr/local/bin/before-notebook.d/seed-home-docs.sh

--- a/containers/datascience-notebook-ssh/home-skel/AGENTS.md
+++ b/containers/datascience-notebook-ssh/home-skel/AGENTS.md
@@ -1,0 +1,53 @@
+# Working in this JupyterHub home
+
+Orientation for anyone -- human or coding agent -- working in this notebook
+environment on the tiles cluster.
+
+## What this is
+
+A JupyterHub single-user server (image `datascience-notebook-ssh`, based on
+jupyter/docker-stacks). Your home directory is a static NFS volume served from
+the `raconteur` NAS. That NFS export squashes every client write to a single uid
+(1024, the NAS `admin` account), so files here show owner `1024` -- and the
+notebook process is built to run as uid `1024` to match, which is why git and
+other ownership-sensitive tools work without a `safe.directory` workaround.
+
+Only your home (and the shared `datasets/` mount) persist. The rest of the
+container filesystem is disposable and resets when the pod restarts.
+
+## Source of truth (edit these, not the running container)
+
+- Image build (Dockerfile):
+  https://github.com/symmatree/tiles/blob/main/containers/datascience-notebook-ssh/Dockerfile
+- Baked dependencies (Ansible playbook):
+  https://github.com/symmatree/tiles/blob/main/containers/datascience-notebook-ssh/install-tools.ansible.yaml
+- JupyterHub deployment (image tag, singleuser config, NB_UID):
+  https://github.com/symmatree/tiles/blob/main/charts/jupyterhub/values.yaml
+- NFS home volume:
+  https://github.com/symmatree/tiles/blob/main/charts/jupyterhub/templates/home-nfs.yaml
+
+## Changing dependencies
+
+The pattern is: test at runtime, then bake it in so it survives a restart.
+
+1. Test in the running container. `pip install <pkg>` writes into the base env
+   (group-writable via gid 100, so no sudo needed); `sudo pip install` and
+   `sudo apt-get install` also work (sudo is granted). Iterate until it works.
+   These runtime installs are disposable -- they vanish on pod restart.
+2. Bake it into the image so it sticks: add the dependency to the Ansible
+   playbook (link above) -- Python packages to the pip task, system packages to
+   the apt task -- and open a PR to the `tiles` repo.
+3. Ship it: merging triggers the image build workflow, which pushes a new
+   `sha-<short>` tag. Bump `singleuser.image.tag` in the JupyterHub
+   `values.yaml` to that tag; ArgoCD deploys it.
+
+This is the same discipline as committing a working experiment out of a
+disposable scratch layer into the base -- iterate in the throwaway space, then
+promote the result into source.
+
+## Note
+
+This file is generated from the image (staged at `/opt/home-skel/AGENTS.md` and
+copied in on each pod start), so local edits here are overwritten on restart.
+Edit the source in the repo:
+https://github.com/symmatree/tiles/blob/main/containers/datascience-notebook-ssh/home-skel/AGENTS.md

--- a/containers/datascience-notebook-ssh/seed-home-docs.sh
+++ b/containers/datascience-notebook-ssh/seed-home-docs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Seed home-directory docs into the user's home.
+#
+# /home/${NB_USER} is an NFS mount that masks anything baked into the image at
+# that path, so the docs are staged at /opt/home-skel and copied in here. The
+# Jupyter base image runs every executable in before-notebook.d/ on each start,
+# so this refreshes the copy every time -- the doc always matches the running
+# image. Edit the source in the repo, not the copy in the home dir.
+#
+# Best-effort: a failure here must never stop the notebook from starting.
+set -euo pipefail
+
+dest="/home/${NB_USER:-jovyan}"
+src="/opt/home-skel/AGENTS.md"
+
+if [ -d "${dest}" ] && [ -f "${src}" ]; then
+	if cp -f "${src}" "${dest}/AGENTS.md"; then
+		echo "seed-home-docs.sh: refreshed ${dest}/AGENTS.md"
+	else
+		echo "seed-home-docs.sh: WARNING: failed to seed AGENTS.md; continuing" >&2
+	fi
+fi


### PR DESCRIPTION
## Problem

The singleuser home is a static NFS volume on `raconteur`, and that export **all-squashes every client write to uid 1024** (the NAS `admin` account; gid 100 is preserved). The notebook ran as `NB_UID=1000`, so home files were owned `1024` while the process was `1000` -- which trips git's dubious-ownership guard. That had been papered over with a global `safe.directory = *` in the stowed `~/.gitconfig`.

**Proven, not inferred:** a file written by uid 1000 into the NFS home lands owned `1024:100`. A non-root write being remapped confirms it's `all_squash`, not `root_squash`.

## Why not just change the squash

One shared export backs `jupyterhub-home`, `loki-data`, `mimir-data`, and `datasets` (all subdirs of the one parent share). The squash exists so pods with heterogeneous uids can all write it; removing it would strand the existing 1024-owned data for Loki/Mimir/etc. So the fix belongs on the **client uid**, not the export.

## Change

Match the notebook uid to the squash target, at **build time** (a runtime `NB_UID` change would force docker-stacks' recursive chown/chmod on every start):

- `usermod` jovyan to uid **1024** + `ENV NB_UID=1024` so `start.sh` doesn't reset it at runtime. gid stays 100.
- **No `/opt/conda` chown needed:** it's setgid + group-writable on gid 100, so a 1024 jovyan keeps install access via the group (`pip`, `sudo pip`, `pip --user` all still work). Only the small `/home/jovyan` skeleton and `/home/linuxbrew` are chowned.
- Add `home-skel/AGENTS.md` (home-dir orientation: links to the Dockerfile + k8s config, and the test-then-bake dependency workflow), seeded into the user's home by a `before-notebook.d` hook -- `/home/jovyan` is an NFS mount that masks image-baked content, so it's staged at `/opt/home-skel` and copied in on each start.

Known tradeoff: the image uid is now coupled to the NAS squash uid (1024). If the squash ever changes, the image follows.

## Follow-ups (not in this PR)

1. After merge, the build workflow pushes a new `sha-<short>` tag -> bump `singleuser.image.tag` in `charts/jupyterhub/values.yaml`.
2. Once the 1024 image is deployed and confirmed running as 1024, remove `safe.directory = *` from the `dotfiles-symm` gitconfig. **Must be after** deploy -- doing it before re-breaks git.
3. Optional: confirm the DSM NFS squash policy for the record (Control Panel -> Shared Folder -> NFS Permissions).

## Testing

- `pre-commit run --files` on all changed files: passes (shfmt, shellcheck, gitleaks, executable-shebang).
- Not built/deployed from here; needs the build workflow + a pod respawn to verify at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0124E3b3dXDDzNLmzVZrD8jr