### PR TITLE
GitOps-managed alerting delivery path: declarative Alertmanager config + provisioned Apprise config

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -35,6 +35,29 @@ spec:
                 create: false
                 embed: true
           extraObjects:
+            # Base Alertmanager config pushed to the Mimir alertmanager (tenant =
+            # cluster name) by the mimir.alerts.kubernetes component below. Routes
+            # every alert to the in-pod alert-forward sidecar -> Apprise. Issue #635.
+            - apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: alertmgr-global
+                namespace: "alloy"
+              data:
+                config: |
+                  route:
+                    receiver: apprise
+                    group_by: ['alertname', 'severity']
+                    group_wait: 30s
+                    group_interval: 5m
+                    repeat_interval: 4h
+                  receivers:
+                    - name: apprise
+                      webhook_configs:
+                        # alert-forward sidecar shares the mimir-alertmanager pod,
+                        # so localhost:3000; it forwards to apprise /notify/apprise.
+                        - url: http://localhost:3000?template=alertmanager&key=apprise
+                          send_resolved: true
             - apiVersion: monitoring.coreos.com/v1
               kind: Probe
               metadata:
@@ -110,6 +133,26 @@ spec:
               mimir.rules.kubernetes "default" {
                 address = "http://mimir-gateway.mimir.svc"
                 tenant_id = "placeholder"
+              }
+              // Push the Alertmanager routing (-> apprise webhook sidecar) into the
+              // Mimir alertmanager for this tenant. global_config carries the full
+              // config; AlertmanagerConfig CRs labelled mimir.alerts=enabled merge in.
+              // Tenant is set via the X-Scope-OrgID header (no tenant_id arg here).
+              remote.kubernetes.configmap "alertmgr_global" {
+                namespace = "alloy"
+                name      = "alertmgr-global"
+              }
+              mimir.alerts.kubernetes "default" {
+                address       = "http://mimir-gateway.mimir.svc"
+                global_config = remote.kubernetes.configmap.alertmgr_global.data["config"]
+                http_headers  = {
+                  "X-Scope-OrgID" = ["placeholder"],
+                }
+                alertmanagerconfig_selector {
+                  match_labels = {
+                    "mimir.alerts" = "enabled",
+                  }
+                }
               }
     - repoURL: https://github.com/symmatree/tiles.git
       targetRevision: 'placeholder'
@@ -194,6 +237,8 @@ spec:
             cluster_issuer: "real-cert"
             apprise_env: 'placeholder-apprise-env'
             apprise_admin: 'placeholder-apprise-admin'
+            # Shared across clusters (no prefix); field config.yml holds the Slack/Gmail URLs.
+            apprise_config: 'apprise-config'
   destination:
     server: https://kubernetes.default.svc
     namespace: apprise

--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -35,29 +35,29 @@ spec:
                 create: false
                 embed: true
           extraObjects:
-            # Base Alertmanager config pushed to the Mimir alertmanager (tenant =
-            # cluster name) by the mimir.alerts.kubernetes component below. Routes
-            # every alert to the in-pod alert-forward sidecar -> Apprise. Issue #635.
-            - apiVersion: v1
-              kind: ConfigMap
+            # Per-tenant Alertmanager routing, pushed to the Mimir alertmanager by
+            # mimir.alerts.kubernetes below. Labelled by tenant so each tenant's
+            # routing is its own git object. With strategy=None this route is a
+            # tenant-wide catch-all -> the in-pod alert-forward sidecar -> Apprise.
+            # route.receiver must be a REAL receiver here (not "null"), or alerts
+            # fall through the merged config and get dropped. Issue #635.
+            - apiVersion: monitoring.coreos.com/v1alpha1
+              kind: AlertmanagerConfig
               metadata:
-                name: alertmgr-global
+                name: apprise-catchall
                 namespace: "alloy"
