### PR TITLE
alloy: bump k8s-monitoring 3.7.1 → 3.8.11 (Alloy 1.13.0) to restore alerting sync (#656)

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -8,7 +8,7 @@ spec:
   project: 'placeholder'
   sources:
     - repoURL: https://grafana.github.io/helm-charts
-      targetRevision: "3.7.1"
+      targetRevision: "3.8.11"
       chart: k8s-monitoring
       helm:
         valueFiles:

--- a/charts/argocd-applications/templates/alloy-application.yaml
+++ b/charts/argocd-applications/templates/alloy-application.yaml
@@ -6,7 +6,7 @@ spec:
   project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
   sources:
     - repoURL: https://grafana.github.io/helm-charts
-      targetRevision: "3.7.1"
+      targetRevision: "3.8.11"
       chart: k8s-monitoring
       helm:
         valueFiles:


### PR DESCRIPTION
Fixes #656.

## What was broken

`alloy-singleton` has been in CrashLoopBackOff since #635 merged (2026-07-24). Its `mimir.alerts.kubernetes` config uses:

```alloy
alertmanagerconfig_matcher {
  strategy = "None"
}
```

That block **only exists in Alloy ≥ v1.13.0**. The deployed chart (`k8s-monitoring` 3.7.1) ships **Alloy v1.12.1**, so the config fails to parse at load time -- and because it fails at parse, *nothing* in the singleton runs: neither `mimir.rules.kubernetes` (PrometheusRule → Mimir ruler) nor `mimir.alerts.kubernetes` (AlertmanagerConfig → Mimir alertmanager). Rule + alert-routing sync has been frozen cluster-wide for days.

## The fix

Bump `k8s-monitoring` **3.7.1 → 3.8.11** (latest 3.x), which ships **Alloy v1.13.0** -- the exact version #635's config was written for. The config parses, the singleton recovers, and rule/alert sync resumes. **No config rewrite**, because the config was already correct for 1.13.

Chosen over the alternatives (per discussion): the 3.x line caps at Alloy 1.13.0, so this is the minimal supported fix. Reaching true head (Alloy 1.18) requires the breaking k8s-monitoring **v4** migration (named instances → `collectors` map) -- filed separately as #659.

## Diff / hygiene

Two lines: `targetRevision` in `alloy-application.yaml` + the regenerated `charts/argocd-applications/rendered.yaml` (regenerated via `build.sh`'s helm template; render-diff confirms the snapshot changes by exactly that one line, nothing displaced).

## Rollout / validation (test first)

This is a chart minor bump on a critical component, so validate on **test** before promoting the prod tag:
- `up{pod=~"alloy-alloy-singleton.*"}` becomes 1; restarts stop.
- `alloy-health.ipynb` / `alloy-nomon.ipynb` (#651) re-run clean -- the CrashLoopBackOff findings clear.
- Mimir ruler rule count tracks current `PrometheusRule` CRs again; the #635 per-tenant AlertmanagerConfig routing actually applies; a test alert reaches apprise.
- Watch for any 3.7→3.8 values-schema surprises (additive minor; our values use the standard `clusterMetrics`/`nodeLogs`/`podLogs`/named-instance keys).

Unblocks #655 (Loki rules can't load until this loader is alive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Mv2cf5sL2vsD86ibibb48