### PR TITLE
spike: pre-render + sentinel-swap for project_id (PoC, not wired live)

### DIFF
--- a/docs/prerender-spike/README.md
+++ b/docs/prerender-spike/README.md
@@ -1,0 +1,94 @@
+# Pre-render + sentinel-swap: a spike
+
+**Status: proof-of-concept, nothing here is wired into the live deploy path.**
+This directory is a self-contained demonstration of one way to get Argo CD out of
+the business of rendering ~30 apps at sync time, without checking Terraform
+outputs into git. It exists so we can look at a working thing and decide, not so
+it can be adopted as-is.
+
+## The problem it targets
+
+Today every child app is rendered at sync time by the repo-server (Tanka CMP or
+Helm). That renderer is a single throttled pod (`reposerver.parallelism.limit:
+"2"`), and Tanka generation is slow and serialized (per-generation `jb install` +
+vendor copy under a global `flock`; see `charts/argocd/templates/tanka.yaml`).
+Because `prod`/`test` are moving tags, every promotion invalidates the manifest
+cache for all apps at once and stampedes that one renderer, so apps drift to stale
+SHAs and "need a manual refresh." (Observed 2026-07: apps on the same `prod` tag
+synced to four different commits, some not reconciled in days.)
+
+## The idea
+
+Structure has to be resolved by a real renderer (jsonnet/Helm). But **scalar leaf
+values can be deferred to a post-render string substitution** -- and every value
+that is genuinely unknown until `terraform apply` is a scalar. In tiles that set
+is essentially one value, `project_id` (`random_project_id = true` in
+`tf/bootstrap/gcp-projects.tf`); it appears only as a leaf (an external-dns
+`--google-project=` arg, a cert-manager ClusterIssuer `project:` field, a Tanka
+`--ext-str`), never in a way that changes structure. Everything else that varies
+is a Terraform *input* (`cluster_name`, CIDRs, `seed_project_id`, ...), known
+before apply.
+
+So:
+
+1. **CI pre-renders** each app per cluster (`scripts/render-app.sh`). Inputs are
+   baked; the one generated output, `project_id`, is emitted as the sentinel
+   `@@TILES_PROJECT@@`. The slow/fragile renderer runs here, in parallel, once.
+2. **Terraform applies** the real `project_id` into the cluster (via the narrow
+   app-of-apps root it already owns) -- live, no intermediary, so it can't lag.
+3. **At sync**, a trivial CMP (`rendered-sub-cmp.yaml`) does a literal token
+   replace `@@TILES_PROJECT@@` -> real `project_id`. No jsonnet, no `tk show`, no
+   flock; a sub-second `sed`. The stampede-prone renderer is gone from the sync
+   path.
+
+The sentinel neutralizes the **lag** objection: the committed/published artifact
+holds a placeholder, never a real post-apply value, so it is never a generation
+behind Terraform. Terraform stays the live source of the real value.
+
+## Proof it's lossless
+
+`scripts/prove-roundtrip.sh` renders each app with the sentinel, `sed`s it back to
+a real value, and diffs against a direct render with that real value. Identical
+output means `project_id` really is a pure leaf and the swap loses nothing; a leak
+would fail loudly here instead of shipping a wrong manifest.
+
+```
+PASS  external-dns     sentinel(sed)->real == direct-render   (sentinels=1)
+PASS  cert-manager     sentinel(sed)->real == direct-render   (sentinels=2)
+```
+
+`rendered/external-dns.yaml` (the arg case) and
+`rendered/cert-manager-issuers-excerpt.yaml` (the CRD-field case) are committed so
+the sentinel placement is inspectable. The cert-manager excerpt shows the
+distinction in one view: `project: "@@TILES_PROJECT@@"` (generated output,
+deferred) right next to `project: "seed-example"` (input, baked).
+
+## Honest edges (what still needs a decision)
+
+- **git vs OCI is a separate question from lag.** The sentinel fixes lag for the
+  generated *output*. But the pre-rendered artifact also bakes Terraform *inputs*
+  (CIDRs, nfs paths, cluster domain) -- non-secret, but the kind of config tiles
+  currently keeps out of git and in 1Password. If that principle holds, publish
+  the artifact to **OCI**, not a git branch. (This demo uses fake inputs precisely
+  so nothing real is committed.)
+- **Per-cluster render is required.** Inter-cluster values differ *structurally*
+  (e.g. loki's `tiles` values add a `resources:`/`singleBinary:` block that
+  `tiles-test` omits), so you cannot render once and string-sub `cluster_name`.
+- **The swap must be a literal token replace, never `envsubst`.** Rendered configs
+  are full of legitimate `${...}` (Alloy/Loki/Mimir, shell scripts). The sentinel
+  has no `$` and cannot collide.
+- **Tanka apps aren't covered here.** `render-app.sh` handles single-source Helm
+  apps. Tanka envs render the same way in principle (`tk show` with the sentinel
+  as `--ext-str project_id`), but that path isn't built in this spike.
+- **Not wired live.** No repo-server sidecar, no Application rewrite. Flipping one
+  app is a small follow-up once the approach is agreed.
+
+## Files
+
+| file | what |
+|------|------|
+| `../../scripts/render-app.sh` | CI pre-render: app-of-apps -> child valuesObject -> chart, with sentinel |
+| `../../scripts/prove-roundtrip.sh` | the lossless-round-trip check above |
+| `example-inputs.yaml` | per-cluster inputs shape (fake values; real ones come from 1Password in CI) |
+| `rendered/` | committed example renders (sentinel visible) |
+| `rendered-sub-cmp.yaml` | the sync-time swap CMP + how an Application flips to it |

