### PR TITLE
argocd: double application-controller memory 384Mi -> 768Mi (GOMEMLIMIT 690MiB)

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -2932,7 +2932,7 @@ spec:
         name: application-controller
         env:
           - name: GOMEMLIMIT
-            value: 340MiB
+            value: 690MiB
           - name: ARGOCD_CONTROLLER_REPLICAS
             value: "1"
           - name: ARGOCD_APPLICATION_CONTROLLER_NAME
@@ -3230,7 +3230,7 @@ spec:
           failureThreshold: 3
         resources:
           limits:
-            memory: 384Mi
+            memory: 768Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -149,10 +149,10 @@ argo-cd:
   controller:
     resources:
       limits:
-        memory: 384Mi
+        memory: 768Mi
     env:
     - name: GOMEMLIMIT
-      value: "340MiB"  # ~90% of the 384Mi memory limit above; GOMEMLIMIT uses MiB/GiB units
+      value: "690MiB"  # ~90% of the 768Mi memory limit above; GOMEMLIMIT uses MiB/GiB units
     ## Application controller metrics configuration
     metrics:
       # -- Deploy metrics service


### PR DESCRIPTION
## Incident
During the #627 front-door remediation, re-applying the root app-of-apps kicked a simultaneous sync of all 30 child apps, which tipped the `argocd-application-controller` into a wedge that **blocked all Application syncs cluster-wide** for hours.

## Root cause (measured, not inferred)
The controller was pinned at its memory cap:
```
/sys/fs/cgroup/memory.current = 402,411,520
/sys/fs/cgroup/memory.max     = 402,653,184   -> 383.8 / 384 MiB = 99.94%
```
It did **not** OOMKill (enough reclaimable page cache), but the kernel + Go runtime burned CPU on continuous reclaim/GC to stay under the cap. That CPU starvation is what made it drop informer watches (`http2: client connection lost`), re-list in a storm, trip client-side rate limiting (backoff grew 40s -> 84s), and fail readiness (`/healthz` timeout). A fresh pod refilled to the cap within ~1 minute, so restart/delete alone could not fix it — the ceiling had to move.

Note: the Go `Sys` memstat (~329 MB) was misleadingly *below* the cap because it excludes page cache the cgroup charges; the cgroup number is the truth.

## Change
`charts/argocd/values.yaml`: application-controller `limits.memory 384Mi -> 768Mi`, and the hand-set `GOMEMLIMIT 340MiB -> 690MiB` (~90%). `rendered.yaml` regenerated with helm v4.2.2; the diff is exactly those two values, nothing adjacent.

Cost: +384 MB on `tiles-wk-2` (had headroom, ~33% mem-requested).

## Deploy (self-heal won't work while it's wedged)
The controller self-manages the `argocd` app, so Argo can't apply its own new spec while down. Plan:
1. Merge.
2. Try letting it self-heal; if it can't, run `bootstrap-cluster` with `argocd=true` (helm-upgrade path, applies without the controller).
3. `kubectl -n argocd delete pod argocd-application-controller-0` — the StatefulSet won't evict an unready pod on its own, so force it onto the new 768Mi revision.
4. Verify controller Ready and the #627 front door propagates.

Follow-up worth considering: this is a single-replica control-plane component that sat 0/1 for ~an hour with no alert — a data point for the observability work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff4szE4XB79hk8nvAdTU2w