-              data:
-                config: |
-                  route:
-                    receiver: apprise
-                    group_by: ['alertname', 'severity']
-                    group_wait: 30s
-                    group_interval: 5m
-                    repeat_interval: 4h
-                  receivers:
-                    - name: apprise
-                      webhook_configs:
-                        # alert-forward sidecar shares the mimir-alertmanager pod,
-                        # so localhost:3000; it forwards to apprise /notify/apprise.
-                        - url: http://localhost:3000?template=alertmanager&key=apprise
-                          send_resolved: true
+                labels:
+                  mimir_tenant: 'placeholder'
+              spec:
+                route:
+                  receiver: apprise
+                receivers:
+                  - name: apprise
+                    webhookConfigs:
+                      # alert-forward sidecar shares the mimir-alertmanager pod,
+                      # so localhost:3000; it forwards to apprise /notify/apprise.
+                      - url: http://localhost:3000?template=alertmanager&key=apprise
+                        sendResolved: true
             - apiVersion: monitoring.coreos.com/v1
               kind: Probe
               metadata:
@@ -129,29 +129,37 @@ spec:
                               port:
                                 number: 4318
           alloy-singleton:
+            alloy:
+              # mimir.alerts.kubernetes is an experimental Alloy component.
+              stabilityLevel: experimental
             extraConfig: |-
               mimir.rules.kubernetes "default" {
                 address = "http://mimir-gateway.mimir.svc"
                 tenant_id = "placeholder"
               }
-              // Push the Alertmanager routing (-> apprise webhook sidecar) into the
-              // Mimir alertmanager for this tenant. global_config carries the full
-              // config; AlertmanagerConfig CRs labelled mimir.alerts=enabled merge in.
-              // Tenant is set via the X-Scope-OrgID header (no tenant_id arg here).
-              remote.kubernetes.configmap "alertmgr_global" {
-                namespace = "alloy"
-                name      = "alertmgr-global"
-              }
+              // Push per-tenant Alertmanager routing to the Mimir alertmanager. This
+              // component has no tenant_id arg, so the tenant is the X-Scope-OrgID
+              // header. global_config is only a null default -- the real routing lives
+              // in per-tenant AlertmanagerConfig CRs (label mimir_tenant=<cluster>),
+              // merged as a tenant-wide catch-all via strategy=None.
               mimir.alerts.kubernetes "default" {
                 address       = "http://mimir-gateway.mimir.svc"
-                global_config = remote.kubernetes.configmap.alertmgr_global.data["config"]
+                global_config = "global:\n  resolve_timeout: 5m\nroute:\n  receiver: \"null\"\nreceivers:\n- name: \"null\"\n"
                 http_headers  = {
                   "X-Scope-OrgID" = ["placeholder"],
                 }
                 alertmanagerconfig_selector {
                   match_labels = {
-                    "mimir.alerts" = "enabled",
+                    mimir_tenant = "placeholder",
                   }
+                }
+                alertmanagerconfig_namespace_selector {
+                  match_labels = {
+                    "kubernetes.io/metadata.name" = "alloy",
+                  }
+                }
+                alertmanagerconfig_matcher {
+                  strategy = "None"
                 }
               }
     - repoURL: https://github.com/symmatree/tiles.git

--- a/charts/argocd-applications/templates/alloy-application.yaml
+++ b/charts/argocd-applications/templates/alloy-application.yaml
@@ -33,6 +33,29 @@ spec:
                 create: false
                 embed: true
           extraObjects:
+            # Base Alertmanager config pushed to the Mimir alertmanager (tenant =
+            # cluster name) by the mimir.alerts.kubernetes component below. Routes
+            # every alert to the in-pod alert-forward sidecar -> Apprise. Issue #635.
+            - apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: alertmgr-global
+                namespace: "alloy"
+              data:
+                config: |
+                  route:
+                    receiver: apprise
+                    group_by: ['alertname', 'severity']
+                    group_wait: 30s
+                    group_interval: 5m
+                    repeat_interval: 4h
+                  receivers:
+                    - name: apprise
+                      webhook_configs:
+                        # alert-forward sidecar shares the mimir-alertmanager pod,
+                        # so localhost:3000; it forwards to apprise /notify/apprise.
+                        - url: http://localhost:3000?template=alertmanager&key=apprise
+                          send_resolved: true
             - apiVersion: monitoring.coreos.com/v1
               kind: Probe
               metadata:
