### PR TITLE
chore(claude): redirect auto-memory to checked-in store

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "autoMemoryDirectory": "~/facts/claude-memories/tiles/memory"
+}


### PR DESCRIPTION
Adds `.claude/settings.json` setting `autoMemoryDirectory` -> `~/facts/claude-memories/tiles/memory`, so this repo's raw agent memory is version-controlled and converges across machines via git rather than the machine-local default project dir.

Committed via a worktree off `origin/main` (shared tree untouched). Committed as project-scope (not `settings.local.json`) so the redirect propagates into git worktrees; honored only after the workspace-trust dialog is accepted per machine.

Tracking: symmatree/facts#12