### PR TITLE
argocd: fix Dex Google login -- reuse oauth2-proxy client + label the secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ secrets.yaml
 *.tmp
 *.bak
 
+# Jupyter notebook checkpoint dirs (created wherever notebooks are opened)
+.ipynb_checkpoints/
+
 # Claude Code transient client state (worktree checkouts); keep the rest of .claude/
 .claude/worktrees/

--- a/charts/argocd/README.md
+++ b/charts/argocd/README.md
@@ -42,7 +42,10 @@ Configuration is managed through `values.yaml` and overridden via the Applicatio
 ### Environment-Specific Settings
 
 - Domain configuration is cluster-specific and set during bootstrap
-- OAuth credentials are stored in `google-oauth-secret` Kubernetes secret
+- Google login (Dex) and the oauth2-proxy perimeter share one GCP OAuth client,
+  stored in the `argocd-oauth2-proxy` Kubernetes secret (keys `client-id` /
+  `client-secret`). That secret is labeled `app.kubernetes.io/part-of: argocd` so
+  ArgoCD's `$secret:key` substitution in `dex.config` can read it.
 - Slack notification token stored in `slack-token` secret (referenced by notifications controller)
 
 ### Dependencies
@@ -56,7 +59,7 @@ Configuration is managed through `values.yaml` and overridden via the Applicatio
 
 ### Required Secrets
 
-- **google-oauth-secret**: Contains `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` for Google OAuth
+- **argocd-oauth2-proxy**: Contains `client-id` / `client-secret` / `cookie-secret`. The `client-id`/`client-secret` are the shared Google OAuth client used by both the oauth2-proxy perimeter and the Dex "Log in with Google" button; the Secret is labeled `app.kubernetes.io/part-of: argocd` so Dex's references resolve.
 - **slack-token**: Slack API token for notifications (referenced as `$slack-token` in notifications config)
 - **GitHub repository secret**: For accessing private Git repositories (TODO: document secret name and format)
 
@@ -201,12 +204,17 @@ kubectl logs -n argocd -l app.kubernetes.io/name=argocd-dex-server
 - Verify `cmp-tanka` ConfigMap exists: `kubectl get configmap -n argocd cmp-tanka`
 - Check plugin generate script: `kubectl get configmap -n argocd cmp-tanka -o yaml`
 
-**OAuth not working:**
+**Google login (Dex) not working:**
 
-- Note: OAuth is currently not functional (work in progress)
-- Verify `google-oauth-secret` exists: `kubectl get secret -n argocd google-oauth-secret`
-- Check Dex pod logs (see Logs section above)
-- Verify OAuth credentials are correct in the secret
+- The most common cause: the `argocd-oauth2-proxy` Secret is missing the
+  `app.kubernetes.io/part-of: argocd` label, so ArgoCD cannot read it and the Dex
+  connector's `clientID`/`clientSecret` stay literal. The dex-server log shows
+  `config referenced '$argocd-oauth2-proxy:client-id', but key does not exist in secret`.
+  Confirm the label: `kubectl get secret -n argocd argocd-oauth2-proxy -o jsonpath='{.metadata.labels}'`.
+- Verify the Secret exists and is synced: `kubectl get onepassworditem,secret -n argocd argocd-oauth2-proxy`
+- Ensure the shared GCP OAuth client has BOTH redirect URIs registered:
+  `.../oauth2/callback` (proxy) and `.../api/dex/callback` (Dex).
+- Check Dex pod logs (see Logs section above).
 
 ### Health Checks
 
@@ -227,7 +235,7 @@ Previously, ArgoCD was deployed as an umbrella chart with a `Chart.yaml` contain
 
 ### Backup Requirements
 
-All ArgoCD configuration is defined as code in Git and can be recreated from the repository. All secrets (including `google-oauth-secret`, `slack-token`, and GitHub repository credentials) are managed via OnePasswordItem CRDs that sync from 1Password. Runtime state (application sync status, etc.) is ephemeral and recreated automatically by ArgoCD on startup.
+All ArgoCD configuration is defined as code in Git and can be recreated from the repository. All secrets (including `argocd-oauth2-proxy`, `slack-token`, and GitHub repository credentials) are managed via OnePasswordItem CRDs that sync from 1Password. Runtime state (application sync status, etc.) is ephemeral and recreated automatically by ArgoCD on startup.
 
 **No Kubernetes resource backups are needed for ArgoCD** - everything can be recreated from Git and 1Password.
 

--- a/charts/argocd/README.md
+++ b/charts/argocd/README.md
@@ -206,15 +206,16 @@ kubectl logs -n argocd -l app.kubernetes.io/name=argocd-dex-server
 
 **Google login (Dex) not working:**
 
