### PR TITLE
fix: node-exporter BestEffort + pin nodeodm to lancer (prod)

### DIFF
--- a/charts/argocd-applications/values/alloy-values.yaml
+++ b/charts/argocd-applications/values/alloy-values.yaml
@@ -67,13 +67,11 @@ clusterMetrics:
   node-exporter:
     enabled: true
     deploy: true
-    # 3-day peak working-set ~31Mi (Mimir). Path assumes the prometheus-node-exporter
-    # subchart reads resources here; the render-diff confirms it lands on the DaemonSet.
-    resources:
-      requests:
-        memory: 64Mi
-      limits:
-        memory: 128Mi
+    # Intentionally BestEffort (no request/limit). node-exporter is a
+    # must-run-on-every-node DaemonSet, so a memory *request* can block it from a
+    # node whose allocatable is fully committed -- and it can't relocate, so that
+    # node just goes dark. Hit exactly that on wk-3 (99% committed) with a 64Mi
+    # request. Its ~31Mi footprint is trivial; keep it schedulable everywhere.
     metricsTuning:
       useDefaultAllowList: true
       useIntegrationAllowList: true

--- a/tanka/environments/odm/main.jsonnet
+++ b/tanka/environments/odm/main.jsonnet
@@ -105,11 +105,14 @@ datasetsPvc: datasetsPvc,
 local nodeOdmLabels = {
   app: 'nodeodm',
 },
+// Match lancer's taint (dedicated=heavy:PreferNoSchedule) so nodeodm can land on
+// it via the prod-only nodeSelector below -- same pin the jupyterhub singleuser
+// uses. The old dedicated=nodeodm toleration was a no-op (no such taint exists).
 local nodeOdmToleration = {
   key: 'dedicated',
   operator: 'Equal',
-  value: 'nodeodm',
-  effect: 'NoSchedule',
+  value: 'heavy',
+  effect: 'PreferNoSchedule',
 },
 local nodeOdmDeployment = kDeployment.new("nodeodm", containers=[
   kContainer.new('nodeodm', image='opendronemap/nodeodm')
@@ -120,6 +123,12 @@ local nodeOdmDeployment = kDeployment.new("nodeodm", containers=[
 + kDeployment.spec.selector.withMatchLabels(nodeOdmLabels)
 + kDeployment.spec.template.metadata.withLabels(nodeOdmLabels)
 + kDeployment.spec.template.spec.withTolerationsMixin([nodeOdmToleration])
+// Prod-only: pin the big nodeodm (6Gi + image unpack) to lancer (128GB metal),
+// the reserved heavy-workload node -- keeps it off the packed g2/g3 workers.
+// Test has no lancer, so no nodeSelector there.
++ (if APP.cluster_name == "tiles"
+   then kDeployment.spec.template.spec.withNodeSelector({ 'kubernetes.io/hostname': 'lancer' })
+   else {})
 + kDeployment.emptyVolumeMount("working-dir", '/cm/local'),
 nodeOdmDeployment: nodeOdmDeployment,
 local nodeOdmService = k_util.serviceFor(nodeOdmDeployment),


### PR DESCRIPTION
Follow-up to #642, for two things that surfaced once it deployed.

## 1. node-exporter → BestEffort (revert the request/limit)
The 64Mi request I added is wrong for a **must-run-on-every-node DaemonSet**: on a node whose allocatable is fully committed, the pod can't schedule *and* can't relocate, so that node goes dark. Hit exactly that — `alloy-node-exporter` went **Pending on wk-3** (99% committed on requests), wk-3 lost its node metrics, and the DaemonSet rollout wedged (alloy stuck `Progressing` for 22h). node-exporter's ~31Mi footprint is trivial; BestEffort keeps it schedulable everywhere. (k8s defaults request=limit if you set only a limit, so a limit-only variant wouldn't help.)

## 2. nodeodm → pinned to lancer (prod only)
nodeodm requests **6Gi** and unpacks its image at node level — it was the elephant filling wk-3. Pin it to lancer (128GB metal, the reserved heavy-workload node) the **same way the jupyterhub singleuser does**: `nodeSelector: kubernetes.io/hostname=lancer` + a matching `dedicated=heavy:PreferNoSchedule` toleration. (The old `dedicated=nodeodm` toleration was a no-op — no such taint.) **Prod-only** via `APP.cluster_name == "tiles"`; test has no lancer and keeps nodeodm schedulable at its 1Gi.

## Validation (rendered locally, per #643's manual recipe)
- alloy node-exporter → `resources: null` (BestEffort) ✓
- odm **prod** (`tiles`) → `nodeSelector {kubernetes.io/hostname: lancer}`, `tolerations [dedicated=heavy:PreferNoSchedule]`, `6Gi` ✓
- odm **test** (`tiles-test`) → `nodeSelector: null`, `1Gi` ✓

Both files are external-chart/tanka (no committed `rendered.yaml`; tracked in #643).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xEKY7f5jT1HDPvnNQxTTj