### PR TITLE
Revert HostnameConfig auto:off + default metal apply_mode to reboot

### DIFF
--- a/.github/workflows/nodes-plan-apply.yaml
+++ b/.github/workflows/nodes-plan-apply.yaml
@@ -25,15 +25,18 @@ on:
           - test
           - prod
       metal_apply_mode:
-        # "reboot" is what makes bare-metal workers rejoin after a rebuild: pair
-        # it with a taint-vms run (which taints the metal config-apply) so the
-        # re-applied node reboots into the new etcd instead of staying orphaned.
-        # Leave "auto" for routine applies. Only consumed on workflow_dispatch;
-        # PR/push/schedule always use the "auto" default below.
+        # Defaults to "reboot" (also the TF var default): the metal config-apply
+        # only re-runs when the config actually changes, so this is not a
+        # reboot-every-apply -- but when it does change (or on a taint-vms
+        # rebuild), rebooting guarantees the change fully applies and lets a
+        # rebuilt node rejoin the new etcd. "auto" reboots only when Talos judges
+        # a field requires it (unreliable) and is a no-op on a rebuild's
+        # byte-identical re-apply, leaving the node orphaned. Override to auto/
+        # no_reboot/staged here if you deliberately want a live-only apply.
         # docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot
-        description: "talosctl apply-config mode for bare-metal nodes (use reboot for a cluster rebuild)"
+        description: "talosctl apply-config mode for bare-metal nodes (default reboot; ensures config fully applies)"
         type: choice
-        default: auto
+        default: reboot
         options:
           - auto
           - reboot
@@ -213,9 +216,10 @@ jobs:
           UNIFI_USERNAME: ${{ steps.load_secrets.outputs.UNIFI_USERNAME }}
           UNIFI_PASSWORD: ${{ steps.load_secrets.outputs.UNIFI_PASSWORD }}
           TF_VAR_proxmox_root_password: ${{ steps.load_secrets.outputs.PROXMOX_ROOT_PASSWORD }}
-          # Rebuild knob: reboot re-applied metal workers so they rejoin the new
-          # etcd. Empty on PR/push/schedule -> "auto" (no behavior change).
-          TF_VAR_metal_apply_mode: ${{ inputs.metal_apply_mode || 'auto' }}
+          # Metal apply mode. Defaults to "reboot" so a metal config change fully
+          # applies (and a rebuild rejoins the new etcd); the config-apply only
+          # re-runs on an actual config change, so this is not a reboot-per-apply.
+          TF_VAR_metal_apply_mode: ${{ inputs.metal_apply_mode || 'reboot' }}
         uses: ./.github/actions/terraform-plan-apply
         with:
           workspace: "test"
@@ -235,9 +239,10 @@ jobs:
           UNIFI_USERNAME: ${{ steps.load_secrets.outputs.UNIFI_USERNAME }}
           UNIFI_PASSWORD: ${{ steps.load_secrets.outputs.UNIFI_PASSWORD }}
           TF_VAR_proxmox_root_password: ${{ steps.load_secrets.outputs.PROXMOX_ROOT_PASSWORD }}
