### PR TITLE
Don't let the seed-home-docs hook leak set -u into start.sh

### DIFF
--- a/containers/datascience-notebook-ssh/seed-home-docs.sh
+++ b/containers/datascience-notebook-ssh/seed-home-docs.sh
@@ -8,15 +8,22 @@
 # image. Edit the source in the repo, not the copy in the home dir.
 #
 # Best-effort: a failure here must never stop the notebook from starting.
-set -euo pipefail
+#
+# Because we're sourced (not executed), keep all strictness inside a subshell:
+# `set -u` at the top level would leak into start.sh, whose own `set -e` plus its
+# reference to an unset JUPYTER_DOCKER_STACKS_QUIET then aborts container startup.
+# (This hook sorts before start-sshd.sh, so it is the first to trip that.)
+(
+	set -euo pipefail
 
-dest="/home/${NB_USER:-jovyan}"
-src="/opt/home-skel/AGENTS.md"
+	dest="/home/${NB_USER:-jovyan}"
+	src="/opt/home-skel/AGENTS.md"
 
-if [ -d "${dest}" ] && [ -f "${src}" ]; then
-	if cp -f "${src}" "${dest}/AGENTS.md"; then
-		echo "seed-home-docs.sh: refreshed ${dest}/AGENTS.md"
-	else
-		echo "seed-home-docs.sh: WARNING: failed to seed AGENTS.md; continuing" >&2
+	if [ -d "${dest}" ] && [ -f "${src}" ]; then
+		if cp -f "${src}" "${dest}/AGENTS.md"; then
+			echo "seed-home-docs.sh: refreshed ${dest}/AGENTS.md"
+		else
+			echo "seed-home-docs.sh: WARNING: failed to seed AGENTS.md; continuing" >&2
+		fi
 	fi
-fi
+) || echo "seed-home-docs.sh: WARNING: failed to seed home docs; notebook continues" >&2


### PR DESCRIPTION
## Symptom
JupyterHub singleuser spawn crashloops. Logs (before the pod is deleted):
```
seed-home-docs.sh: refreshed /home/jovyan/AGENTS.md
/usr/local/bin/start.sh: line 11: JUPYTER_DOCKER_STACKS_QUIET: unbound variable
```
Container exits → CrashLoopBackOff → hub's 30s spawn probe times out.

## Root cause
`before-notebook.d/*.sh` hooks are **sourced** into `start.sh`'s shell.
`seed-home-docs.sh` (added in `94f9d9b`) set `set -euo pipefail` at the **top
level**, so `set -u` leaked into `start.sh`, which then aborts on its reference
to the unset `JUPYTER_DOCKER_STACKS_QUIET`.

This is the exact bug `ca6220d` already fixed in `start-sshd.sh` — but
`seed-home-docs.sh` reintroduced it, and since it sorts *before* `start-sshd.sh`
it trips first, so the earlier fix never gets a chance to matter.

Not a stale pin: the live cluster runs `sha-efc8f90`, matching
`values.yaml` — that image simply contains the buggy script.

## Fix
Wrap the body in a subshell with strictness inside, mirroring `start-sshd.sh`.
Verified the sourcing scenario no longer leaks `nounset`.

## Deploy (two-step, as with prior image changes)
1. Merge → the `build-datascience-notebook-ssh` workflow builds `sha-<merge>`.
2. Follow-up: bump `charts/jupyterhub/values.yaml` singleuser `image.tag` to that
   new `sha-<...>` and regenerate `rendered.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)