@@ -108,6 +131,26 @@ spec:
               mimir.rules.kubernetes "default" {
                 address = "http://mimir-gateway.mimir.svc"
                 tenant_id = "{{ required ".Values.cluster_name is required" .Values.cluster_name }}"
+              }
+              // Push the Alertmanager routing (-> apprise webhook sidecar) into the
+              // Mimir alertmanager for this tenant. global_config carries the full
+              // config; AlertmanagerConfig CRs labelled mimir.alerts=enabled merge in.
+              // Tenant is set via the X-Scope-OrgID header (no tenant_id arg here).
+              remote.kubernetes.configmap "alertmgr_global" {
+                namespace = "alloy"
+                name      = "alertmgr-global"
+              }
+              mimir.alerts.kubernetes "default" {
+                address       = "http://mimir-gateway.mimir.svc"
+                global_config = remote.kubernetes.configmap.alertmgr_global.data["config"]
+                http_headers  = {
+                  "X-Scope-OrgID" = ["{{ required ".Values.cluster_name is required" .Values.cluster_name }}"],
+                }
+                alertmanagerconfig_selector {
+                  match_labels = {
+                    "mimir.alerts" = "enabled",
+                  }
+                }
               }
     - repoURL: https://github.com/symmatree/tiles.git
       targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'

--- a/charts/argocd-applications/templates/alloy-application.yaml
+++ b/charts/argocd-applications/templates/alloy-application.yaml
@@ -33,29 +33,29 @@ spec:
                 create: false
                 embed: true
           extraObjects:
-            # Base Alertmanager config pushed to the Mimir alertmanager (tenant =
-            # cluster name) by the mimir.alerts.kubernetes component below. Routes
-            # every alert to the in-pod alert-forward sidecar -> Apprise. Issue #635.
-            - apiVersion: v1
-              kind: ConfigMap
+            # Per-tenant Alertmanager routing, pushed to the Mimir alertmanager by
+            # mimir.alerts.kubernetes below. Labelled by tenant so each tenant's
+            # routing is its own git object. With strategy=None this route is a
+            # tenant-wide catch-all -> the in-pod alert-forward sidecar -> Apprise.
+            # route.receiver must be a REAL receiver here (not "null"), or alerts
+            # fall through the merged config and get dropped. Issue #635.
+            - apiVersion: monitoring.coreos.com/v1alpha1
+              kind: AlertmanagerConfig
               metadata:
-                name: alertmgr-global
+                name: apprise-catchall
                 namespace: "alloy"
-              data:
-                config: |
-                  route:
-                    receiver: apprise
-                    group_by: ['alertname', 'severity']
-                    group_wait: 30s
-                    group_interval: 5m
-                    repeat_interval: 4h
-                  receivers:
-                    - name: apprise
-                      webhook_configs:
-                        # alert-forward sidecar shares the mimir-alertmanager pod,
-                        # so localhost:3000; it forwards to apprise /notify/apprise.
-                        - url: http://localhost:3000?template=alertmanager&key=apprise
-                          send_resolved: true
+                labels:
+                  mimir_tenant: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+              spec:
+                route:
+                  receiver: apprise
+                receivers:
+                  - name: apprise
+                    webhookConfigs:
+                      # alert-forward sidecar shares the mimir-alertmanager pod,
+                      # so localhost:3000; it forwards to apprise /notify/apprise.
+                      - url: http://localhost:3000?template=alertmanager&key=apprise
+                        sendResolved: true
             - apiVersion: monitoring.coreos.com/v1
               kind: Probe
               metadata:
@@ -127,29 +127,37 @@ spec:
                               port:
                                 number: 4318
           alloy-singleton:
+            alloy:
+              # mimir.alerts.kubernetes is an experimental Alloy component.
+              stabilityLevel: experimental
             extraConfig: |-
               mimir.rules.kubernetes "default" {
                 address = "http://mimir-gateway.mimir.svc"
                 tenant_id = "{{ required ".Values.cluster_name is required" .Values.cluster_name }}"
               }
