### PR TITLE
vio-offline: suspend CronJob -> on-demand (coordinator #139)

### DIFF
--- a/tanka/environments/vio-offline/README.md
+++ b/tanka/environments/vio-offline/README.md
@@ -8,8 +8,11 @@ to score against the FC EKF.
 
 ## What it does
 
-A `CronJob` (`0 5 * * *` UTC -- an hour after flight-analysis, whose output the VIO-quality notebook
-consumes) that, for every `*.feat` under the NAS `flights` share (`/mnt/flights`):
+**On-demand** (the CronJob ships `suspend: true` -- coordinator #139): now that the mainline
+analysis compares the onboard `VISP` directly, offline regen is a *leverage / gap-fill* tool
+(config sweeps, or flights that lack an online pose), not a nightly mainline. Trigger a run
+manually (see below); the `0 5 * * *` schedule is retained but inert until someone flips
+`suspend` back. For every `*.feat` under the NAS `flights` share (`/mnt/flights`) it:
 
 - regenerates `<stem>.vinspose.csv` -- the VINS trajectory (`t,qw..qz,px..pz,vx..vz`) -- via
   `vio-offline-runner` (`coordinator/containers/vio-estimator/offline_runner.py`, baked into the image);

--- a/tanka/environments/vio-offline/main.jsonnet
+++ b/tanka/environments/vio-offline/main.jsonnet
@@ -92,7 +92,13 @@ local volumes = [
 
 local cronJob =
   kCronJob.new('vio-offline')
-  + kCronJob.spec.withSchedule('0 5 * * *')  // after flight-analysis (04:00 UTC); vinspose feeds vio-quality
+  // On-demand, not a nightly sweep (coordinator #139): now that the mainline compares onboard
+  // VISP directly, offline regen is a leverage/gap-fill tool (config sweeps, flights missing
+  // online pose), triggered manually via `kubectl create job --from=cronjob/vio-offline ...`.
+  // suspend=true keeps the manifest/jobTemplate but stops the schedule; the schedule is retained
+  // so re-enabling is a one-line flip if we later want gated nightly regen.
+  + kCronJob.spec.withSuspend(true)
+  + kCronJob.spec.withSchedule('0 5 * * *')  // retained for a future re-enable; inert while suspended
   + kCronJob.spec.withConcurrencyPolicy('Forbid')
   + kCronJob.spec.withSuccessfulJobsHistoryLimit(3)
   + kCronJob.spec.withFailedJobsHistoryLimit(3)


### PR DESCRIPTION
Pairs with coordinator #140 / #139. Rescopes the `vio-offline` nightly to **on-demand**: `suspend: true` on the CronJob.

**Why:** the mainline analysis now compares onboard `VISP` directly (`vio_ekf_compare.compare_visp_to_ekf`), so offline regen is a leverage/gap-fill tool (config sweeps, flights missing an online pose), not a nightly mainline. Suspending also avoids churning poses to the new `derived/pose/` location (#140) before the `vio-quality` reader is updated.

**Behavior:** the jobTemplate + `0 5 * * *` schedule are retained but inert; runs happen via `kubectl create job --from=cronjob/vio-offline ...` (works while suspended). Re-enabling — or a future online-pose-gated nightly — is a one-line flip.

**Render:** `tk eval` shows `spec.suspend: true`; no change to `argocd-applications/rendered.yaml` (the CronJob renders via the tanka plugin at sync, not in the app-of-apps chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)