### PR TITLE
resources: fleet requests/limits + repo-server parallelism 4→2

### DIFF
--- a/charts/argocd-applications/values/alloy-values.yaml
+++ b/charts/argocd-applications/values/alloy-values.yaml
@@ -67,6 +67,13 @@ clusterMetrics:
   node-exporter:
     enabled: true
     deploy: true
+    # 3-day peak working-set ~31Mi (Mimir). Path assumes the prometheus-node-exporter
+    # subchart reads resources here; the render-diff confirms it lands on the DaemonSet.
+    resources:
+      requests:
+        memory: 64Mi
+      limits:
+        memory: 128Mi
     metricsTuning:
       useDefaultAllowList: true
       useIntegrationAllowList: true

--- a/charts/argocd-applications/values/mimir-tiles-values.yaml
+++ b/charts/argocd-applications/values/mimir-tiles-values.yaml
@@ -15,3 +15,12 @@ store_gateway:
   resources:
     requests:
       memory: 1Gi
+
+alertmanager:
+  # 3-day peak working-set ~78Mi (Mimir). (The alert-forward sidecar, ~88Mi, is
+  # a separate container and is left unbounded for now.)
+  resources:
+    requests:
+      memory: 128Mi
+    limits:
+      memory: 256Mi

--- a/charts/argocd/rendered.yaml
+++ b/charts/argocd/rendered.yaml
@@ -289,10 +289,10 @@ data:
   otlp.address: ""
   redis.server: argocd-redis:6379
   repo.server: argocd-repo-server:8081
-  reposerver.git.lsremote.parallelism.limit: "4"
+  reposerver.git.lsremote.parallelism.limit: "2"
   reposerver.log.format: text
   reposerver.log.level: trace
-  reposerver.parallelism.limit: "4"
+  reposerver.parallelism.limit: "2"
   reposerver.repo.cache.expiration: 30m
   server.dex.server: https://argocd-dex-server:5556
   server.dex.server.strict.tls: "false"
@@ -1321,7 +1321,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
+        checksum/cmd-params: 3cee5bc94fe67a73309018177220770fd62b01dac6cd7d1e80c6bb92710747c7
       labels:
         helm.sh/chart: argo-cd-9.5.2
         app.kubernetes.io/name: argocd-applicationset-controller
@@ -1616,7 +1616,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
+        checksum/cmd-params: 3cee5bc94fe67a73309018177220770fd62b01dac6cd7d1e80c6bb92710747c7
         checksum/cm: 9c35afe03e088de1876dfc9cad969d3ba6f51a943e61af87e61adc1d87dcae39
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -1942,7 +1942,8 @@ spec:
           successThreshold: 1
           failureThreshold: 6
         resources:
-          {}
+          requests:
+            memory: 160Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1964,6 +1965,9 @@ spec:
           /var/run/argocd/argocd-cmp-server
         image: prontotools/alpine-git-curl:latest
         name: tanka
+        resources:
+          requests:
+            memory: 192Mi
         securityContext:
           runAsNonRoot: true
           runAsUser: 999
@@ -1989,7 +1993,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: copyutil
         resources:
-          {}
+          requests:
+            memory: 160Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -2076,7 +2081,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
+        checksum/cmd-params: 3cee5bc94fe67a73309018177220770fd62b01dac6cd7d1e80c6bb92710747c7
         checksum/cm: 9c35afe03e088de1876dfc9cad969d3ba6f51a943e61af87e61adc1d87dcae39
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2540,7 +2545,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
+        checksum/cmd-params: 3cee5bc94fe67a73309018177220770fd62b01dac6cd7d1e80c6bb92710747c7
         checksum/cm: 9c35afe03e088de1876dfc9cad969d3ba6f51a943e61af87e61adc1d87dcae39
       labels:
         helm.sh/chart: argo-cd-9.5.2
