### PR TITLE
argocd: loosen repo-server liveness/readiness probes for ~60s Tanka stalls (#573)

### DIFF
--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -1929,18 +1929,18 @@ spec:
             port: metrics
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 5
+          timeoutSeconds: 30
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /healthz
             port: metrics
           initialDelaySeconds: 10
           periodSeconds: 10
-          timeoutSeconds: 1
+          timeoutSeconds: 10
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 6
         resources:
           {}
         securityContext:

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -292,10 +292,21 @@ argo-cd:
     # webhooks-github-token:
 
   repoServer:
-    # Repo-server main container: allow healthz to survive brief load spikes (default timeout 1s is tight).
+    # The Tanka CMP's MatchRepository/GenerateManifest stalls run ~60s (see the
+    # gRPC-deadline note under params below), far longer than the old 5s liveness
+    # timeout -- so the deep /healthz?full=true probe timed out and kubelet SIGKILL'd
+    # a repo-server that was only slow, crashlooping it and blocking every Tanka and
+    # multi-source app from rendering (this is #573, whose "OOM" title is a
+    # misdiagnosis: exit 137 came from "failed liveness probe", no mem limit is set,
+    # and the node was not under memory pressure). Tolerate the known stalls.
     livenessProbe:
-      timeoutSeconds: 5
-      failureThreshold: 3
+      timeoutSeconds: 30
+      failureThreshold: 6
+    # Default readiness (timeoutSeconds 1) also flaps the single repo-server out of
+    # its Service under the same load; give it headroom too.
+    readinessProbe:
+      timeoutSeconds: 10
+      failureThreshold: 6
     ## Repo-server metrics service configuration
     metrics:
       # -- Deploy metrics service


### PR DESCRIPTION
The argocd-repo-server is crashlooping and blocking every Tanka / multi-source app from rendering (`alloy`, `apprise` go `SYNC=Unknown` with `connection refused`). This is what stalled the alerting deploy (#635).

## Mechanism (verified, and it's NOT what #573's title says)
- Events: `Killing: Container repo-server failed liveness probe, will be restarted` + `Liveness probe failed: GET /healthz?full=true: context deadline exceeded`. Containers exit **137 (SIGKILL)** with `reason=Error` (not `OOMKilled`).
- `resources: {}` (no memory limit) and node `MemoryPressure=False` -- so **not OOM**. #573's "OOM" framing is a misdiagnosis.
- The repo's own values already document that **Tanka CMP stalls run ~60s** (the reason `controller.repo.server.timeout.seconds` was bumped to 300). But the liveness probe is `/healthz?full=true` (a deep check) at `timeoutSeconds: 5`, so a repo-server that's merely slow for ~60s during a Tanka render gets killed. Restart -> re-vendor tk/jb -> render slowly -> killed again. Self-perpetuating.

## Change
`charts/argocd/values.yaml` repoServer:
- `livenessProbe`: `timeoutSeconds 5 -> 30`, `failureThreshold 3 -> 6`
- `readinessProbe`: `timeoutSeconds 1 -> 10`, `failureThreshold 3 -> 6` (default 1s readiness flaps the single replica out of its Service under the same load)

Render-diff is exactly those four values (helm v4.2.2). No resource limits added -- deliberately, since it isn't a memory problem.

## Not applied
This only changes git. Applying it to the running (crashlooping) repo-server is a separate step to decide -- likely re-running the bootstrap Argo install (helm upgrade) rather than an imperative patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ff4szE4XB79hk8nvAdTU2w