### PR TITLE
bootstrap-cluster: load ingress_lb_ip from misc-config (fix front door, #627)

### DIFF
--- a/.github/workflows/bootstrap-cluster.yaml
+++ b/.github/workflows/bootstrap-cluster.yaml
@@ -125,6 +125,13 @@ jobs:
           pod_cidr: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/pod_cidr"
           cluster_name: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/cluster_name"
           external_ip_cidr: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/external_ip_cidr"
+          # Front-door LB IP for the shared Cilium ingress. Written to misc-config
+          # by Terraform (tf/modules/talos-cluster/main.tf), consumed by
+          # install-application.sh via envsubst into the root Application's
+          # valuesObject -> cilium-config lb-static-pool. Empty on tiles-test.
+          # Was missing here -> root Application got ingress_lb_ip="" -> no
+          # lb-static-pool -> cilium-ingress <pending>. See issue #627.
+          ingress_lb_ip: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/ingress_lb_ip"
           vault_name: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/vault_name"
           project_id: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/project_id"
           seed_project_id: "op://tiles-secrets/${{ github.event.inputs.cluster }}-misc-config/config/seed_project_id"


### PR DESCRIPTION
Fixes the plumbing half of #627.

## What
Adds `ingress_lb_ip` to the `bootstrap-cluster` workflow's **Load cluster config from 1Password** step so `install-application.sh`'s `envsubst` can see it.

## Why
Terraform writes `ingress_lb_ip` into the `{cluster}-misc-config` 1Password item (`tf/modules/talos-cluster/main.tf:116-119`), but the workflow's load step never read it back out. So `envsubst` substituted empty into the root `argocd-applications` Application's `valuesObject`, `charts/cilium-config`'s `lb-static-pool` (gated on `.Values.ingress_lb_ip`) never rendered, and the shared `cilium-ingress` (the WAN front door pinned to `10.0.130.1`) sat `<pending>` for 10+ days — invisibly, because the value is imperative bootstrap state ArgoCD can't see. `tiles-test` leaves the field empty → no-op there.

Verified live on prod `admin@tiles`: root Application `ingress_lb_ip=""`, `lb-static-pool` absent, `cilium-ingress` EXTERNAL-IP `<pending>`. A steady-state `terraform apply` cannot fix it (it doesn't re-run `install-application.sh`).

## This PR is only the durable plumbing fix
It does **not** restore the live cluster by itself. After merge, the front door comes back by re-running the `argocd_applications` bootstrap step (dispatch `bootstrap-cluster` with `cluster=tiles`, `argocd_applications=true`, rest false) — a **live prod change requiring operator approval** (tracked as step B in #627). Post-check: `lb-static-pool` exists, `cilium-ingress`=`10.0.130.1`, `argocd`/`cilium` apps Healthy, `argocd.tiles.symmatree.com` 302→Google over WAN.

## Notes
- Not a doc gap: `docs/config-propagation.md` already documents this add-procedure and even predicts the "missing env entry → empty substitution" symptom; the field was just never added. The real fragility is the un-enforced tf-to-k8s field list (#284) — a parity check across {tfvars → TF 1P-write → workflow env-load → tmpl} would prevent recurrence.
- Unblocks the notebook front door (#605/#606), which inherits the same shared ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff4szE4XB79hk8nvAdTU2w