### PR TITLE
cilium: gate lb-static-pool on ingress_lb_ip (prod-only, no test-pool collision)

### DIFF
--- a/charts/cilium-config/rendered.yaml
+++ b/charts/cilium-config/rendered.yaml
@@ -28,12 +28,15 @@ spec:
 
 ---
 # Source: cilium-config/templates/lb-static-pool.helm.yaml
-# Dedicated static-IP pool for LoadBalancer services (created on every cluster;
-# inert where no service opts in). A service opts in with the label below AND
-# requests a specific IP via the lbipam.cilium.io/ips annotation (the shared
-# cilium-ingress does both -- see charts/argocd-applications/values/cilium-tiles-values.yaml).
-# The /24 is hardcoded; the ingress_lb_ip in tf/nodes/prod.tfvars MUST fall
-# inside it -- keep the two in sync.
+# Dedicated static-IP pool for LoadBalancer services that need a fixed IP. A
+# service opts in with the label below AND requests a specific IP via the
+# lbipam.cilium.io/ips annotation (the shared cilium-ingress does both -- see
+# charts/argocd-applications/values/cilium-tiles-values.yaml).
+#
+# Gated on ingress_lb_ip so this only exists where a front-door IP is pinned
+# (prod); test leaves ingress_lb_ip empty, so it does NOT get a 10.0.130.0/24
+# pool (which would collide with prod on the shared L2). The /24 is hardcoded;
+# tf/nodes/prod.tfvars ingress_lb_ip MUST fall inside it -- keep the two in sync.
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
 metadata:

--- a/charts/cilium-config/templates/lb-static-pool.helm.yaml
+++ b/charts/cilium-config/templates/lb-static-pool.helm.yaml
@@ -1,9 +1,13 @@
-# Dedicated static-IP pool for LoadBalancer services (created on every cluster;
-# inert where no service opts in). A service opts in with the label below AND
-# requests a specific IP via the lbipam.cilium.io/ips annotation (the shared
-# cilium-ingress does both -- see charts/argocd-applications/values/cilium-tiles-values.yaml).
-# The /24 is hardcoded; the ingress_lb_ip in tf/nodes/prod.tfvars MUST fall
-# inside it -- keep the two in sync.
+{{- if .Values.ingress_lb_ip }}
+# Dedicated static-IP pool for LoadBalancer services that need a fixed IP. A
+# service opts in with the label below AND requests a specific IP via the
+# lbipam.cilium.io/ips annotation (the shared cilium-ingress does both -- see
+# charts/argocd-applications/values/cilium-tiles-values.yaml).
+#
+# Gated on ingress_lb_ip so this only exists where a front-door IP is pinned
+# (prod); test leaves ingress_lb_ip empty, so it does NOT get a 10.0.130.0/24
+# pool (which would collide with prod on the shared L2). The /24 is hardcoded;
+# tf/nodes/prod.tfvars ingress_lb_ip MUST fall inside it -- keep the two in sync.
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
 metadata:
@@ -15,3 +19,4 @@ spec:
       tiles.symmatree.com/static-lb: "true"
   blocks:
     - cidr: "10.0.130.0/24"
+{{- end }}


### PR DESCRIPTION
Follow-up to #614. Removing the guard created `lb-static-pool` (`10.0.130.0/24`, prod's static range) on **tiles-test** too. Inert today (no test service opts in via the `static-lb` label), but a latent shared-L2 conflict if one ever is.

Gate on `ingress_lb_ip` instead of `cluster_name`: cilium-config **does** receive `ingress_lb_ip` (test leaves it empty), so the pool renders on prod and is absent on test. `rendered.yaml` unchanged (build.sh's placeholder `ingress_lb_ip` is truthy).

Ref: #596.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>