-- The most common cause: the `argocd-oauth2-proxy` Secret is missing the
-  `app.kubernetes.io/part-of: argocd` label, so ArgoCD cannot read it and the Dex
-  connector's `clientID`/`clientSecret` stay literal. The dex-server log shows
-  `config referenced '$argocd-oauth2-proxy:client-id', but key does not exist in secret`.
-  Confirm the label: `kubectl get secret -n argocd argocd-oauth2-proxy -o jsonpath='{.metadata.labels}'`.
+- On a fresh cluster, make sure the shared GCP OAuth client has BOTH redirect
+  URIs registered: `.../oauth2/callback` (proxy) and `.../api/dex/callback`
+  (Dex). A missing `/api/dex/callback` shows up as `redirect_uri_mismatch` at
+  Google.
 - Verify the Secret exists and is synced: `kubectl get onepassworditem,secret -n argocd argocd-oauth2-proxy`
-- Ensure the shared GCP OAuth client has BOTH redirect URIs registered:
-  `.../oauth2/callback` (proxy) and `.../api/dex/callback` (Dex).
-- Check Dex pod logs (see Logs section above).
+- Check Dex pod logs (see Logs section above). If they show
+  `config referenced '$argocd-oauth2-proxy:client-id', but key does not exist in secret`,
+  ArgoCD can't read the Secret -- it must carry `app.kubernetes.io/part-of: argocd`
+  (set on the OnePasswordItem in `templates/oauth2-proxy-secret.yaml`; a rendered
+  cluster gets this automatically).
 
 ### Health Checks
 

--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -143,10 +143,21 @@ data:
         name: Google
         config:
           issuer: https://accounts.google.com
-          # Connector config values starting with "$" reference Kubernetes secrets.
-          # Format: $<secret-name>:<key>
-          clientID: $google-oauth-secret:OAUTH_CLIENT_ID
-          clientSecret: $google-oauth-secret:OAUTH_CLIENT_SECRET
+          # Values starting with "$" are resolved by ARGOCD (not Dex) against
+          # Secrets labeled app.kubernetes.io/part-of=argocd, in the form
+          # $<secret-name>:<key>. If the referenced Secret lacks that label
+          # ArgoCD cannot see it, leaves the reference literal, and Google
+          # login breaks with "key does not exist in secret" in the dex log.
+          #
+          # We reuse the oauth2-proxy perimeter's Google client for Dex: one
+          # GCP OAuth client, with BOTH redirect URIs registered on it --
+          # /oauth2/callback (proxy) and /api/dex/callback (Dex). So the
+          # argocd-oauth2-proxy Secret is the single source of the client
+          # id/secret, and it is labeled part-of=argocd in
+          # templates/oauth2-proxy-secret.yaml precisely so these two
+          # references resolve. One client to rotate; no second 1Password item.
+          clientID: $argocd-oauth2-proxy:client-id
+          clientSecret: $argocd-oauth2-proxy:client-secret
   exec.enabled: "true"
   resource.customizations.ignoreResourceUpdates.ConfigMap: |
     jqPathExpressions:
@@ -1606,7 +1617,7 @@ spec:
     metadata:
       annotations:
         checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
-        checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
+        checksum/cm: 9c35afe03e088de1876dfc9cad969d3ba6f51a943e61af87e61adc1d87dcae39
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-repo-server
@@ -2066,7 +2077,7 @@ spec:
     metadata:
       annotations:
         checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
-        checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
+        checksum/cm: 9c35afe03e088de1876dfc9cad969d3ba6f51a943e61af87e61adc1d87dcae39
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-server
@@ -2530,7 +2541,7 @@ spec:
     metadata:
       annotations:
         checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
-        checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
+        checksum/cm: 9c35afe03e088de1876dfc9cad969d3ba6f51a943e61af87e61adc1d87dcae39
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-dex-server
@@ -2910,7 +2921,7 @@ spec:
     metadata:
       annotations:
         checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
-        checksum/cm: c889b4387d64060cf16f98b7d2e890cd239eb05964f383e1b42f5a9614b891a6
+        checksum/cm: 9c35afe03e088de1876dfc9cad969d3ba6f51a943e61af87e61adc1d87dcae39
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-application-controller
@@ -3387,23 +3398,21 @@ spec:
   itemPath: 'vaults/placeholder/items/argocd-slack-token'
 
 ---
-# Source: argocd/templates/google-oauth-secret.yaml
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
-metadata:
-  name: google-oauth-secret
-  namespace: "argocd"
-type: Opaque
-spec:
-  itemPath: 'vaults/placeholder/items/argocd-google-oauth'
-
----
 # Source: argocd/templates/oauth2-proxy-secret.yaml
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
   name: argocd-oauth2-proxy
   namespace: "argocd"
