### PR TITLE
argocd/oauth2-proxy: drop email_domains=* from config file (real allowlist fix)

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -437,7 +437,7 @@ metadata:
   name: argocd-oauth2-proxy
   namespace: argocd
 data:
-  oauth2_proxy.cfg: "email_domains = [ \"*\" ]\nupstreams = [ \"file:///dev/null\" ]"
+  oauth2_proxy.cfg: "upstreams = [ \"file:///dev/null\" ]"
 ---
 # Source: argocd/templates/tanka.yaml
 apiVersion: v1
@@ -2729,7 +2729,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c0329892592df8b1519fac51e84aee8cf879bb8e157e5a04f6556b38b5a2435b
+        checksum/config: 9c1ecd9f0889c5271728298190b5b9b1104baac2492387267c860173bb7765e8
         checksum/config-emails: 27a8e7f3520c51f2b1fb340fc9cfb18be7d5fd195077b86c4521f37ca9d80c24
         checksum/secret: 8fa6fdae65861caa2986544b8860a5205be1937328c8ec2bad6bad076b9e2425
         checksum/google-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -339,12 +339,20 @@ oauth2-proxy:
   # authorize step is rejected and no callback ever returns.
   config:
     existingSecret: argocd-oauth2-proxy
+    # Override the chart's default configFile, which sets email_domains = [ "*" ]
+    # (allowAll). oauth2-proxy merges --config with CLI args, so dropping the
+    # --email-domain arg alone was NOT enough -- the wildcard lived here too and
+    # kept letting every Google account in. With no email_domains anywhere, the
+    # authenticated-emails-file below is the sole gate. (upstreams here is the
+    # chart's required dummy; the real upstream is --upstream in extraArgs.)
+    configFile: |-
+      upstreams = [ "file:///dev/null" ]
   extraArgs:
     - --provider=google
     # Do NOT set --email-domain: in oauth2-proxy email validation is OR, not AND
     # (valid = domain-matches OR in-emails-file), and --email-domain=* sets allowAll
     # -> every Google account passes and the emails file below is never consulted.
-    # With no email-domain configured, the authenticated-emails-file is the sole gate.
+    # The wildcard must also be absent from config.configFile above (chart default).
     - --upstream=http://argocd-server:80
     - --pass-host-header=true
     - --set-xauthrequest=true


### PR DESCRIPTION
## Problem (security) -- #602 was incomplete

#602 removed the `--email-domain=*` **CLI arg**, but the wildcard also lives in the oauth2-proxy chart's default `config.configFile`, mounted via `--config`:
```
email_domains = [ "*" ]
upstreams = [ "file:///dev/null" ]
```
oauth2-proxy **merges** the config file with CLI args, so `email_domains=[ "*" ]` stayed in effect and `allowAll` was still on. Confirmed live: after #602 deployed, `symmetry@lovelace.ai` (not in the allowlist) logged in via a fresh incognito window.

I fixed the wrong copy in #602. This gets the config-file copy.

## Fix

Override `config.configFile` to keep only the dummy `upstreams` line and drop `email_domains` entirely. With no `email_domains` from any source, the `authenticated-emails-file` is the sole gate -> only `seth.porter@gmail.com`.

oauth2-proxy re-validates the session email on **every** request (v7.6.0 `oauthproxy.go`, `getAuthenticatedSession`: `invalidEmail := session.Email != "" && !p.Validator(session.Email)`), so any existing non-allowlisted session is also rejected on its next request -- no cookie rotation needed.

### Rendered diff
- configmap `oauth2_proxy.cfg`: `email_domains = [ "*" ]\nupstreams=...` -> `upstreams = [ "file:///dev/null" ]`
- deployment `checksum/config` changes -> pod auto-rolls on sync (no manual restart)
- `grep email_domains rendered.yaml` -> none

## Verify after deploy
`seth.porter@gmail.com` still gets in; a fresh-incognito `symmetry@lovelace.ai` now gets **403 / bounced**. Only then is #596 closeable and #593 (WAN) unblocked.

Refs #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Cbb58ZZNYezpdqoBPiyAP