### PR TITLE
notebook image: bump DOTFILES_REF to the lsb_release fix

### DIFF
--- a/containers/datascience-notebook-ssh/Dockerfile
+++ b/containers/datascience-notebook-ssh/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
 # at build time and pinned by SHA -- no local copy to drift, no submodule.
 # Bump DOTFILES_REF to adopt upstream changes. See symmatree/tiles#607.
 ARG DOTFILES_REPO=https://github.com/symmatree/dotfiles-symm.git
-ARG DOTFILES_REF=5321890b65f4a1bf1c9c4fe7d7344d7bc93d05b4
+ARG DOTFILES_REF=9abc64e154a9b3766bd7454041d0364d301f2cd2
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 # Fix linuxbrew permissions because we're running as root.
 RUN git clone "${DOTFILES_REPO}" /tmp/dotfiles-symm \


### PR DESCRIPTION
Follow-up to #608. That PR pinned `DOTFILES_REF=5321890b`, which predated the `lsb_release` regression fix, so the main build failed at the codename task.

Bumps the pin to dotfiles-symm `main` (`9abc64e`, includes [dotfiles-symm#8](https://github.com/symmatree/dotfiles-symm/pull/8)). **Validated**: a dispatch build of this exact playbook content passed end-to-end (full toolchain, ~11 min). This makes the notebook image build green on main again. Refs #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)