### PR TITLE
argocd/oauth2-proxy: consume the OnePasswordItem secret, not a placeholder

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -112,27 +112,6 @@ metadata:
     app.kubernetes.io/version: "v3.3.7"
 type: Opaque
 ---
-# Source: argocd/charts/oauth2-proxy/templates/secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    app: oauth2-proxy    
-    helm.sh/chart: oauth2-proxy-7.7.0
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: authentication-proxy
-    app.kubernetes.io/part-of: oauth2-proxy
-    app.kubernetes.io/name: oauth2-proxy
-    app.kubernetes.io/instance: argocd
-    app.kubernetes.io/version: "7.6.0"
-  name: argocd-oauth2-proxy
-  namespace: argocd
-type: Opaque
-data:
-  cookie-secret: "WFhYWFhYWFhYWFhYWFhYWA=="
-  client-secret: "WFhYWFhYWFg="
-  client-id: "WFhYWFhYWA=="
----
 # Source: argocd/charts/argo-cd/templates/argocd-configs/argocd-cm.yaml
 apiVersion: v1
 kind: ConfigMap

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -324,13 +324,21 @@ argo-cd:
           name: cmp-tanka
 
 oauth2-proxy:
-  # Credentials injected from 1Password. Create a vault item named 'argocd-oauth2-proxy' with
-  # fields: OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET, OAUTH2_PROXY_COOKIE_SECRET.
-  # Generate cookie secret with: openssl rand -base64 32 | head -c 32 | base64
-  # GCP OAuth2 client redirect URI: https://argocd.{cluster}.symmatree.com/oauth2/callback
-  extraEnvFrom:
-    - secretRef:
-        name: argocd-oauth2-proxy
+  # Credentials come from 1Password via the OnePasswordItem in
+  # templates/oauth2-proxy-secret.yaml, which creates a Secret named
+  # 'argocd-oauth2-proxy'. The vault item's field labels must be exactly
+  # 'client-id', 'client-secret', 'cookie-secret' -- those become the Secret keys
+  # that the chart's existingSecret path reads.
+  #   - client-id / client-secret: from the GCP OAuth2 client 'argocd-oauth-proxy'
+  #     (redirect URI https://argocd.{cluster}.symmatree.com/oauth2/callback)
+  #   - cookie-secret: openssl rand -base64 32 | head -c 32 | base64
+  #
+  # existingSecret is required: without it the chart renders its OWN Secret of the
+  # same name full of "XXXXXXX" placeholders, which collides with the OnePasswordItem
+  # and (Argo self-heal winning the race) sends client_id=XXXXXXX to Google -- the
+  # authorize step is rejected and no callback ever returns.
+  config:
+    existingSecret: argocd-oauth2-proxy
   extraArgs:
     - --provider=google
     - "--email-domain=*"


### PR DESCRIPTION
## Problem

After #545, oauth2-proxy in front of Argo CD redirects **every** visitor to Google and lets **no one** through -- not a crash, but a dead gate.

Root cause found in-cluster: the oauth2-proxy subchart, with no `config.existingSecret` set, renders its **own** `Secret` named `argocd-oauth2-proxy` full of the chart's default `XXXXXXX` placeholder credentials. That **collides** with the `OnePasswordItem` of the same name (`templates/oauth2-proxy-secret.yaml`). Two controllers write one Secret; Argo CD self-heal wins the race, so the live `client-id` is the 7-char literal `XXXXXXX`.

The proxy sends `client_id=XXXXXXX` to Google -> the authorize step is rejected -> **no `/oauth2/callback` ever returns**. The `--reverse-proxy`/redirect_uri (`https://argocd.tiles.symmatree.com/oauth2/callback`) and the GCP client `argocd-oauth-proxy` are both correct; the credential in use was simply the placeholder.

### Evidence (live cluster)
- Proxy's 302 to Google carried `client_id=XXXXXXX` (7 bytes, not a real `...apps.googleusercontent.com` id).
- Proxy log shows the outbound 302 and **no** callback.
- `charts/argocd/rendered.yaml` emitted a `Secret` with `client-id: "WFhYWFhYWA=="` -> base64-decodes to `XXXXXXX`.

## Fix

- Set `oauth2-proxy.config.existingSecret: argocd-oauth2-proxy` so the chart stops emitting its placeholder Secret and reads `client-id`/`client-secret`/`cookie-secret` from the OnePasswordItem-managed Secret (keys already match).
- Drop `extraEnvFrom` -- it was a no-op (never rendered into the deployment).
- Update the values comment to document the required 1Password field labels.

**Rendered diff:** the placeholder `Secret` manifest is removed; nothing else changes (the deployment already referenced those keys via `secretKeyRef`). Verified with `helm lint --strict` + re-render.

## Out-of-band (already done by operator)
The `argocd-oauth2-proxy` 1Password item's fields were relabeled to `client-id` / `client-secret` / `cookie-secret` with the real GCP client values + a real 32-byte cookie secret.

## After merge
Once synced, roll the proxy so it picks up the real secret (env-from-secret changes don't auto-restart):
```
kubectl -n argocd rollout restart deploy/argocd-oauth2-proxy
```
Then verify: incognito -> Google login -> only `seth.porter@gmail.com` passes. Do **not** apply the WAN cutover (#593) until that gate is confirmed.

Refs #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Cbb58ZZNYezpdqoBPiyAP