### PR TITLE
Fix lb-static-pool guard (never rendered -> front-door ingress got no IP)

### DIFF
--- a/charts/cilium-config/rendered.yaml
+++ b/charts/cilium-config/rendered.yaml
@@ -25,3 +25,23 @@ metadata:
 spec:
   blocks:
     - cidr: "placeholder"
+
+---
+# Source: cilium-config/templates/lb-static-pool.helm.yaml
+# Dedicated static-IP pool for LoadBalancer services (created on every cluster;
+# inert where no service opts in). A service opts in with the label below AND
+# requests a specific IP via the lbipam.cilium.io/ips annotation (the shared
+# cilium-ingress does both -- see charts/argocd-applications/values/cilium-tiles-values.yaml).
+# The /24 is hardcoded; the ingress_lb_ip in tf/nodes/prod.tfvars MUST fall
+# inside it -- keep the two in sync.
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  namespace: "cilium-config"
+  name: lb-static-pool
+spec:
+  serviceSelector:
+    matchLabels:
+      tiles.symmatree.com/static-lb: "true"
+  blocks:
+    - cidr: "10.0.130.0/24"

--- a/charts/cilium-config/templates/lb-static-pool.helm.yaml
+++ b/charts/cilium-config/templates/lb-static-pool.helm.yaml
@@ -1,9 +1,9 @@
-{{- if eq .Values.cluster_name "tiles" }}
-# Dedicated static-IP pool for the WAN-forwarded front door. A service opts in
-# with the label below AND requests a specific IP via the lbipam.cilium.io/ips
-# annotation (the shared cilium-ingress does both -- see charts/cilium/application.yaml).
-# The /24 is hardcoded (prod-only); it MUST agree with the ingress_lb_ip value in
-# tf/nodes/prod.tfvars (which must fall inside this range).
+# Dedicated static-IP pool for LoadBalancer services (created on every cluster;
+# inert where no service opts in). A service opts in with the label below AND
+# requests a specific IP via the lbipam.cilium.io/ips annotation (the shared
+# cilium-ingress does both -- see charts/argocd-applications/values/cilium-tiles-values.yaml).
+# The /24 is hardcoded; the ingress_lb_ip in tf/nodes/prod.tfvars MUST fall
+# inside it -- keep the two in sync.
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
 metadata:
@@ -15,4 +15,3 @@ spec:
       tiles.symmatree.com/static-lb: "true"
   blocks:
     - cidr: "10.0.130.0/24"
-{{- end }}


### PR DESCRIPTION
Follow-up to #613. The `lb-static-pool` template guarded on `cluster_name == tiles`, but cilium-config's Application never receives `cluster_name` (empty), so the pool was never created. Once #613 deployed, the shared ingress got its `static-lb` label + `lbipam.cilium.io/ips: 10.0.130.1` annotation but had **no matching pool**, so LB-IPAM gave it **no IP** (front door down; argocd still reachable via port-forward).

Drop the guard — the pool is inert on any cluster where nothing opts in via the label. Then `lb-static-pool` exists, the ingress matches its `serviceSelector`, and `10.0.130.1` is allocatable.

Verified: renders under build.sh. Deploys via ArgoCD on the prod tag.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>