### PR TITLE
install-application: fix Argo CD admin password op edit syntax (#477 follow-up)

### DIFF
--- a/charts/argocd-applications/install-application.sh
+++ b/charts/argocd-applications/install-application.sh
@@ -122,14 +122,24 @@ sync_argocd_admin_password() {
 		return 0
 	fi
 
-	if op item edit "${item}" --vault "${vault}" "${field}[password]=${pw}" >/dev/null 2>&1; then
+	# Update the existing password field with a plain `field=value` assignment.
+	# A `field[password]=value` *type* annotation targets a NEW field and fails
+	# on a Login item's existing password field -- that was the original bug.
+	# Capture op's stderr so a failure is diagnosable, but never print it if it
+	# could contain the secret value.
+	local op_err=""
+	if op_err=$(op item edit "${item}" --vault "${vault}" "${field}=${pw}" 2>&1 >/dev/null); then
 		echo "Updated 1Password item '${item}' (vault '${vault}', field '${field}') with the current Argo CD admin password"
 	else
 		echo "WARNING: could not update 1Password item '${item}' in vault '${vault}'." >&2
-		echo "         Ensure the item exists and the service account has write access, then set it manually from:" >&2
-		echo "         kubectl -n ${ARGOCD_NAMESPACE} get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d" >&2
+		if [[ ${op_err} == *"${pw}"* ]]; then
+			echo "  op: <error withheld: it referenced the secret value>" >&2
+		else
+			printf '  op: %s\n' "${op_err}" >&2
+		fi
+		echo "  Fallback: kubectl -n ${ARGOCD_NAMESPACE} get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d" >&2
 	fi
-	unset pw
+	unset pw op_err
 	return 0
 }
 sync_argocd_admin_password


### PR DESCRIPTION
Follow-up to #477 / #622. The first real bootstrap (`tiles`, `apps=true`, run 29840719042) validated the whole path — `op` present, SA signed in, vault `tiles-secrets` resolved, `argocd-initial-admin-secret` read, no password leaked, run stayed green — but the `op item edit` failed.

Diagnosis (item confirmed to exist as a Login item, vault correct, SA is read-write `tiles-onepassword-sa`): the bug was the **assignment syntax**. `field[password]=value` is a *type annotation* for adding a **new** field and fails against a Login item's existing `password` field. The correct update is a plain **`field=value`**.

## Changes
- `op item edit … "${field}=${pw}"` (was `"${field}[password]=${pw}"`).
- Stop swallowing op's stderr (why the first failure was opaque): capture it and print it on failure — but **withhold it if it contains the secret value** (`[[ $op_err == *"$pw"* ]]`), so no password can reach the log.

## Testing
`shellcheck` + `shfmt` clean, `bash -n` OK; no chart templates touched. Re-testable with the same safe dispatch (`apps=true`, all reset boxes off) on `tiles` — expected: `Updated 1Password item 'argocd-tiles-admin' …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)