### PR TITLE
argocd/oauth2-proxy: set --trusted-proxy-ip to the pod CIDR (harden X-Forwarded)

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -2761,6 +2761,7 @@ spec:
           - --silence-ping-logging=true
           - --skip-provider-button=true
           - --reverse-proxy=true
+          - --trusted-proxy-ip=10.0.144.0/20
           - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
           - --authenticated-emails-file=/etc/oauth2-proxy/argocd-oauth2-proxy-accesslist
         env:

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -367,6 +367,15 @@ oauth2-proxy:
     - --silence-ping-logging=true
     - --skip-provider-button=true
     - --reverse-proxy=true
+    # Restrict who may set X-Forwarded-* to the in-cluster pod CIDR
+    # (cilium ipv4-native-routing-cidr). Without this, --reverse-proxy trusts
+    # X-Forwarded-* from 0.0.0.0/0 -- fine when only the ingress could reach us,
+    # but this is now internet-facing. The Cilium ingress Envoy SNATs its backend
+    # connections into this CIDR (observed proxy source IPs 10.0.145/148/149.x all
+    # land here), so trusting it covers every legitimate ingress source while
+    # excluding external clients. Node IPs are heterogeneous (10.0.128.x and
+    # 10.0.99.x) so the pod CIDR -- not node subnets -- is the reliable boundary.
+    - --trusted-proxy-ip=10.0.144.0/20
   # Allowlist: the ONLY emails permitted. The chart writes them to a ConfigMap and
   # passes --authenticated-emails-file automatically. This is the actual restriction --
   # it works precisely because --email-domain is unset (see extraArgs above).


### PR DESCRIPTION
## Why

The proxy is now internet-facing (#593). v7.15.3 warns on startup:
> `--reverse-proxy is enabled but no --trusted-proxy-ip CIDRs were configured. All connecting IPs are trusted to supply X-Forwarded-* headers by default (0.0.0.0/0, ::/0).`

We know exactly who legitimately sends us traffic: the Cilium ingress Envoy. So trust only that, not the whole internet.

## What

`--trusted-proxy-ip=10.0.144.0/20` — the Cilium `ipv4-native-routing-cidr` (pod CIDR).

Investigation: the proxy's observed source IPs for ingress traffic (`10.0.145.19`, `10.0.148.182`, `10.0.149.132`) all fall in this CIDR — Envoy SNATs backend connections into the pod network. Node IPs are heterogeneous (`10.0.128.x` and `10.0.99.14`), so the pod CIDR, not node subnets, is the reliable boundary. Rendered diff is the single added arg.

## Safety

- Identity spoofing was already blocked (identity comes from the encrypted session cookie; spoofed `X-Forwarded-User`/`X-Auth-Request-*` still 302 to Google — tested). This is defense-in-depth for the `X-Forwarded-*` the proxy *does* consult (`Proto`/`Host`/`For`).
- **Post-deploy check:** `--reverse-proxy` relies on `X-Forwarded-Proto: https`. After this deploys, confirm the login `redirect_uri` stays `https` (i.e. Envoy's source is trusted). If Envoy ever sourced outside `10.0.144.0/20`, the proxy would treat requests as http and break OAuth — not observed. I'll verify on deploy.

Refs #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Cbb58ZZNYezpdqoBPiyAP