-              // Push the Alertmanager routing (-> apprise webhook sidecar) into the
-              // Mimir alertmanager for this tenant. global_config carries the full
-              // config; AlertmanagerConfig CRs labelled mimir.alerts=enabled merge in.
-              // Tenant is set via the X-Scope-OrgID header (no tenant_id arg here).
-              remote.kubernetes.configmap "alertmgr_global" {
-                namespace = "alloy"
-                name      = "alertmgr-global"
-              }
+              // Push per-tenant Alertmanager routing to the Mimir alertmanager. This
+              // component has no tenant_id arg, so the tenant is the X-Scope-OrgID
+              // header. global_config is only a null default -- the real routing lives
+              // in per-tenant AlertmanagerConfig CRs (label mimir_tenant=<cluster>),
+              // merged as a tenant-wide catch-all via strategy=None.
               mimir.alerts.kubernetes "default" {
                 address       = "http://mimir-gateway.mimir.svc"
-                global_config = remote.kubernetes.configmap.alertmgr_global.data["config"]
+                global_config = "global:\n  resolve_timeout: 5m\nroute:\n  receiver: \"null\"\nreceivers:\n- name: \"null\"\n"
                 http_headers  = {
                   "X-Scope-OrgID" = ["{{ required ".Values.cluster_name is required" .Values.cluster_name }}"],
                 }
                 alertmanagerconfig_selector {
                   match_labels = {
-                    "mimir.alerts" = "enabled",
+                    mimir_tenant = "{{ required ".Values.cluster_name is required" .Values.cluster_name }}",
                   }
+                }
+                alertmanagerconfig_namespace_selector {
+                  match_labels = {
+                    "kubernetes.io/metadata.name" = "alloy",
+                  }
+                }
+                alertmanagerconfig_matcher {
+                  strategy = "None"
                 }
               }
     - repoURL: https://github.com/symmatree/tiles.git

--- a/charts/install-crds.sh
+++ b/charts/install-crds.sh
@@ -24,6 +24,9 @@ kubectl apply --server-side --force-conflicts -f "https://raw.githubusercontent.
 kubectl apply --server-side --force-conflicts -f "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${PROMETHEUS_OPERATOR_VERSION}/example/prometheus-operator-crd-full/monitoring.coreos.com_probes.yaml"
 kubectl apply --server-side --force-conflicts -f "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${PROMETHEUS_OPERATOR_VERSION}/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusrules.yaml"
 kubectl apply --server-side --force-conflicts -f "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${PROMETHEUS_OPERATOR_VERSION}/example/prometheus-operator-crd-full/monitoring.coreos.com_scrapeconfigs.yaml"
+# AlertmanagerConfig: consumed by Alloy's mimir.alerts.kubernetes to push the
+# alertmanager routing (-> apprise webhook) into the Mimir alertmanager per tenant.
+kubectl apply --server-side --force-conflicts -f "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${PROMETHEUS_OPERATOR_VERSION}/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml"
 # gateway-api
 kubectl apply --server-side --force-conflicts -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
 # cert-manager

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -142,6 +142,19 @@ Future clients to add when those components are set up:
 
 See `charts/jupyterhub/README.md` for the full secrets architecture.
 
