### PR TITLE
vio-offline: nightly in-cluster VINS pose-regen CronJob (coordinator #85)

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -1370,3 +1370,42 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+
+---
+# Source: argocd-applications/templates/vio-offline-application.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vio-offline
+spec:
+  project: 'placeholder'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: 'placeholder'
+    path: tanka
+    plugin:
+      env:
+        - name: TK_ENV
+          value: vio-offline
+      parameters:
+        - name: cluster_name
+          string: 'placeholder'
+        - name: vault_name
+          string: 'placeholder'
+        - name: app_settings
+          map:
+            nfs_server: 'placeholder'
+            datasets_nfs_path: 'placeholder'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vio-offline
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/warn: baseline

--- a/charts/argocd-applications/templates/vio-offline-application.yaml
+++ b/charts/argocd-applications/templates/vio-offline-application.yaml
@@ -1,0 +1,1 @@
+../../../tanka/environments/vio-offline/application.yaml

--- a/tanka/environments/vio-offline/README.md
+++ b/tanka/environments/vio-offline/README.md
@@ -1,0 +1,58 @@
+# vio-offline
+
+Nightly **VINS pose regeneration** over the NAS flight captures -- the estimator-half sibling of
+[`flight-analysis`](../flight-analysis/). Where flight-analysis runs the FC-log *notebook* over every
+`.bin`, this runs the deterministic estimator over every `.feat` and writes the regenerated pose next
+to it, so downstream analysis (`coordinator/analysis/vio-quality.ipynb`) has a fresh `*.vinspose.csv`
+to score against the FC EKF.
+
+## What it does
+
+A `CronJob` (`0 5 * * *` UTC -- an hour after flight-analysis, whose output the VIO-quality notebook
+consumes) that, for every `*.feat` under the NAS `flights` share (`/mnt/flights`):
+
+- regenerates `<stem>.vinspose.csv` -- the VINS trajectory (`t,qw..qz,px..pz,vx..vz`) -- via
+  `vio-offline-runner` (`coordinator/containers/vio-estimator/offline_runner.py`, baked into the image);
+- writes a `<stem>.vinspose.polisher.json` provenance sidecar (estimator source SHA, `vins_fusion`
+  commit, fixture + config sha256, pose row count -- RO-Crate-ish field names, per coordinator #40);
+- **skips** fixtures whose sidecar is already fresh (same estimator source SHA + same fixture/config
+  hashes), so a nightly run only does new/changed work.
+
+The estimator binary is **single-threaded with no wall-clock solver cap**, so the output is
+**byte-reproducible** for a given (source, config, fixture). This is pose *regeneration only* -- the
+VINS-vs-EKF comparison (ATE/scale) is a separate step, `coordinator/analysis/vio-quality.ipynb`.
+
+## Image and config
+
+- **Image:** `ghcr.io/symmatree/coordinator-vio-estimator:main` -- multi-arch, so on this amd64
+  cluster the pod pulls the **native** amd64 image (no qemu; coordinator #85). It bakes the
+  `vins_fusion_offline` binary, the `vio-offline-runner` entrypoint, and `COORDINATOR_SHA`.
+- **Config:** the estimator config is **not** baked into the image. An `initContainer` fetches the
+  deployed seed `oak_d.yaml` from the (public) `coordinator` repo at `main` -- keeping coordinator the
+  single source of truth -- into a shared `emptyDir` at `/config/oak_d.yaml`. The runner records the
+  config's sha256, so a config change is both detectable and re-triggers regen. (Fetch uses the image's
+  own `python3`; no git or token needed.)
+
+## Storage
+
+Static NFS PV/PVC (`vio-offline-flights`) bound to the same NAS `.../datasets/flights` subpath as
+flight-analysis. `ReadWriteMany`, `Retain` -- a separate PV/PVC from flight-analysis so the two
+pipelines are independent; both may mount the share concurrently.
+
+## Trigger a run manually (don't reinvent it locally)
+
+```bash
+kubectl create job --from=cronjob/vio-offline \
+  vio-offline-manual-$(date +%Y%m%d-%H%M%S) -n vio-offline
+kubectl logs -n vio-offline -l job-name=<name> -c runner -f
+```
+
+New captures land on the NAS (`.feat` teed in-flight, coordinator #78); the next nightly picks them up
+automatically. Use the manual trigger only when you don't want to wait for 05:00 UTC.
+
+## Related
+
+- [`flight-analysis`](../flight-analysis/) -- the FC-log notebook sibling (runs 04:00 UTC).
+- `coordinator/containers/vio-estimator/offline_runner.py` -- the runner (baked into the image).
+- `coordinator/docs/vio-offline-replay.md` -- the offline-replay design (Option C is this Job).
+- `coordinator/analysis/vio-quality.ipynb` -- consumes `*.vinspose.csv`, scores vs FC EKF/GPS.

--- a/tanka/environments/vio-offline/application.yaml
+++ b/tanka/environments/vio-offline/application.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vio-offline
+spec:
+  project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+    path: tanka
+    plugin:
+      env:
+        - name: TK_ENV
+          value: vio-offline
+      parameters:
+        - name: cluster_name
+          string: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+        - name: vault_name
+          string: '{{ required ".Values.vault_name is required" .Values.vault_name }}'
+        - name: app_settings
+          map:
+            nfs_server: '{{ required ".Values.nfs_server is required" .Values.nfs_server }}'
+            datasets_nfs_path: '{{ required ".Values.datasets_nfs_path is required" .Values.datasets_nfs_path }}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vio-offline
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/warn: baseline

--- a/tanka/environments/vio-offline/main.jsonnet
+++ b/tanka/environments/vio-offline/main.jsonnet
@@ -1,0 +1,110 @@
+local k = import 'k.libsonnet';
+
+local APP_VARS = std.parseJson(std.extVar('ARGOCD_APP_PARAMETERS'));
+local isString(v) = std.objectHas(v, 'string');
+local isMap(v) = std.objectHas(v, 'map');
+local APP = {
+  [v.name]: v.string
+  for v in std.filter(isString, APP_VARS)
+} + {
+  [v.name]: v.map
+  for v in std.filter(isMap, APP_VARS)
+};
+
+local kPersistentVolume = k.core.v1.persistentVolume;
+local kPersistentVolumeClaim = k.core.v1.persistentVolumeClaim;
+local kCronJob = k.batch.v1.cronJob;
+local kContainer = k.core.v1.container;
+local kVolumeMount = k.core.v1.volumeMount;
+local kVolume = k.core.v1.volume;
+local kServiceAccount = k.core.v1.serviceAccount;
+
+// The estimator image bakes vins_fusion_offline, the `vio-offline-runner` entrypoint, and
+// COORDINATOR_SHA (its own source commit). It is multi-arch, so on this (amd64) cluster the
+// pod pulls the NATIVE amd64 image -- no qemu (coordinator #85).
+local image = 'ghcr.io/symmatree/coordinator-vio-estimator:main';
+
+// The estimator config is NOT baked into the image. Fetch the deployed seed from the (public)
+// coordinator repo at CONFIG_REF, so coordinator stays the single source of truth. The runner
+// records the config's sha256 in the provenance sidecar, so a config change is both detectable
+// and re-triggers regen (freshness keys on config sha + estimator source sha).
+local configRef = 'main';
+local configUrl = 'https://raw.githubusercontent.com/symmatree/coordinator/' + configRef +
+                  '/host/ansible/roles/coordinator/files/oak_d.yaml';
+
+// NFS storage: static PV binding, same pattern as flight-analysis / Mimir / Loki / ODM. Same
+// NAS 'flights' subpath as flight-analysis, but a separate PV/PVC so this pipeline is
+// independent (RWX -> both may mount the share concurrently).
+local flightsPv =
+  kPersistentVolume.new('vio-offline-flights')
+  + kPersistentVolume.spec.withCapacity({ storage: '2Ti' })
+  + kPersistentVolume.spec.withAccessModes(['ReadWriteMany'])
+  + kPersistentVolume.spec.withPersistentVolumeReclaimPolicy('Retain')
+  + kPersistentVolume.spec.nfs.withServer(APP.app_settings.nfs_server)
+  + kPersistentVolume.spec.nfs.withPath(APP.app_settings.datasets_nfs_path + '/flights');
+
+local flightsPvc =
+  kPersistentVolumeClaim.new('vio-offline-flights')
+  + kPersistentVolumeClaim.spec.withAccessModes(['ReadWriteMany'])
+  + kPersistentVolumeClaim.spec.resources.withRequests({ storage: '2Ti' })
+  + kPersistentVolumeClaim.spec.withVolumeName('vio-offline-flights')
+  + kPersistentVolumeClaim.spec.withStorageClassName('');
+
+local serviceAccount = kServiceAccount.new('vio-offline');
+
+// initContainer: fetch the deployed config into a shared emptyDir. Uses the estimator image's
+// own python3 (stdlib urllib) -- no git, no token, since coordinator is public. Fails loudly
+// (non-zero -> Job fails) if the config is missing/moved rather than running on a stale copy.
+local fetchConfig =
+  kContainer.new('fetch-config', image)
+  + kContainer.withCommand([
+    'python3',
+    '-c',
+    "import urllib.request; "
+    + "d = urllib.request.urlopen('" + configUrl + "', timeout=30).read(); "
+    + "assert len(d) > 200 and b'imu:' in d, 'fetched config looks wrong'; "
+    + "open('/config/oak_d.yaml', 'wb').write(d); "
+    + "print('fetched oak_d.yaml', len(d), 'bytes')",
+  ])
+  + kContainer.resources.withRequests({ cpu: '50m', memory: '64Mi' })
+  + kContainer.withVolumeMountsMixin([kVolumeMount.new('config', '/config')]);
+
+// runner: walk /mnt/flights, regenerate <stem>.vinspose.csv + provenance sidecar for each
+// *.feat, skipping fixtures already fresh. Deterministic (single-threaded, no wall-clock cap).
+local runner =
+  kContainer.new('runner', image)
+  + kContainer.withCommand(['/opt/coordinator/bin/vio-offline-runner'])
+  + kContainer.withEnvMap({
+    VINS_CONFIG: '/config/oak_d.yaml',
+    FLIGHTS_DIR: '/mnt/flights',
+  })
+  + kContainer.resources.withRequests({ cpu: '500m', memory: '1Gi' })
+  + kContainer.resources.withLimits({ memory: '4Gi' })
+  + kContainer.withVolumeMountsMixin([
+    kVolumeMount.new('flights', '/mnt/flights'),
+    kVolumeMount.new('config', '/config'),
+  ]);
+
+local volumes = [
+  kVolume.fromPersistentVolumeClaim('flights', flightsPvc.metadata.name),
+  kVolume.fromEmptyDir('config'),
+];
+
+local cronJob =
+  kCronJob.new('vio-offline')
+  + kCronJob.spec.withSchedule('0 5 * * *')  // after flight-analysis (04:00 UTC); vinspose feeds vio-quality
+  + kCronJob.spec.withConcurrencyPolicy('Forbid')
+  + kCronJob.spec.withSuccessfulJobsHistoryLimit(3)
+  + kCronJob.spec.withFailedJobsHistoryLimit(3)
+  + kCronJob.spec.jobTemplate.spec.template.spec.withInitContainers([fetchConfig])
+  + kCronJob.spec.jobTemplate.spec.template.spec.withContainers([runner])
+  + kCronJob.spec.jobTemplate.spec.template.spec.withVolumes(volumes)
+  + kCronJob.spec.jobTemplate.spec.template.spec.withRestartPolicy('OnFailure')
+  + kCronJob.spec.jobTemplate.spec.template.spec.withServiceAccountName(serviceAccount.metadata.name);
+
+{
+  flightsPv: flightsPv,
+  flightsPvc: flightsPvc,
+  serviceAccount: serviceAccount,
+  cronJob: cronJob,
+}

--- a/tanka/environments/vio-offline/spec.json
+++ b/tanka/environments/vio-offline/spec.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "environments/vio-offline"
+  },
+  "spec": {
+    "namespace": "vio-offline",
+    "resourceDefaults": {},
+    "expectVersions": {}
+  }
+}


### PR DESCRIPTION
## What

The durable, native-amd64 **VINS pose-regeneration CronJob** — the estimator-half sibling of
`flight-analysis`. Follow-up to coordinator **#85** (the ad-hoc Job it validated is now a standing
pipeline). Runs `vio-offline-runner` (baked into `coordinator-vio-estimator`) over every `*.feat`
under the NAS flights share, writing `<stem>.vinspose.csv` + a provenance sidecar next to each
fixture and skipping fresh ones. **Pose regeneration only** — the VINS-vs-EKF scoring stays in
`coordinator/analysis/vio-quality.ipynb`.

