### PR TITLE
argocd/oauth2-proxy: ingress pathType Prefix so /oauth2/callback routes

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -3264,7 +3264,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
+            pathType: Prefix
             backend:
               service:
                 name: argocd-oauth2-proxy

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -359,6 +359,12 @@ oauth2-proxy:
   ingress:
     enabled: true
     className: cilium
+    # Prefix (not the chart's default ImplementationSpecific): under Cilium,
+    # ImplementationSpecific + path "/" matches ONLY the exact "/", so /oauth2/callback
+    # and the whole Argo CD UI 404 at Envoy before reaching the proxy. Every other
+    # ingress in this cluster uses Prefix "/"; match that so all paths route.
+    path: /
+    pathType: Prefix
     annotations:
       cert-manager.io/cluster-issuer: real-cert
       # Ride the single shared front door (the pinned cilium-ingress LB IP)


### PR DESCRIPTION
## Problem

After #600 fixed the credentials, Google auth now completes -- but the redirect back to `https://argocd.tiles.symmatree.com/oauth2/callback?...` fails in the browser ("no website found"), so login can never finish.

Root cause: the oauth2-proxy ingress used the chart's default `pathType: ImplementationSpecific` with `path: /`. **Under Cilium that matches only the exact `/`**, so every other path 404s at Envoy before reaching the proxy.

### Evidence (in-cluster, through the Envoy ingress at 10.0.129.2)
```
/                  -> 301   (route exists)
/oauth2/callback   -> 404   (login return dies here)
/applications      -> 404   (the whole Argo CD UI would 404 too)
```
The same paths reach the proxy fine when hitting the Service directly (bypassing Envoy), so oauth2-proxy is correct -- it's purely the ingress path match. The proxy log confirms it: repeated `GET /` -> 302 to Google, and **no `/oauth2/callback` ever arrives**.

Every other ingress in this cluster (grafana, webodm, postgres-operator-ui, apprise, hubble-ui) uses `path: /` + `pathType: Prefix` and works. The argocd-oauth2-proxy ingress was the lone `ImplementationSpecific` outlier.

## Fix

Set `oauth2-proxy.ingress.pathType: Prefix` (path `/`). Rendered diff is the single `pathType` line. `helm lint --strict` + re-render clean.

## After merge
Once `prod` moves and the app syncs, the ingress updates in place (no pod restart needed). Then the full flow should work: `/` -> Google -> `/oauth2/callback` -> allowlist (`seth.porter@gmail.com`) -> Argo CD UI.

Refs #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Cbb58ZZNYezpdqoBPiyAP