### PR TITLE
notebook build: auto-resolve dotfiles-symm main SHA (real PR; supersedes mis-merged #615)

### DIFF
--- a/.github/workflows/build-datascience-notebook-ssh.yaml
+++ b/.github/workflows/build-datascience-notebook-ssh.yaml
@@ -26,6 +26,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Resolve dotfiles-symm main to a concrete SHA and pass it in as a
+      # build-arg. This adopts dotfiles main automatically (no manual pin-bump
+      # PR) while keeping builds reproducible and cache-correct: the SHA is a
+      # unique ARG value, so the git-clone/ansible layer busts only when main
+      # actually moves. The resolved SHA is logged and baked into image labels.
+      - name: Resolve dotfiles-symm main
+        id: dotfiles
+        run: |
+          sha=$(git ls-remote https://github.com/symmatree/dotfiles-symm.git refs/heads/main | cut -f1)
+          if [ -z "$sha" ]; then echo "could not resolve dotfiles-symm main" >&2; exit 1; fi
+          echo "Building against dotfiles-symm main = $sha"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
       - name: Docker Metadata
         id: docker-metadata
         uses: docker/metadata-action@v6
@@ -53,6 +66,7 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
             BASE_TAG=${{ env.BASE_TAG }}
+            DOTFILES_REF=${{ steps.dotfiles.outputs.sha }}
           extra-args: |
             --disable-compression=false
             --cache-from=${{ env.IMAGE_NAME }}-cache

--- a/containers/datascience-notebook-ssh/Dockerfile
+++ b/containers/datascience-notebook-ssh/Dockerfile
@@ -27,7 +27,11 @@ RUN apt-get update \
 
 # Dev toolchain comes from the single source of truth (dotfiles-symm), fetched
 # at build time and pinned by SHA -- no local copy to drift, no submodule.
-# Bump DOTFILES_REF to adopt upstream changes. See symmatree/tiles#607.
+# CI resolves dotfiles-symm main to its current SHA and passes it as a
+# --build-arg (see .github/workflows/build-datascience-notebook-ssh.yaml), so
+# merges to dotfiles main are adopted automatically -- no manual bump PR. The
+# pinned default below is only a fallback for local/manual `buildah bud` runs
+# that do not pass --build-arg; keep it roughly current. See symmatree/tiles#607.
 ARG DOTFILES_REPO=https://github.com/symmatree/dotfiles-symm.git
 ARG DOTFILES_REF=bded044ada2225e27a204794a0bfa9e628818461
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers


### PR DESCRIPTION
## Context / correction

The workflow auto-resolve change was **not** actually in the merged #615 — #615 merged with only the manual `DOTFILES_REF` bump to `bded044`, and the auto-resolve commit ended up on a branch with no open PR (my sequencing error). This is that change, for real.

## What

- **Workflow:** new `Resolve dotfiles-symm main` step (`git ls-remote … refs/heads/main`) feeds the SHA in as `--build-arg DOTFILES_REF`.
- **Dockerfile:** `ARG DOTFILES_REF` default documented as a local-build fallback; CI overrides it.

## Why this also fixes the current red build

`main` currently pins `bded044` = dotfiles main *after* the docker-start fix but *before* the docker-group fix (symmatree/dotfiles-symm#16). So the build #615's merge triggered (run 29176046143) failed (its pinned `bded044` predates the docker-group fix #16, so it could not succeed; the retrievable log ends mid-run, so I am not claiming the exact task). Resolving dotfiles **main** at build time picks up #16 (now merged), so this both installs the auto-resolve *and* moves the build onto the fixed dotfiles.

Merging this triggers a build (Dockerfile is under `containers/**`) that resolves current dotfiles main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)