## Files

- New tanka env `tanka/environments/vio-offline/` (`spec.json`, `main.jsonnet`, `application.yaml`, `README.md`).
- Registered via the usual `charts/argocd-applications/templates/vio-offline-application.yaml` **symlink**.
- `charts/argocd-applications/rendered.yaml` regenerated (`build.sh` mechanism) — diff is **exactly** the new Application block, nothing else.

## Design

- **Native amd64, no qemu.** The estimator image is multi-arch; on this amd64 cluster the pod pulls the native image (the whole point of #85).
- **Config not baked into the image.** An `initContainer` fetches the deployed seed `oak_d.yaml` from **public `coordinator@main`** into a shared `emptyDir` (image's own `python3`; no git, no token). The runner records the config `sha256`, so a config change is detectable and re-triggers regen. Keeps coordinator the single source of truth (no drifting copy in tiles).
- **Storage:** separate NFS PV/PVC (`vio-offline-flights`) to the same `.../datasets/flights` subpath as flight-analysis (RWX / Retain) — independent pipeline, both may mount concurrently.
- **Schedule** `0 5 * * *` (after flight-analysis's 04:00), `Forbid`, `OnFailure`.

## Validation

- `tk eval environments/vio-offline` renders (PV/PVC/SA/CronJob correct).
- **Render-diff:** regenerated `rendered.yaml` diff is only the vio-offline Application (+39 lines).
- **Dry-run against the live API:** PV `--dry-run=server` OK; CronJob/PVC/SA `--dry-run=client` OK (initContainers/env/`batch/v1` schema valid). Nothing was applied.

## Caveats (surfaced, not buried)

- **GitOps:** merging this makes ArgoCD create the CronJob; first run at 05:00 UTC, or `kubectl create job --from=cronjob/vio-offline ...`. I have **not** applied anything live.
- **First run refreshes existing derived CSVs.** The 260705 `*.vinspose.csv` were generated under an older config sha, so freshness will re-run them under the current seed and overwrite (regenerable derived data — that's the intent).
- **Output location for 260712:** the runner writes next to the `.feat` (`captures/.../*.vinspose.csv`), whereas the existing 260712 pose sits in `derived/` (placed by the manual notebook). So the cron will create a second copy alongside the fixture — worth reconciling which location `vio-quality` consumes, but not introduced by this PR (it's `offline_runner.py`'s by-design "next to the fixture" behavior).
- `IMAGE_DIGEST` defaults to `unknown` (same as flight-analysis); the provenance identity is the baked `COORDINATOR_SHA` + config sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