@@ -2920,7 +2925,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cmd-params: dcae8d8ffc248c16abbd852d384b92fadf4611373c0e28824bebd33b0a0b6899
+        checksum/cmd-params: 3cee5bc94fe67a73309018177220770fd62b01dac6cd7d1e80c6bb92710747c7
         checksum/cm: 9c35afe03e088de1876dfc9cad969d3ba6f51a943e61af87e61adc1d87dcae39
       labels:
         helm.sh/chart: argo-cd-9.5.2

--- a/charts/argocd/values.yaml
+++ b/charts/argocd/values.yaml
@@ -134,8 +134,8 @@ argo-cd:
       otlp.address: ""
       server.insecure: true
       # Cap concurrent manifest generation and git ls-remote during cold start (see repoServer.livenessProbe).
-      reposerver.parallelism.limit: "4"
-      reposerver.git.lsremote.parallelism.limit: "4"
+      reposerver.parallelism.limit: "2"
+      reposerver.git.lsremote.parallelism.limit: "2"
       # Tanka CMP MatchRepository / GenerateManifest stalls are observed to last
       # ~60s and consistently hit the default controller -> repo-server gRPC
       # deadline of 60s, leaving the affected apps stuck in Unknown. We have
@@ -292,6 +292,14 @@ argo-cd:
     # webhooks-github-token:
 
   repoServer:
+    # Requests only (no limit yet): give the scheduler a realistic footprint so
+    # the repo-server pod stops bin-packing onto a full node as if it needs zero
+    # RAM. Sized from 21d Mimir working-set (repo-server container ~170Mi avg,
+    # tanka sidecar ~193Mi avg -- tanka is the bigger of the two). A limit is
+    # deferred until we see the effect of the parallelism 4->2 reduction.
+    resources:
+      requests:
+        memory: 160Mi
     # The Tanka CMP's MatchRepository/GenerateManifest stalls run ~60s (see the
     # gRPC-deadline note under params below), far longer than the old 5s liveness
     # timeout -- so the deep /healthz?full=true probe timed out and kubelet SIGKILL'd
@@ -321,6 +329,9 @@ argo-cd:
       - name: tanka
         # We need git for downloading dependencies with jb.
         image: prontotools/alpine-git-curl:latest
+        resources:
+          requests:
+            memory: 192Mi
         # install jb and tk then start the argocd-cmp-server
         command:
           - sh

--- a/charts/cert-manager/rendered.yaml
+++ b/charts/cert-manager/rendered.yaml
@@ -1276,6 +1276,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              memory: 128Mi
       nodeSelector:
         kubernetes.io/os: "linux"
         node-role.kubernetes.io/control-plane: ""
@@ -1478,6 +1483,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          resources:
+            limits:
+              memory: 64Mi
+            requests:
+              memory: 64Mi
       nodeSelector:
         kubernetes.io/os: "linux"
         node-role.kubernetes.io/control-plane: ""

--- a/charts/cert-manager/values.yaml
+++ b/charts/cert-manager/values.yaml
@@ -41,6 +41,12 @@ cert-manager:
             sourceLabels:
               - __name__
   webhook:
+    # 3-day peak working-set ~41Mi (Mimir).
+    resources:
+      requests:
+        memory: 64Mi
+      limits:
+        memory: 64Mi
     tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
@@ -49,6 +55,12 @@ cert-manager:
       kubernetes.io/os: linux
       node-role.kubernetes.io/control-plane: ""
   cainjector:
+    # 3-day peak working-set ~71Mi (Mimir); 64 would OOMKill it, so 128.
+    resources:
+      requests:
+        memory: 128Mi
+      limits:
+        memory: 128Mi
     tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane

--- a/charts/cilium/rendered.yaml
+++ b/charts/cilium/rendered.yaml
@@ -2091,6 +2091,11 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "7445"
         
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            memory: 128Mi
         securityContext:
           seLinuxOptions:
             level: s0