+## Apprise
+
+Apprise (the notification service) uses three 1Password items in the cluster vault:
+
+### Terraform-managed (automatic)
+
+* `{cluster_name}-apprise-env` -- `SECRET_KEY` for the Apprise API. Created by `tf/modules/k8s-cluster/apprise.tf`.
+* `{cluster_name}-apprise-admin` -- admin username/password and `.htpasswd` for the web UI. Created by `apprise.tf`.
+
+### Manual (one-time, shared across clusters)
+
+* `apprise-config` -- **no cluster prefix**; a Secure Note with a `config.yml` field holding the actual notification routing (Slack URLs, Gmail echo, tags). Synced to an `apprise-config` Secret by the OnePassword operator and mounted read-only at `/config/apprise.yml`, so `/notify/apprise` uses it. **This is the delivery config itself -- if it is empty or wrong, alerts reach nobody.** It is intentionally declarative (secret-mounted, not the old paste-into-the-UI PVC), so it survives a cluster rebuild; edit it in 1Password and restart the apprise pod to apply. See `tanka/environments/apprise/README.md`.
+
 ## Runtime / Github Actions
 
 Github has a single secret, `ONEPASSWORD_SA_TOKEN`, which allows a workflow to call

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -12,7 +12,7 @@
 * [Workload Identity](https://github.com/symmatree/tiles/issues/41) for the cluster(s),
   enrolling in federated identity so any KSA can be matched to a GSA and we don't need
   actual SA keys any longer, only the email addresses.
-* [Setup](https://github.com/symmatree/tiles/issues/30) ArgoCD notifications to be sent to Apprise
+* Alertmanager alerts -> Apprise delivery is gitops-managed via Alloy `mimir.alerts.kubernetes` (#635). The old #30 (ArgoCD's native notifications -> Apprise) is closed; revisit only if that separate channel is wanted.
 * Transition DNS and certs for external servers (unifi, home assistant, etc)
   from "tales" cluster to "tiles". Either hand over the `local.symmatree.com` domain
   or just switch to using `tiles.symmatree.com`.

--- a/tanka/environments/apprise/README.md
+++ b/tanka/environments/apprise/README.md
@@ -60,9 +60,9 @@ Configuration is managed through the Application's plugin parameters:
 - **Apprise Admin**: Stored in 1Password as `{cluster_name}-apprise-admin`
   - Created by Terraform (`tf/modules/k8s-cluster/apprise.tf`)
   - Contains admin username/password and `.htpasswd` file
-- **Apprise Config**: Stored in 1Password as `apprise-config` (manually created)
-  - Contains notification service configuration (Slack, Gmail, etc.)
-  - Must be pasted into the Apprise UI if it gets wiped
+- **Apprise Config**: Stored in 1Password as `apprise-config` (shared across clusters, field `config.yml`)
+  - Contains the notification routing (Slack, Gmail, etc.)
+  - Synced to a Secret by the OnePassword operator and mounted read-only at `/config/apprise.yml`; `/notify/apprise` uses it. Edit in 1Password and restart the pod to apply -- no longer pasted into the UI, so a cluster rebuild can't silently empty it (issue #635).
 
 ### Required Infrastructure
 
@@ -145,11 +145,11 @@ kubectl logs -n apprise -l app=apprise
 - Check `.htpasswd` file is correct in the secret
 - Verify OnePasswordItem is synced: `kubectl get onepassworditem {cluster_name}-apprise-admin -n apprise`
 
-**Config lost:**
+**Config lost / not delivering:**
 
-- Apprise config is stored in PVC and may be lost if PVC is deleted
-- Restore from 1Password `apprise-config` item via the configuration UI
-- TODO: Move config to a proper provisioned secret
+- Config is provisioned from the 1Password `apprise-config` item (secret-mounted at `/config/apprise.yml`); it is not on a PVC and cannot be lost on rebuild.
+- If targets are wrong/empty, fix the `config.yml` field in the `apprise-config` 1Password item and restart the pod (`kubectl -n apprise rollout restart deploy/apprise`).
+- Confirm the sync: `kubectl -n apprise get secret apprise-config` and `kubectl -n apprise get onepassworditem apprise-config`.
 
 ### Health Checks
 
@@ -168,13 +168,13 @@ kubectl logs -n apprise -l app=apprise
 
 ### Backup Requirements
 
-- **Apprise Config**: Stored in PVC, should be backed up from 1Password `apprise-config` item
+- **Apprise Config**: Lives in the 1Password `apprise-config` item (source of truth; secret-mounted into the pod)
 - **Admin Credentials**: Stored in 1Password, backed up there
 - **Environment Secret**: Stored in 1Password, backed up there
 
 ### Known Limitations
 
-- **Config Storage**: Apprise config is stored in PVC and may be lost if PVC is deleted (should be moved to a provisioned secret)
+- **Config editing**: The notification config is secret-mounted read-only from 1Password `apprise-config` (survives rebuilds); it is not editable via the web UI -- change it in 1Password and restart the pod.
 - **Single Instance**: Apprise runs as a single instance (no HA)
 
 ## Usage
@@ -190,7 +190,7 @@ Services can send notifications to Apprise via:
 
 ### Configuration Management
 
-Apprise configuration is managed via the web UI at `https://apprise.{cluster_name}.symmatree.com/cfg/apprise`. The configuration YAML is stored in 1Password `apprise-config` item and should be pasted back into the UI if it gets wiped.
+The notification config (the `apprise` key) is provisioned declaratively: the `config.yml` field of the 1Password `apprise-config` item is synced to a Secret by the OnePassword operator and mounted read-only at `/config/apprise.yml`. To change routing, edit the item in 1Password and restart the pod. (The web UI at `/cfg/apprise` reflects the mounted config but cannot persist edits -- the mount is read-only by design so a rebuild can't empty it.)
 
 ### Key Services Pattern
 

--- a/tanka/environments/apprise/application.yaml
+++ b/tanka/environments/apprise/application.yaml
@@ -25,6 +25,8 @@ spec:
             cluster_issuer: "real-cert"
             apprise_env: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-apprise-env'
             apprise_admin: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}-apprise-admin'
+            # Shared across clusters (no prefix); field config.yml holds the Slack/Gmail URLs.
+            apprise_config: 'apprise-config'
   destination:
     server: https://kubernetes.default.svc
     namespace: apprise

--- a/tanka/environments/apprise/main.jsonnet
+++ b/tanka/environments/apprise/main.jsonnet
@@ -29,6 +29,7 @@ local apprise = {
     // Ref https://github.com/caronc/apprise-api#environment-variables
     envSecret: APP.app_settings.apprise_env,
     htpasswdSecret: APP.app_settings.apprise_admin,
+    configSecret: APP.app_settings.apprise_config,
     port: kPort.newNamed(8000, 'http'),
     ingressAnnotations: {
       'cert-manager.io/cluster-issuer': APP.app_settings.cluster_issuer,
@@ -41,9 +42,10 @@ local apprise = {
     local config = defaults + overrides,
     envSecret: op.item.new(config.envSecret, 'vaults/' + APP.vault_name + '/items/' + config.envSecret),
     htpasswd: op.item.new(config.htpasswdSecret, 'vaults/' + APP.vault_name + '/items/' + config.htpasswdSecret),
-    configPvc: kPersistentVolumeClaim.new(std.format('%s-config', config.name))
-               + kPersistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
-               + kPersistentVolumeClaim.spec.resources.withRequestsMixin({ storage: '1Gi' }),
+    // Notification config (Slack/Gmail URLs) synced from 1Password 'apprise-config'
+    // (field config.yml), mounted read-only at /config/apprise.yml so /notify/apprise
+    // uses it. Off local-path so a node rebuild can't silently empty it (issue #635).
+    configSecret: op.item.new(config.configSecret, 'vaults/' + APP.vault_name + '/items/' + config.configSecret),
     attachPvc: kPersistentVolumeClaim.new(std.format('%s-attach', config.name))
                + kPersistentVolumeClaim.spec.withAccessModes(['ReadWriteOnce'])
                + kPersistentVolumeClaim.spec.resources.withRequestsMixin({ storage: '10Gi' }),
@@ -93,7 +95,15 @@ local apprise = {
         + readinessProbe.withFailureThreshold(3),
       ])
       + kDeployment.spec.template.spec.withTerminationGracePeriodSeconds(30)
-      + k_util.pvcVolumeMount(appriseObj.configPvc.metadata.name, '/config')
+      // /config is a writable emptyDir (apprise's store/ cache lives here); the
+      // per-key notification config is layered in read-only from the secret.
+      + k_util.emptyVolumeMount('config', '/config')
+      + k_util.secretVolumeMount(
+        appriseObj.configSecret.metadata.name,
+        '/config/apprise.yml',
+        420,
+        kVolumeMount.withSubPath('config.yml') + kVolumeMount.withReadOnly(true)
+      )
       + k_util.pvcVolumeMount(appriseObj.attachPvc.metadata.name, '/attach')
       + k_util.configMapVolumeMount(
         appriseObj.nginxConfig,


### PR DESCRIPTION
Closes #635. Makes the alert-delivery path (Mimir Alertmanager -> alert-forward sidecar -> Apprise -> Slack/Gmail) gitops-managed **and per-tenant configurable**, so it stops silently rotting and can differ across tenants.

## The breaks this fixes
1. **Alertmanager routing** was a hand-upload in Mimir NFS state pointing at a nonexistent `apprise-webhook:3000` with `key=logger` -- the sidecar received nothing for 12 days.
2. **Apprise config** was on node-local `local-path`, wiped by the July-11 rebuild -- zero delivery targets.

## Design (verified against the Alloy + prometheus-operator docs, not guessed)
**Per-tenant Alertmanager routing via Alloy `mimir.alerts.kubernetes`** (`charts/argocd-applications/templates/alloy-application.yaml`)
- Routing lives in a per-tenant **`AlertmanagerConfig` resource** labelled `mimir_tenant=<cluster>` -- the git-managed unit that lets each tenant differ. A shared global/fallback config cannot do per-tenant, which is the whole point.
- `global_config` is a minimal inline `"null"` default. The top-level default receiver must live there (a CR can't supply it); all real routing is delegated to the CR.
- `strategy = "None"` makes the CR's route a tenant-wide catch-all; its `route.receiver` is the real `apprise` receiver (not `"null"`), so alerts don't fall through and drop.
- Tenant is set via `X-Scope-OrgID` (no `tenant_id` arg on this component). A second tenant = a second `mimir.alerts.kubernetes` block + a CR with a different `mimir_tenant` label.
- The receiver webhooks to the in-pod sidecar: `http://localhost:3000?template=alertmanager&key=apprise`.
- `mimir.alerts.kubernetes` is experimental -> singleton bumped to `alloy.stabilityLevel: experimental` (value path verified: renders `--stability.level=experimental` via the grafana/alloy subchart passthrough).
- `install-crds.sh` gains the `AlertmanagerConfig` CRD (v0.86.2). Prereqs verified already satisfied: Mimir `alertmanager.enable_api=true`; the singleton clusterrole already grants `alertmanagerconfigs`.

**Apprise -> secret-to-file** (`tanka/environments/apprise/main.jsonnet`)
- 1Password `apprise-config` (`config.yml`) synced to a Secret, mounted read-only at `/config/apprise.yml`; `/config` is a writable emptyDir. Off local-path; declarative; survives rebuilds.

**Docs**: `docs/secrets.md` Apprise section added; apprise README's PVC/paste-into-UI language corrected; `docs/todo.md` #30 reconciled.

## Validation
- Apprise jsonnet + `charts/argocd-applications/rendered.yaml` render-checked (helm v4.2.2). Render-diff = the `AlertmanagerConfig`, the `mimir.alerts.kubernetes` block, `stabilityLevel`, the apprise secret mount -- nothing adjacent disturbed.
- The River config itself validates at Alloy runtime, not helm-template time (every piece is doc-grounded, but that's the one thing only the pod confirms).

## Deploy notes / ordering
- The `AlertmanagerConfig` CRD must exist before the alloy app syncs. **Already applied live** ahead of merge; and on a rebuild the `crds` bootstrap step runs before `argocd_applications`, so it's covered both ways.
- Separate, pre-existing break (NOT in this PR): `mimir.rules.kubernetes` is currently failing on `per-user rule groups limit (70; actual 71)`, so alert **rules** aren't fully loading. Needs a `ruler_max_rule_groups_per_tenant` bump in Mimir limits -- tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff4szE4XB79hk8nvAdTU2w