-          # Rebuild knob: reboot re-applied metal workers so they rejoin the new
-          # etcd. Empty on PR/push/schedule -> "auto" (no behavior change).
-          TF_VAR_metal_apply_mode: ${{ inputs.metal_apply_mode || 'auto' }}
+          # Metal apply mode. Defaults to "reboot" so a metal config change fully
+          # applies (and a rebuild rejoins the new etcd); the config-apply only
+          # re-runs on an actual config change, so this is not a reboot-per-apply.
+          TF_VAR_metal_apply_mode: ${{ inputs.metal_apply_mode || 'reboot' }}
         uses: ./.github/actions/terraform-plan-apply
         with:
           workspace: "prod"

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Each cluster uses `/18` allocation (64 /24s). Pods use `/20` with `node-cidr-mas
 Use this when you want **new Proxmox VMs** (fresh disks / reinstall Talos), for example after a major Talos pin change. Workspaces are **`test`** and **`prod`**; pick one and stay consistent through the apply. This flow uses GitHub Actions (service account, VPN, secrets) end to end.
 
 1. Run **[`taint-vms`](.github/workflows/taint-vms.yaml)** in Actions. Enable **taint test** and/or **taint prod** (each taints the Talos VM resources for that workspace, **`talos_machine_bootstrap`** so bootstrap runs again after disks are new, and each bare-metal **`talos_machine_configuration_apply`** so metal workers re-apply).
-2. Run **`nodes-plan-apply`** with **apply** for the workspace you tainted, and set **`metal_apply_mode = reboot`**: a push to **`main`** applies **test** by default; use **`workflow_dispatch`** with apply and **prod** for production.
+2. Run **`nodes-plan-apply`** with **apply** for the workspace you tainted (**`metal_apply_mode`** defaults to **`reboot`**, which the rebuild needs): a push to **`main`** applies **test** by default; use **`workflow_dispatch`** with apply and **prod** for production.
 
-After apply, Terraform recreates the VMs, applies machine config, and bootstraps the cluster. **Bare-metal workers need `metal_apply_mode = reboot`** to rejoin the new etcd -- a plain re-apply is a no-op and leaves them orphaned. See [docs/bare-metal-nodes.md](docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot).
+After apply, Terraform recreates the VMs, applies machine config, and bootstraps the cluster. **Bare-metal workers rejoin the new etcd via `metal_apply_mode = reboot`** (now the default) -- a plain `auto` re-apply is a no-op and leaves them orphaned. See [docs/bare-metal-nodes.md](docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot).
 
 See `docs/environment-strategy.md` for workspace behavior.
 

--- a/docs/bare-metal-nodes.md
+++ b/docs/bare-metal-nodes.md
@@ -118,16 +118,16 @@ The [Recreating cluster](../README.md#recreating-cluster) flow taints the Proxmo
 
 ### Rebuilds: metal reapply + reboot
 
-**The trap.** A metal worker's machine config is derived from `talos_machine_secrets`, which a bootstrap recreate does **not** change. Re-applying it therefore produces byte-identical config, and `talos_machine_configuration_apply` under the default `apply_mode = "auto"` is a **no-op -- no reboot**. The node keeps its old in-memory etcd/kubelet identity, its Node object was wiped with the old etcd, and the long-running kubelet loops `nodes "<name>" not found`; `NodeRestriction` then denies every pod pinned there. (Observed 2026-06-30 -> 07-01: `acebase` -- the GNSS base -- sat orphaned ~35h, so `ntrip/rtkbase` + `mavproxy` were `Pending` and **RTK was down**. See [tiles#547](https://github.com/symmatree/tiles/issues/547).)
+**The trap.** A metal worker's machine config is derived from `talos_machine_secrets`, which a bootstrap recreate does **not** change. Re-applying it therefore produces byte-identical config, and `talos_machine_configuration_apply` under `apply_mode = "auto"` is a **no-op -- no reboot** (this is exactly why `apply_mode` now **defaults to `reboot`**; see below). The node keeps its old in-memory etcd/kubelet identity, its Node object was wiped with the old etcd, and the long-running kubelet loops `nodes "<name>" not found`; `NodeRestriction` then denies every pod pinned there. (Observed 2026-06-30 -> 07-01: `acebase` -- the GNSS base -- sat orphaned ~35h, so `ntrip/rtkbase` + `mavproxy` were `Pending` and **RTK was down**. See [tiles#547](https://github.com/symmatree/tiles/issues/547).)
 
 A config *apply* is not a *reset*. PKI is preserved across the recreate (both apid mTLS and the kubelet client cert still authenticate), so the node needs neither new certs nor a reinstall -- it only needs to **reboot** (or at minimum `talosctl -n <NODE_IP> service kubelet restart`) to rejoin. Since `auto` won't reboot on unchanged config, we force it.
 
 **The mechanism -- two knobs, both required:**
 
 1. **[`taint-vms`](../.github/workflows/taint-vms.yaml)** taints each metal `talos_machine_configuration_apply` (derived from state, so it tracks `metal_{amd,intel}_nodes` automatically) so the apply re-runs on the next Terraform apply.
-2. **[`nodes-plan-apply`](../.github/workflows/nodes-plan-apply.yaml)** takes a **`metal_apply_mode`** input, threaded via `TF_VAR_metal_apply_mode` into the metal module's `apply_mode`. Set it to **`reboot`** for a rebuild: the re-applied node reboots and rejoins the new etcd. The metal modules `depends_on` `talos_machine_bootstrap`, so the reboot lands **after** the new etcd exists.
+2. **[`nodes-plan-apply`](../.github/workflows/nodes-plan-apply.yaml)** takes a **`metal_apply_mode`** input, threaded via `TF_VAR_metal_apply_mode` into the metal module's `apply_mode`. It **defaults to `reboot`**, which a rebuild requires: the re-applied node reboots and rejoins the new etcd. The metal modules `depends_on` `talos_machine_bootstrap`, so the reboot lands **after** the new etcd exists.
 
-Routine applies (PR / push / daily schedule) leave `metal_apply_mode = "auto"`, so this is inert outside a deliberate rebuild. The same `reboot` knob is also the general way to push a machine-config change that needs a reboot to a metal node.
+`metal_apply_mode` now **defaults to `reboot`** for every apply (PR / push / daily schedule / dispatch). This is **not** a reboot-every-apply: the metal `talos_machine_configuration_apply` has no `replace_triggered_by` and stable inputs, so Terraform only re-runs it -- and only reboots -- when the metal config **actually changes** (or on a `taint-vms` rebuild). Rebooting on a real change guarantees the config fully applies (Talos `auto` reboots only when it judges a changed field requires it, which is unreliable -- it can hold state until reboot) and lets a rebuilt node rejoin the new etcd. Override to `auto` / `no_reboot` / `staged` only when you deliberately want a live-only apply.
 
 > **apply-config modes** ([Talos v1.13](https://docs.siderolabs.com/talos/v1.13/configure-your-talos-cluster/system-configuration/editing-machine-configuration)): `auto` reboots only if a changed field requires it; `no_reboot` fails if a reboot would be needed; `reboot` always reboots to apply; `staged` applies on next reboot. Changes Terraform apply cannot make at all (install disk, disk encryption, wiping state) need a **reset**, not an apply -- see [Wipe and reinstall](#3-wipe-and-reinstall-talos-on-the-same-machine).
 >
@@ -136,7 +136,7 @@ Routine applies (PR / push / daily schedule) leave `metal_apply_mode = "auto"`, 
 **Rebuild runbook**
 
 1. Run **`taint-vms`** for the workspace (taints VMs, `talos_machine_bootstrap`, and metal config-apply).
-2. Run **`nodes-plan-apply`** with **apply** for that workspace and **`metal_apply_mode = reboot`**.
+2. Run **`nodes-plan-apply`** with **apply** for that workspace (**`metal_apply_mode`** defaults to **`reboot`**, which the rebuild needs).
 3. Verify: `talosctl -n <NODE_IP> get members` and `kubectl get nodes` show the metal node; any pinned pods (e.g. `ntrip`, `mavproxy`) return to `Running`.
 
 ## Related docs

--- a/tf/modules/talos-cluster/nodes.tf
+++ b/tf/modules/talos-cluster/nodes.tf
@@ -18,23 +18,6 @@ locals {
     }
   })
 
-  # The talos provider injects a `HostnameConfig` document with `auto: stable`,
-  # which makes a node self-assign a deterministic `talos-xxx` hostname when no
-  # DHCP/platform hostname is available. After a power event that took the UniFi
-  # UDM (our DHCP source) down at boot, nodes came up under those fallback names
-  # and joined as *new* Node objects -- orphaning hostname-pinned local-path PVs
-  # and leaving collided duplicates of every node. `auto: off` keeps the nice
-  # DHCP-discovered hostnames (auto is the lowest-priority source, so normal
-  # boots are unchanged) but drops the self-assign fallback: with no DHCP name a
-  # node simply fails to join and recovers once the UDM is back, instead of
-  # joining under a bogus identity. See:
-  # https://docs.siderolabs.com/talos/v1.12/reference/configuration/network/hostnameconfig
-  hostname_auto_off_patch_yaml = yamlencode({
-    "apiVersion" = "v1alpha1"
-    "kind"       = "HostnameConfig"
-    "auto"       = "off"
-  })
-
   # See: https://docs.siderolabs.com/talos/v1.12/reference/configuration/network/layer2vipconfig
   layer2_vip_patch_yaml = yamlencode({
     apiVersion = "v1alpha1"
@@ -97,7 +80,6 @@ module "talos-vm" {
   config_patches = concat(
     [local.base_config_yaml],
     [local.common_patch_yaml],
-    [local.hostname_auto_off_patch_yaml],
     local.eviction_patches,
     [yamlencode({
       "machine" = {
@@ -133,7 +115,6 @@ module "talos-amd-metal" {
   config_patches = concat(
     [local.base_config_yaml],
     [local.common_patch_yaml],
-    [local.hostname_auto_off_patch_yaml],
     local.eviction_patches,
     [yamlencode({
       "machine" = {
@@ -176,7 +157,6 @@ module "talos-intel-metal" {
   config_patches = concat(
     [local.base_config_yaml],
     [local.common_patch_yaml],
-    [local.hostname_auto_off_patch_yaml],
     local.eviction_patches,
     [yamlencode({
       "machine" = {

--- a/tf/modules/talos-cluster/variables.tf
+++ b/tf/modules/talos-cluster/variables.tf
@@ -51,9 +51,9 @@ variable "metal_intel_nodes" {
 }
 
 variable "metal_apply_mode" {
-  description = "talosctl apply-config mode for bare-metal nodes (auto | no_reboot | reboot | staged). Use \"reboot\" during a cluster rebuild so re-applied metal workers reboot and rejoin the new etcd. See docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot."
+  description = "talosctl apply-config mode for bare-metal nodes (auto | no_reboot | reboot | staged). Defaults to \"reboot\": the metal config-apply only re-runs when the config actually changes (no replace_triggered_by, stable inputs), so this is not a reboot-every-apply -- but when the config does change, rebooting guarantees it fully takes effect (Talos \"auto\" reboots only when it judges a field requires it, which is not fully reliable) and lets a rebuilt node rejoin the new etcd. See docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot."
   type        = string
-  default     = "auto"
+  default     = "reboot"
 
   validation {
     condition     = contains(["auto", "no_reboot", "reboot", "staged"], var.metal_apply_mode)

--- a/tf/modules/talos-metal/main.tf
+++ b/tf/modules/talos-metal/main.tf
@@ -15,9 +15,12 @@ resource "talos_machine_configuration_apply" "this" {
   node                        = var.ip_address
   config_patches              = var.config_patches
 
-  # "auto" (default) applies live and reboots only when a field requires it. A
-  # cluster rebuild re-applies byte-identical config, so "auto" is a no-op and
-  # the node never rejoins the new etcd -- set apply_mode="reboot" for rebuilds.
+  # Defaults to "reboot" (var.apply_mode): this resource only re-runs when the
+  # metal config actually changes, and rebooting then guarantees the change
+  # fully takes effect and lets a rebuilt node rejoin the new etcd. "auto" would
+  # reboot only when Talos judges a field requires it (unreliable -- Talos can
+  # hold state until reboot), and on a rebuild's byte-identical re-apply "auto"
+  # is a no-op that leaves the node orphaned.
   # docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot
   apply_mode = var.apply_mode
 

--- a/tf/modules/talos-metal/variables.tf
+++ b/tf/modules/talos-metal/variables.tf
@@ -61,9 +61,9 @@ variable "config_patches" {
 # re-applied metal node reboots and rejoins the new etcd. See
 # docs/bare-metal-nodes.md#rebuilds-metal-reapply--reboot.
 variable "apply_mode" {
-  description = "talosctl apply-config mode for the metal node: auto | no_reboot | reboot | staged"
+  description = "talosctl apply-config mode for the metal node: auto | no_reboot | reboot | staged. Defaults to \"reboot\" so a config change fully applies (and a rebuild rejoins the new etcd); the resource only re-runs on an actual config change, so this is not a reboot-every-apply."
   type        = string
-  default     = "auto"
+  default     = "reboot"
 
   validation {
     condition     = contains(["auto", "no_reboot", "reboot", "staged"], var.apply_mode)


### PR DESCRIPTION
Two related metal/Talos changes, folded together so `main` lands in one clean state.

## 1. Revert `HostnameConfig auto: off` (commit a6acb32, from #610)
`auto: off` is **invalid** on a real Talos node: `off` is the enum zero value, so Talos reads it as "auto not set", and with no static `hostname` either it rejects the whole config (`HostnameConfig: either 'auto' or 'hostname' must be set`). `talosctl validate` accepted it locally (false positive), but the node did not. During the prod rebuild this failed `talos_machine_configuration_apply` on all 6 VMs → etcd never bootstrapped → **prod outage**. Recovered by reverting to provider-default `auto: stable` + re-apply + `bootstrap-cluster`. This restores `main` to the known-good config now deployed (the recovery ran from this branch, so the `prod` tag already points here).

## 2. Default metal `apply_mode` to `reboot` (was `auto`)
`auto` reboots a metal node only when Talos judges a changed field requires it — unreliable (Talos can hold state until reboot), so a config change may not fully take effect. The metal `talos_machine_configuration_apply` has **no `replace_triggered_by` and stable inputs**, so Terraform only re-runs it — and only reboots — when the metal config **actually changes** (or on a `taint-vms` rebuild). So this is **not** a reboot-every-apply; it's "reboot when the metal config changes," which guarantees full application and keeps the rebuild path working **by default** (no more explicit `metal_apply_mode=reboot`). It also ends the `apply_mode` oscillation (rebuild sets `reboot`, routine applies defaulted `auto`). Override to `auto`/`no_reboot`/`staged` for a deliberate live-only apply.

Changed: both `variables.tf` defaults, the `nodes-plan-apply` input default + non-dispatch fallback, module comments, `docs/bare-metal-nodes.md`, `README`.

## Follow-up (not here)
Durable hostname fix redone as a static `hostname:` pin (valid — hostname is set), **validated on the test cluster first**.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>