### PR TITLE
argocd: raise controller client-go QPS/Burst (50/100 -> 100/200)

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -2933,6 +2933,10 @@ spec:
         env:
           - name: GOMEMLIMIT
             value: 690MiB
+          - name: ARGOCD_K8S_CLIENT_QPS
+            value: "100"
+          - name: ARGOCD_K8S_CLIENT_BURST
+            value: "200"
           - name: ARGOCD_CONTROLLER_REPLICAS
             value: "1"
           - name: ARGOCD_APPLICATION_CONTROLLER_NAME

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -153,6 +153,16 @@ argo-cd:
     env:
     - name: GOMEMLIMIT
       value: "690MiB"  # ~90% of the 768Mi memory limit above; GOMEMLIMIT uses MiB/GiB units
+    # client-go's own rate limiter (not server-side API Priority & Fairness) was
+    # the dominant bottleneck: at defaults (QPS 50 / Burst 100) the controller
+    # logged "client-side throttling, not priority and fairness ... Waited before
+    # sending request" with delays up to ~25m during cold-start cache sync, which
+    # kept it from ever going Ready. The control plane has ample headroom, so lift
+    # the client limits. Applied to all argocd components via the shared env var.
+    - name: ARGOCD_K8S_CLIENT_QPS
+      value: "100"
+    - name: ARGOCD_K8S_CLIENT_BURST
+      value: "200"
     ## Application controller metrics configuration
     metrics:
       # -- Deploy metrics service


### PR DESCRIPTION
## Why

The `argocd-application-controller` has been wedging on cold start (0/1, `/healthz` never Ready), which stalled the app-of-apps sync. The **dominant signal** in the controller log is its own client-go rate limiter:

```
"client-side throttling, not priority and fairness" ... "Waited before sending request" delay=25m24s
```

That message is from client-go's token-bucket limiter (QPS/Burst) — it is explicitly **not** server-side API Priority & Fairness. At the defaults (QPS 50 / Burst 100) the cold-start cache-sync request storm queued for 10-25 minutes, so the pod never reported Ready and the `argocd-applications` sync couldn't finish. Downstream effect: the `jupyterhub` child Application never received its updated `valuesObject`, so the oauth2-proxy ingress rendered the chart-default host `notebook.placeholder.symmatree.com` and `notebook.tiles` has no DNS record.

## What

Raise the client limits via the shared env vars (applied to all argocd components):

- `ARGOCD_K8S_CLIENT_QPS: 100`
- `ARGOCD_K8S_CLIENT_BURST: 200`

Regenerated `charts/argocd/rendered.yaml` (the only collateral is the 4 env lines).

Pairs with the 768Mi / GOMEMLIMIT bump in `5b8527b` — the two **evidence-backed** root causes were memory pressure (GOMEMLIMIT 340MiB on a 384Mi cap, NumGC climbing, ~1900 goroutines) and this self-throttle. Both are self-inflicted; neither implicates the control plane.

## Honesty notes / caveats

- I did **not** independently verify the sparse `dial tcp 10.0.136.1:443: i/o timeout` lines as a dataplane fault (didn't check cilium-agent health, node state, or other pods on `tiles-wk-2`). They're a small minority of the log and are equally explained by a memory-starved, throttled pod failing its own dials, so I'm treating them as a symptom, not a separate cause.
- 100/200 is a deliberate, conservative 2x. If throttling persists after the RAM bump lands, these can go higher (e.g. 200/400) — server-side APF is the backstop, so being generous client-side is low risk on a healthy control plane.
- Verification: rendered locally with `build.sh` (helm v4.2.3 local vs v4.2.2 CI pin; the argocd chart rendered clean with only the intended 4-line diff). I have **not** applied this to the live cluster — it takes effect when the controller Deployment re-syncs (your bootstrap run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)