### PR TITLE
mimir: raise ruler_max_rule_groups_per_tenant 70 -> 200 (rules failing to sync)

### DIFF
--- a/charts/argocd-applications/values/mimir-values.yaml
+++ b/charts/argocd-applications/values/mimir-values.yaml
@@ -18,6 +18,11 @@ mimir:
       enabled: true
     limits:
       ruler_max_rules_per_rule_group: 100
+      # Raised from the Mimir default of 70. The single tenant already has 71 rule
+      # groups (kubernetes/node-exporter/argocd/cert-manager/cilium/... mixins), so
+      # mimir.rules.kubernetes was failing to sync ("per-user rule groups limit
+      # (limit: 70 actual: 71) exceeded"). 200 leaves room to grow.
+      ruler_max_rule_groups_per_tenant: 200
       # default is 150000 per user, we are currently all in one
       max_global_series_per_user: 500000
       max_fetched_chunks_per_query: 4000000


### PR DESCRIPTION
`mimir.rules.kubernetes` is currently failing every reconcile:

```
per-user rule groups limit (limit: 70 actual: 71) exceeded
```

So alert **rules** aren't fully loading into the Mimir ruler right now — alerting is broken on the rules-ingestion side, independent of delivery. The tenant already has 71 rule groups from the mixins (kubernetes / node-exporter / argocd / cert-manager / cilium / ...), and Mimir's default `ruler_max_rule_groups_per_tenant` is 70.

This raises it to 200 (headroom to grow) in `mimir.structuredConfig.limits`. Values-only change (path-referenced `valueFiles`), so no rendered.yaml impact.

Found while wiring the gitops alerting delivery path (#635); kept separate because it's a different subsystem (ruler ingestion vs. alertmanager delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff4szE4XB79hk8nvAdTU2w