--- a/charts/cilium/values.yaml
+++ b/charts/cilium/values.yaml
@@ -280,6 +280,12 @@ cilium:
   # Configure Cilium Envoy options.
   envoy:
     enabled: true
+    # 3-day peak working-set ~91Mi (Mimir); request/limit sized above it.
+    resources:
+      requests:
+        memory: 128Mi
+      limits:
+        memory: 256Mi
     # -- Roll out cilium envoy pods automatically when configmap is updated.
     rollOutPods: true
     # Ingress/gateway Envoy stream_idle_timeout (default 300s). ArgoCD UI grpc-web Watch

--- a/tanka/environments/apprise/main.jsonnet
+++ b/tanka/environments/apprise/main.jsonnet
@@ -92,7 +92,10 @@ local apprise = {
         + healthProbe(livenessProbe)
         + livenessProbe.withFailureThreshold(6)
         + healthProbe(readinessProbe)
-        + readinessProbe.withFailureThreshold(3),
+        + readinessProbe.withFailureThreshold(3)
+        // 3-day peak working-set ~108Mi (Mimir); request=limit=128Mi.
+        + kContainer.resources.withRequests({ memory: '128Mi' })
+        + kContainer.resources.withLimits({ memory: '128Mi' }),
       ])
       + kDeployment.spec.template.spec.withTerminationGracePeriodSeconds(30)
       // /config is a writable emptyDir (apprise's store/ cache lives here); the


### PR DESCRIPTION
Post-incident sizing (2026-07-25/26). Every **limit** checked against that container's **3-day Mimir working-set peak**, and every change **rendered locally to confirm it lands on the actual workload** (not left for review to discover).

## Changes

| workload | request | limit | 3d peak | validated |
|---|---|---|---|---|
| argocd **repo-server** container | 160Mi | — | 240Mi | build.sh render |
| argocd **tanka** sidecar | 192Mi | — | 233Mi | build.sh render |
| mimir **alertmanager** | 128Mi | 256Mi | 78Mi | `helm template` → 128/256 ✓ |
| **cilium-envoy** | 128Mi | 256Mi | 91Mi | build.sh render |
| alloy **node-exporter** | 64Mi | 128Mi | 31Mi | `helm template` → DaemonSet 64/128 ✓ |
| cert-manager **cainjector** | 128Mi | 128Mi | 71Mi | build.sh render |
| cert-manager **webhook** | 64Mi | 64Mi | 41Mi | build.sh render |
| **apprise** | 128Mi | 128Mi | 108Mi | `tk eval` → 128/128 ✓ |

Plus **repo-server `parallelism.limit` + `git.lsremote.parallelism.limit` 4→2**.

**Left out:** mimir-ingester (steady ~300Mi; a 512 limit OOM-loops it on WAL replay — confirmed still 300Mi/no-limit in the render), argocd-server.

## repo-server: request only, no limit yet
Keystone argocd component; no OOMKill fuse, and it doesn't balloon (steady ~207Mi pod). Limit follows once we see parallelism-2's effect. `repoServer.resources` also lands on the `copyutil` init container (160Mi) — benign, doesn't raise the effective pod request.

## Verification
- **Local charts (argocd/cilium/cert-manager):** `rendered.yaml` regenerated with `./build.sh`; diffs are exactly the intended changes and **no untouched chart drifted** (confirms helm 4.2.3 == committed snapshots).
- **External-chart apps (mimir/alloy):** rendered locally with `helm template <chart> --version <v> -f <base-values> -f <cluster-values> -f <valuesObject>` (valuesObject extracted from the app template, cluster_name→tiles) — node-exporter and alertmanager confirmed on the workloads above.
- **apprise (Tanka):** `tk eval` confirmed the container resources.

These external-chart apps have no committed `rendered.yaml` (build.sh doesn't cover them) — tracked in #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xEKY7f5jT1HDPvnNQxTTj