### PR TITLE
helm-setup: bump CI helm default v4.2.0 -> v4.2.2 (lockstep with dotfiles)

### DIFF
--- a/.github/actions/helm-setup/action.yml
+++ b/.github/actions/helm-setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   helm_version:
     description: "Helm version to install"
     required: true
-    default: "v4.2.0"
+    default: "v4.2.2"
   debug:
     description: "Enable debug logging for cache key globs"
     required: false


### PR DESCRIPTION
Bumps the `helm-setup` action default `v4.2.0` → `v4.2.2` to stay in lockstep with `dotfiles-symm` install-tools (symmatree/dotfiles-symm#17), which the notebook image consumes — so renders run locally in the notebook match CI.

**No render churn:** verified `build.sh` at 4.2.2 leaves every `charts/*/rendered.yaml` unchanged (byte-identical to 4.2.0), so `build-test` stays green with no regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)