### PR TITLE
install-application: fix op item edit stdin JSON-template error (#477 follow-up)

### DIFF
--- a/charts/argocd-applications/install-application.sh
+++ b/charts/argocd-applications/install-application.sh
@@ -123,12 +123,14 @@ sync_argocd_admin_password() {
 	fi
 
 	# Update the existing password field with a plain `field=value` assignment.
-	# A `field[password]=value` *type* annotation targets a NEW field and fails
-	# on a Login item's existing password field -- that was the original bug.
+	# `< /dev/null` is essential: `op item edit` reads stdin as a JSON *template*
+	# whenever stdin is not a TTY (i.e. always in CI), and then fails with
+	# "invalid JSON provided" -- unrelated to the assignment. Feeding it an empty
+	# stdin makes it use only the assignment arg.
 	# Capture op's stderr so a failure is diagnosable, but never print it if it
 	# could contain the secret value.
 	local op_err=""
-	if op_err=$(op item edit "${item}" --vault "${vault}" "${field}=${pw}" 2>&1 >/dev/null); then
+	if op_err=$(op item edit "${item}" --vault "${vault}" "${field}=${pw}" </dev/null 2>&1 >/dev/null); then
 		echo "Updated 1Password item '${item}' (vault '${vault}', field '${field}') with the current Argo CD admin password"
 	else
 		echo "WARNING: could not update 1Password item '${item}' in vault '${vault}'." >&2


### PR DESCRIPTION
The actual root cause of the admin-password sync failing, now visible thanks to the stderr surfacing in #624:

```
op: [ERROR] 2026/07/21 15:05:55 invalid JSON provided
```

`op item edit` reads **stdin as a JSON template** whenever stdin isn't a TTY (per `op item edit --help`: "You can also edit an item using piped input") — which is always true in CI. So op tried to parse the runner's stdin as JSON and failed, regardless of the assignment. (This means #624's `password=` vs `password[password]=` change was cleaner but not the real blocker — both hit this stdin wall.)

## Fix
`op item edit … "${field}=${pw}" < /dev/null` — empty stdin, so op uses only the assignment.

## Testing
`shellcheck` + `shfmt` clean, `bash -n` OK. Couldn't fully repro locally (op 2.34.1 here auths before reaching the stdin parse), but the behavior is documented in `op item edit --help`. Error surfacing from #624 stays in place, so if anything else is wrong the next run names it. Re-test: same safe dispatch (`tiles`, `apps=true`, reset boxes off) — expected `Updated 1Password item 'argocd-tiles-admin' …`.