+  # The 1Password operator copies these labels onto the generated Secret.
+  # ArgoCD's $<secret>:<key> substitution -- used by dex.config in values.yaml to
+  # reuse this same Google client for the "Log in with Google" (Dex) button --
+  # only reads Secrets labeled part-of=argocd. Without this label the Dex
+  # connector's clientID/clientSecret references stay literal and Google login
+  # breaks. (oauth2-proxy itself reads the Secret via existingSecret regardless
+  # of this label; the label is purely for the ArgoCD/Dex side.)
+  labels:
+    app.kubernetes.io/part-of: argocd
 type: Opaque
 spec:
   itemPath: 'vaults/placeholder/items/argocd-oauth2-proxy'

--- a/charts/argocd/templates/google-oauth-secret.yaml
+++ b/charts/argocd/templates/google-oauth-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
-metadata:
-  name: google-oauth-secret
-  namespace: "{{ .Release.Namespace }}"
-type: Opaque
-spec:
-  itemPath: 'vaults/{{ required ".Values.vault_name is required" .Values.vault_name }}/items/argocd-google-oauth'

--- a/charts/argocd/templates/oauth2-proxy-secret.yaml
+++ b/charts/argocd/templates/oauth2-proxy-secret.yaml
@@ -3,6 +3,15 @@ kind: OnePasswordItem
 metadata:
   name: argocd-oauth2-proxy
   namespace: "{{ .Release.Namespace }}"
+  # The 1Password operator copies these labels onto the generated Secret.
+  # ArgoCD's $<secret>:<key> substitution -- used by dex.config in values.yaml to
+  # reuse this same Google client for the "Log in with Google" (Dex) button --
+  # only reads Secrets labeled part-of=argocd. Without this label the Dex
+  # connector's clientID/clientSecret references stay literal and Google login
+  # breaks. (oauth2-proxy itself reads the Secret via existingSecret regardless
+  # of this label; the label is purely for the ArgoCD/Dex side.)
+  labels:
+    app.kubernetes.io/part-of: argocd
 type: Opaque
 spec:
   itemPath: 'vaults/{{ required ".Values.vault_name is required" .Values.vault_name }}/items/argocd-oauth2-proxy'

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -53,10 +53,21 @@ argo-cd:
             name: Google
             config:
               issuer: https://accounts.google.com
-              # Connector config values starting with "$" reference Kubernetes secrets.
-              # Format: $<secret-name>:<key>
-              clientID: $google-oauth-secret:OAUTH_CLIENT_ID
-              clientSecret: $google-oauth-secret:OAUTH_CLIENT_SECRET
+              # Values starting with "$" are resolved by ARGOCD (not Dex) against
+              # Secrets labeled app.kubernetes.io/part-of=argocd, in the form
+              # $<secret-name>:<key>. If the referenced Secret lacks that label
+              # ArgoCD cannot see it, leaves the reference literal, and Google
+              # login breaks with "key does not exist in secret" in the dex log.
+              #
+              # We reuse the oauth2-proxy perimeter's Google client for Dex: one
+              # GCP OAuth client, with BOTH redirect URIs registered on it --
+              # /oauth2/callback (proxy) and /api/dex/callback (Dex). So the
+              # argocd-oauth2-proxy Secret is the single source of the client
+              # id/secret, and it is labeled part-of=argocd in
+              # templates/oauth2-proxy-secret.yaml precisely so these two
+              # references resolve. One client to rotate; no second 1Password item.
+              clientID: $argocd-oauth2-proxy:client-id
+              clientSecret: $argocd-oauth2-proxy:client-secret
       # Override this whole value just to remove Endpoints (needed for Cilium)
       resource.exclusions: |
         ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
@@ -347,8 +358,14 @@ oauth2-proxy:
   # 'argocd-oauth2-proxy'. The vault item's field labels must be exactly
   # 'client-id', 'client-secret', 'cookie-secret' -- those become the Secret keys
   # that the chart's existingSecret path reads.
-  #   - client-id / client-secret: from the GCP OAuth2 client 'argocd-oauth-proxy'
-  #     (redirect URI https://argocd.{cluster}.symmatree.com/oauth2/callback)
+  #   - client-id / client-secret: from the GCP OAuth2 client 'argocd-oauth-proxy'.
+  #     This one client is shared by BOTH auth layers, so register both redirect
+  #     URIs on it:
+  #       https://argocd.{cluster}.symmatree.com/oauth2/callback   (this proxy)
+  #       https://argocd.{cluster}.symmatree.com/api/dex/callback  (Dex/SSO)
+  #     The Dex "Log in with Google" button reads its client from THIS Secret
+  #     (see argo-cd.configs.cm 'dex.config' above), which is why this
+  #     OnePasswordItem is labeled part-of=argocd.
   #   - cookie-secret: openssl rand -base64 32 | head -c 32 | base64
   #
   # existingSecret is required: without it the chart renders its OWN Secret of the

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -124,9 +124,17 @@ Current OAuth clients:
   - `https://notebook.tiles.symmatree.com/hub/oauth_callback`
   - `https://notebook.tiles-test.symmatree.com/hub/oauth_callback`
 
