### PR TITLE
argocd/oauth2-proxy: drop --email-domain=* so the email allowlist is enforced

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -2755,7 +2755,6 @@ spec:
           - --https-address=0.0.0.0:4443
           - --metrics-address=0.0.0.0:44180
           - --provider=google
-          - --email-domain=*
           - --upstream=http://argocd-server:80
           - --pass-host-header=true
           - --set-xauthrequest=true

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -341,17 +341,19 @@ oauth2-proxy:
     existingSecret: argocd-oauth2-proxy
   extraArgs:
     - --provider=google
-    - "--email-domain=*"
+    # Do NOT set --email-domain: in oauth2-proxy email validation is OR, not AND
+    # (valid = domain-matches OR in-emails-file), and --email-domain=* sets allowAll
+    # -> every Google account passes and the emails file below is never consulted.
+    # With no email-domain configured, the authenticated-emails-file is the sole gate.
     - --upstream=http://argocd-server:80
     - --pass-host-header=true
     - --set-xauthrequest=true
     - --silence-ping-logging=true
     - --skip-provider-button=true
     - --reverse-proxy=true
-  # Allowlist: only these emails may authenticate. The chart writes them to a
-  # ConfigMap and passes --authenticated-emails-file automatically. --email-domain=*
-  # above lets the domain check pass; this file is the actual restriction. (There is
-  # no --allowed-email flag in oauth2-proxy -- the old line was a no-op at best.)
+  # Allowlist: the ONLY emails permitted. The chart writes them to a ConfigMap and
+  # passes --authenticated-emails-file automatically. This is the actual restriction --
+  # it works precisely because --email-domain is unset (see extraArgs above).
   authenticatedEmailsFile:
     enabled: true
     restricted_access: |


### PR DESCRIPTION
## Problem (security)

Login works now, but **any Google account** gets into Argo CD -- confirmed live: both `seth.porter@gmail.com` and `symmetry@lovelace.ai` were admitted, though the allowlist contains only `seth.porter@gmail.com`. Argo CD's `rbac.policy.default` is `role:admin`, so this is **admin access for any Google user** who can reach the endpoint.

Not WAN-exposed (the #593 cutover is still blocked), so it's contained to LAN/VPN -- but it must land and be verified before any WAN exposure.

## Root cause

oauth2-proxy email validation is **OR, not AND** (v7.6.0 `validator.go`):
```go
valid = isEmailValidWithDomains(email, domains)   // "*" -> allowAll -> true
if !valid { valid = validUsers.IsValid(email) }   // emails file, fallback only
```
`--email-domain=*` sets `allowAll`, so validation returns true for everyone and the `--authenticated-emails-file` is never the deciding check. The prior values comment ("the file is the actual restriction") had the semantics backwards.

## Fix

Remove `--email-domain` entirely. With no domains configured, `isEmailValidWithDomains` never matches, so the `authenticated-emails-file` becomes the **sole** gate and only `seth.porter@gmail.com` is admitted. Rendered diff is the single removed arg line; `helm lint --strict` + re-render clean.

## After merge / verify

Deploy (prod tag) + sync, then re-test: `seth.porter@gmail.com` still gets in; any other Google account gets **403 / denied**. Only after that should #593 (WAN cutover) be considered.

Refs #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Cbb58ZZNYezpdqoBPiyAP