--- a/docs/prerender-spike/example-inputs.yaml
+++ b/docs/prerender-spike/example-inputs.yaml
@@ -1,0 +1,17 @@
+# Example per-cluster inputs for scripts/render-app.sh.
+# In CI these come from 1Password misc-config (the same handoff bootstrap uses),
+# with project_id overwritten by the sentinel. Values here are fake on purpose so
+# this committed demo carries no real infrastructure config.
+cluster_name: examplecluster
+cluster_nfs_path: /volume/example
+datasets_nfs_path: /volume/datasets
+external_ip_cidr: 10.0.0.0/24
+ingress_lb_ip: 10.0.1.1
+nfs_server: nfs.example.com
+pod_cidr: 10.1.0.0/16
+seed_project_id: seed-example
+targetRevision: prod
+vault_name: example-secrets
+# The one Terraform *output* that reaches a manifest: sentinel, not a real value,
+# so this artifact never lags Terraform. Swapped for the real project_id at sync.
+project_id: '@@TILES_PROJECT@@'

--- a/docs/prerender-spike/rendered-sub-cmp.yaml
+++ b/docs/prerender-spike/rendered-sub-cmp.yaml
@@ -1,0 +1,68 @@
+# Example (NOT wired into the running repo-server yet) -- the sync-time swap.
+#
+# This is the whole "runtime rendering" cost under the pre-render model: a literal
+# token replace over already-rendered YAML. No jsonnet, no `jb install`, no `tk
+# show`, no flock -- the slow, fragile work (charts/argocd/templates/tanka.yaml)
+# has moved to CI. Generation here is a sub-second sed.
+#
+# CRITICAL: this is a LITERAL token replace, never `envsubst`/`${VAR}` expansion.
+# Rendered manifests are full of legitimate `$`/`${...}` (Alloy/River config, Loki
+# and Mimir env expansion, shell scripts in ConfigMaps). A blind envsubst would
+# corrupt those. The sentinel `@@TILES_PROJECT@@` contains no `$` and cannot
+# collide with shell/kubelet expansion.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cmp-rendered-sub
+  namespace: argocd
+data:
+  plugin.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: rendered-sub
+    spec:
+      # The Application selects this plugin explicitly (spec.source.plugin.name),
+      # so discovery is only a guard.
+      discover:
+        fileName: "./*.yaml"
+      generate:
+        # ARGOCD_ENV_PROJECT_ID is the REAL project_id, delivered live by the
+        # root app-of-apps valuesObject (which Terraform applies with its fresh
+        # output). So the value is late-bound at sync from Terraform, never baked
+        # into git, and never lagging.
+        command:
+          - sh
+          - -c
+          - |
+            : "${ARGOCD_ENV_PROJECT_ID:?rendered-sub: PROJECT_ID env not set}"
+            for f in ./*.yaml; do
+              sed "s|@@TILES_PROJECT@@|${ARGOCD_ENV_PROJECT_ID}|g" "$f"
+              echo "---"
+            done
+---
+# How an Application flips to this model. Its source becomes a plain directory of
+# pre-rendered YAML (published per cluster; see the README on git-vs-OCI), and the
+# only runtime input is project_id, passed as a plugin env from the propagated
+# (Terraform-delivered) value.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-dns
+spec:
+  project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git      # or oci://... for OCI
+    targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+    path: 'rendered/{{ required ".Values.cluster_name is required" .Values.cluster_name }}/external-dns'
+    plugin:
+      name: rendered-sub
+      env:
+        - name: PROJECT_ID
+          value: '{{ required ".Values.project_id is required" .Values.project_id }}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-dns
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions: [CreateNamespace=true, ServerSideApply=true]

--- a/docs/prerender-spike/rendered/cert-manager-issuers-excerpt.yaml
+++ b/docs/prerender-spike/rendered/cert-manager-issuers-excerpt.yaml
@@ -1,0 +1,60 @@
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+# Source: cert-manager/templates/lets-encrypt-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: staging-cert
+  namespace: "cert-manager"
+spec:
+  acme:
+    email: symmetry@pobox.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: lets-encrypt-staging
+    solvers:
+      # Solver for cluster's own domain (in main project)
+      - selector:
+          dnsZones:
+            - "examplecluster.symmatree.com"
+        dns01:
+          cloudDNS:
+            project: "@@TILES_PROJECT@@"
+            serviceAccountSecretRef:
+              # Secret name is created in charts/cert-manager/templates/clouddns-sa-secret.yaml
+              name: cert-manager-dns01-sa-key
+              # This key-name is created in tf/modules/k8s-cluster/k8s-cert-manager.tf
+              key: private_key.json
+      # Solver for ad.local.symmatree.com and local.symmatree.com (in seed project)
+      - selector:
+          dnsZones:
+            - "ad.local.symmatree.com"
+            - "local.symmatree.com"
+        dns01:
+          cloudDNS:
+            project: "seed-example"
+            serviceAccountSecretRef:
+              name: cert-manager-dns01-sa-key
+              key: private_key.json
+---
+# Source: cert-manager/templates/lets-encrypt-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: real-cert
+spec:
+  acme:
+    email: symmetry@pobox.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: lets-encrypt-real
+    solvers:
+      # Solver for cluster's own domain (in main project)
+      - selector:
+          dnsZones:
+            - "examplecluster.symmatree.com"
+        dns01:
+          cloudDNS:
+            project: "@@TILES_PROJECT@@"
+            serviceAccountSecretRef:

--- a/docs/prerender-spike/rendered/external-dns.yaml
+++ b/docs/prerender-spike/rendered/external-dns.yaml
@@ -1,0 +1,228 @@
+---
+# Source: external-dns/charts/external-dns/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: external-dns
+  labels:
+    helm.sh/chart: external-dns-1.20.0
+    app.kubernetes.io/name: external-dns
+    app.kubernetes.io/instance: external-dns
+    app.kubernetes.io/version: "0.20.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+
+---
+# Source: external-dns/charts/external-dns/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+  labels:
+    helm.sh/chart: external-dns-1.20.0
+    app.kubernetes.io/name: external-dns
+    app.kubernetes.io/instance: external-dns
+    app.kubernetes.io/version: "0.20.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list","watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get","watch","list"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get","watch","list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get","watch","list"]
+  - apiGroups: ["extensions","networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get","watch","list"]
+
+---
+# Source: external-dns/charts/external-dns/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+  labels:
+    helm.sh/chart: external-dns-1.20.0
+    app.kubernetes.io/name: external-dns
+    app.kubernetes.io/instance: external-dns
+    app.kubernetes.io/version: "0.20.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: external-dns
+
+---
+# Source: external-dns/charts/external-dns/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-dns
+  namespace: external-dns
+  labels:
+    helm.sh/chart: external-dns-1.20.0
+    app.kubernetes.io/name: external-dns
+    app.kubernetes.io/instance: external-dns
+    app.kubernetes.io/version: "0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: external-dns
+    app.kubernetes.io/instance: external-dns
+  ports:
+    - name: http
+      port: 7979
+      targetPort: http
+      protocol: TCP
+
+---
+# Source: external-dns/charts/external-dns/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: external-dns
+  labels:
+    helm.sh/chart: external-dns-1.20.0
+    app.kubernetes.io/name: external-dns
+    app.kubernetes.io/instance: external-dns
+    app.kubernetes.io/version: "0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+      app.kubernetes.io/instance: external-dns
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: external-dns
+        app.kubernetes.io/instance: external-dns
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: external-dns
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: external-dns
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+          image: registry.k8s.io/external-dns/external-dns:v0.20.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/secrets/service-account/credential.json
+          args:
+            - --log-level=info
+            - --log-format=text
+            - --interval=1m
+            - --source=service
+            - --source=ingress
+            - --policy=sync
+            - --registry=txt
+            - --txt-owner-id=examplecluster
+            - --domain-filter=examplecluster.symmatree.com
+            - --domain-filter=0.10.in-addr.arpa
+            - --provider=google
+            - --google-project=@@TILES_PROJECT@@
+            - --regex-domain-exclusion=^_acme-challenge\.
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 7979
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /etc/secrets/service-account/
+              name: google-service-account
+      volumes:
+        - name: google-service-account
+          secret:
+            secretName: clouddns-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+
+---
+# Source: external-dns/templates/clouddns-sa-secret.yaml
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: clouddns-sa
+  namespace: "external-dns"
+type: Opaque
+spec:
+  # secret name is specified in tf/modules/k8s-cluster/external-dns.tf
+  itemPath: vaults/example-secrets/items/examplecluster-external-dns-clouddns-sa-key
+
+---
+# Source: external-dns/charts/external-dns/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: external-dns
+  namespace: external-dns
+  labels:
+    helm.sh/chart: external-dns-1.20.0
+    app.kubernetes.io/name: external-dns
+    app.kubernetes.io/instance: external-dns
+    app.kubernetes.io/version: "0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  jobLabel: app.kubernetes.io/instance
+  namespaceSelector:
+    matchNames:
+      - external-dns
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+      app.kubernetes.io/instance: external-dns
+  endpoints:
+    - port: http
+      path: /metrics

--- a/scripts/prove-roundtrip.sh
+++ b/scripts/prove-roundtrip.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Proof that the pre-render + sentinel-swap compromise is lossless: for each app,
+# render once with project_id as the sentinel, sed the sentinel back to a real
+# value, and show that equals a direct render with the real value. If they differ,
+# the "project_id is a pure leaf scalar" assumption leaked somewhere -- and this
+# fails loudly instead of shipping a wrong manifest.
+#
+# Usage: scripts/prove-roundtrip.sh [inputs-file] [app...]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+INPUTS="${1:-docs/prerender-spike/example-inputs.yaml}"
+shift || true
+APPS=("$@")
+[[ ${#APPS[@]} -eq 0 ]] && APPS=(external-dns cert-manager)
+
+SENTINEL="@@TILES_PROJECT@@"
+REAL="roundtrip-proof-value"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+rc=0
+for app in "${APPS[@]}"; do
+	bash scripts/render-app.sh "${app}" "${INPUTS}" >"${tmp}/sentinel.yaml" 2>/dev/null
+	sed "s/${SENTINEL}/${REAL}/g" "${tmp}/sentinel.yaml" >"${tmp}/reconstructed.yaml"
+	bash scripts/render-app.sh "${app}" "${INPUTS}" "${REAL}" >"${tmp}/direct.yaml" 2>/dev/null
+
+	n=$(grep -c "${SENTINEL}" "${tmp}/sentinel.yaml" || true)
+	if diff -q "${tmp}/direct.yaml" "${tmp}/reconstructed.yaml" >/dev/null; then
+		printf 'PASS  %-16s sentinel(sed)->real == direct-render   (sentinels=%s)\n' "${app}" "${n}"
+	else
+		printf 'FAIL  %-16s round-trip differs:\n' "${app}"
+		diff "${tmp}/direct.yaml" "${tmp}/reconstructed.yaml" | sed 's/^/      /'
+		rc=1
+	fi
+done
+exit "${rc}"

--- a/scripts/render-app.sh
+++ b/scripts/render-app.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Faithfully pre-render one app-of-apps child Application to static YAML, the way
+# Argo CD would, but with the one genuinely-post-apply scalar (project_id) left as
+# a collision-proof sentinel token instead of a real value.
+#
+# The render is two-level, mirroring Argo:
+#   1. helm-template the argocd-applications (app-of-apps) chart for a given
+#      cluster, which produces every child Application manifest with its
+#      valuesObject fully expanded (domainFilters, extraArgs, etc.).
+#   2. pull the named child's spec.source.{path,helm} back out and helm-template
+#      that chart with the same valueFiles + valuesObject.
+#
+# Everything that is a Terraform *input* (cluster_name, vault_name, ...) is baked
+# in per cluster. The only Terraform *output* that reaches a manifest -- project_id
+# -- is fed in as the sentinel @@TILES_PROJECT@@ so the committed artifact never
+# holds a real, post-apply value and therefore can never lag Terraform.
+#
+# Usage: scripts/render-app.sh <app-name> <inputs-file> [real_project_id]
+#
+# <inputs-file> is a YAML of the per-cluster propagated values -- every Terraform
+# *input* (cluster_name, vault_name, seed_project_id, CIDRs, nfs paths, ...) at
+# its real value, and the one Terraform *output* that reaches a manifest,
+# project_id, set to the sentinel @@TILES_PROJECT@@. In CI this file is produced
+# by pulling misc-config from 1Password (exactly the bootstrap handoff) with
+# project_id overwritten by the sentinel.
+#
+# The optional [real_project_id] overrides project_id with a real value; it exists
+# only for the round-trip proof (render sentinel vs. render real, then diff).
+set -euo pipefail
+
+APP="${1:?app name required, e.g. external-dns}"
+INPUTS="${2:?inputs file required (per-cluster values, project_id=@@TILES_PROJECT@@)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INPUTS="$(cd "$(dirname "${INPUTS}")" && pwd)/$(basename "${INPUTS}")"
+
+# Export every input as an environment variable BEFORE sourcing helm-common: it
+# builds `--set <var>=${var:-placeholder}` from the environment (the same handoff
+# the bootstrap workflow uses), so exported inputs flow into the render and
+# unspecified vars fall back to "placeholder". project_id carries the sentinel
+# unless the caller overrides it (round-trip proof only).
+# shellcheck disable=SC2016  # the yq expression below is literal, not a shell expansion
+while IFS=$'\t' read -r k v; do
+	[[ -n ${k} ]] && export "${k}=${v}"
+done < <(yq -o=tsv 'to_entries | .[] | [.key, .value] | @tsv' "${INPUTS}")
+[[ -n ${3:-} ]] && export "project_id=${3}"
+
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/scripts/helm-common.bash"
+cd "${REPO_ROOT}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+# 1. Render the app-of-apps for this cluster; set_flags carries the exported inputs.
+# shellcheck disable=SC2154  # helm_template_args and set_flags come from helm-common.bash
+helm template argocd-applications charts/argocd-applications \
+	--namespace argocd --skip-crds \
+	"${helm_template_args[@]}" \
+	"${set_flags[@]}" \
+	>"${work}/app-of-apps.yaml"
+
+# 2. Extract the named child Application's source path + helm block.
+export APP
+path="$(yq eval-all 'select(.kind == "Application" and .metadata.name == env(APP)) | .spec.source.path' "${work}/app-of-apps.yaml")"
+if [[ -z ${path} || ${path} == "null" ]]; then
+	echo "ERROR: no Application named '${APP}' with a single .spec.source.path in the app-of-apps render" >&2
+	echo "(multi-source apps and tanka/plugin apps are rendered differently; this spike covers single-source helm apps)" >&2
+	exit 1
+fi
+
+# valueFiles are repo-relative (they use values.yaml alongside the chart, and
+# occasionally $values/... refs which we skip -- those resolve inside Argo only).
+# shellcheck disable=SC2016  # yq expression and the grep pattern are literal, not shell
+mapfile -t value_files < <(yq eval-all \
+	'select(.kind == "Application" and .metadata.name == env(APP)) | .spec.source.helm.valueFiles[]' \
+	"${work}/app-of-apps.yaml" 2>/dev/null | grep -v '^\$values' || true)
+
+yq eval-all \
+	'select(.kind == "Application" and .metadata.name == env(APP)) | .spec.source.helm.valuesObject' \
+	"${work}/app-of-apps.yaml" >"${work}/values-object.yaml"
+
+# 3. Render the child chart exactly as Argo would: its own valueFiles first, then
+#    the Application's valuesObject last (highest precedence), matching Argo order.
+helm_values_args=()
+for vf in "${value_files[@]}"; do
+	[[ -n ${vf} ]] && helm_values_args+=(-f "${path}/${vf}")
+done
+helm_values_args+=(-f "${work}/values-object.yaml")
+
+helm template "${APP}" "${path}" \
+	--namespace "${APP}" --skip-crds \
+	"${helm_template_args[@]}" \
+	"${helm_values_args[@]}"


### PR DESCRIPTION
Not for merge as-is — this is the "let me see it working" artifact for the deploy-rendering discussion. Everything is additive (two scripts + a `docs/prerender-spike/` folder); nothing touches the live deploy path.

## What it shows

The recurring "changes need a manual refresh" pain traces to rendering ~30 apps at sync time through one throttled repo-server (parallelism 2, Tanka's per-generation `jb install` + vendor-copy under a global flock), stampeded on every moving-tag promotion. The idea: **pre-render structure in CI, defer only the one genuinely-post-apply scalar (`project_id`) to a post-render literal string swap.** `project_id` (`random_project_id = true`) only ever appears as a leaf — an external-dns `--google-project=` arg, a cert-manager ClusterIssuer `project:` field, a Tanka `--ext-str` — never structurally. So CI bakes every Terraform *input*, emits `project_id` as the sentinel `@@TILES_PROJECT@@`, and a sub-second `sed` at sync swaps in the real value that Terraform delivers live. The sentinel is why this doesn't lag Terraform: the artifact holds a placeholder, never a real post-apply value.

## Proof it's lossless

`scripts/prove-roundtrip.sh`: render with sentinel → `sed` back to a real value → diff against a direct render with that value.

```
PASS  external-dns     sentinel(sed)->real == direct-render   (sentinels=1)
PASS  cert-manager     sentinel(sed)->real == direct-render   (sentinels=2)
```

external-dns is the arg case; cert-manager is the CRD-field case that genuinely needs the swap (nothing at runtime expands a CRD field). `docs/prerender-spike/rendered/cert-manager-issuers-excerpt.yaml` shows the distinction in one view: `project: "@@TILES_PROJECT@@"` (generated output, deferred) next to `project: "seed-example"` (input, baked).

## Honest edges (in the README, not resolved here)

- **git-vs-OCI is separate from lag.** The sentinel fixes lag for the *output*; the baked *inputs* (CIDRs, nfs paths) are TF-managed config tiles keeps out of git today → that argues for publishing to OCI, not a git branch. (Demo uses fake inputs so nothing real is committed.)
- Per-cluster render is required (inter-cluster values differ structurally).
- The swap must be literal, never `envsubst` (rendered configs are full of legit `${...}`).
- Tanka apps aren't built in this spike (same idea, `tk show` with sentinel `--ext-str`).
- No sidecar / no Application rewrite. Flipping one app is a small follow-up if we like it.

See `docs/prerender-spike/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)