-Future clients to add when those components are set up:
-* `argocd-oauth-client` — ArgoCD Dex Google login. Redirect URIs will be `https://argocd.{cluster}.symmatree.com/api/dex/callback`.
-* `oauth-proxy-client` — oauth2-proxy (if used). Redirect URIs will be `/oauth2/callback` on protected services.
+* **`argocd-oauth-proxy`** (GCP client) — stored in the 1Password item
+  **`argocd-oauth2-proxy`** with fields `client-id` / `client-secret` /
+  `cookie-secret`. **One client, shared by both of ArgoCD's auth layers**: the
+  oauth2-proxy perimeter and the Dex "Log in with Google" button. Register both
+  redirect URIs on it:
+  - `https://argocd.tiles.symmatree.com/oauth2/callback` (+ `tiles-test`) — proxy
+  - `https://argocd.tiles.symmatree.com/api/dex/callback` (+ `tiles-test`) — Dex
+  Dex reads its client from this same Secret via ArgoCD's `$secret:key`
+  substitution, which requires the Secret to carry the label
+  `app.kubernetes.io/part-of: argocd` (set on the OnePasswordItem in
+  `charts/argocd/templates/oauth2-proxy-secret.yaml`).
 
 #### SSH key
 


### PR DESCRIPTION
## What was broken

The ArgoCD "Log in with Google" (Dex) button was dead. Root cause, verified from the **live** `argocd-dex-server` log:

```
config referenced '$google-oauth-secret:OAUTH_CLIENT_ID', but key does not exist in secret
config referenced '$google-oauth-secret:OAUTH_CLIENT_SECRET', but key does not exist in secret
```

The `google-oauth-secret` Secret existed and synced fine from 1Password (`status: Ready=True`) -- but **ArgoCD never read it**. ArgoCD only feeds a Secret's keys into its `$<secret>:<key>` substitution map when the Secret carries `app.kubernetes.io/part-of=argocd`:

- `util/settings/settings.go` `getSecrets()` lists with `labels.Parse("app.kubernetes.io/part-of=argocd")` only, and builds the `secretValues` map from just those Secrets (verified against argo-cd `v3.3.7`).
- The `google-oauth-secret` OnePasswordItem set no labels, so its Secret was invisible to ArgoCD. Dex then received the *literal* string `$google-oauth-secret:OAUTH_CLIENT_ID` as the client ID and Google rejected the authorize step.

Confirmed live: the only `part-of=argocd`-labeled Secret in the namespace was `argocd-secret` itself.

(Note: no GSA/KSA is involved -- Dex's Google OIDC connector uses a plain web OAuth client, so that complication doesn't apply. The `admin` username/password fallback is unaffected.)

## The fix

Reuse the oauth2-proxy perimeter's Google client for Dex too -- **one GCP OAuth client, two redirect URIs** (`/oauth2/callback` for the proxy, `/api/dex/callback` for Dex), matching the working JupyterHub pattern.

- `dex.config` now references `$argocd-oauth2-proxy:client-id` / `:client-secret`.
- The `argocd-oauth2-proxy` OnePasswordItem is labeled `app.kubernetes.io/part-of: argocd`. The 1Password operator copies CR `metadata.labels` onto the generated Secret (verified in `onepassword-operator` v1.12.0 `internal/controller/onepassworditem_controller.go` -> `BuildKubernetesSecretFromOnePasswordItem`).
- Deleted the now-unused `google-oauth-secret.yaml` template (and its separate `argocd-google-oauth` 1Password item is no longer referenced).
- Docs updated (`charts/argocd/README.md`, `docs/secrets.md`) to the single-client model.

`rendered.yaml` regenerated with the CI helm version (`v4.2.2`); the render-diff is exactly: the `dex.config` change, the added label, the removed item, and the `checksum/cm` bump on the four workloads (expected -- argocd-cm content changed so the pods roll to pick it up).

## Manual step required (cannot be scripted -- GCP has no OAuth-client API)

Add redirect URI `https://argocd.{cluster}.symmatree.com/api/dex/callback` (both `tiles` and `tiles-test`) to the **`argocd-oauth-proxy`** GCP OAuth client. Until that URI is registered, Dex login will fail at Google with `redirect_uri_mismatch` even though the k8s side is correct.

## Verification

Not yet verified end-to-end in-cluster -- this needs the manual GCP redirect-URI step above and a sync first. After merge + sync, the fix is confirmed when the `argocd-dex-server` log stops emitting the `key does not exist in secret` warnings and a Google login round-trips through `/api/dex/callback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)