### PR TITLE
alloy: collect Talos node logs from /var/log/*.log (fixes #662)

### DIFF
--- a/charts/argocd-applications/values/alloy-values.yaml
+++ b/charts/argocd-applications/values/alloy-values.yaml
@@ -98,8 +98,13 @@ clusterEvents:
   enabled: true
   logFormat: json
 
+# Talos has no systemd journal, so the chart's journal-based node logs
+# (loki.source.journal on /var/log/journal) fail on every node -- a permanent
+# unhealthy component (#662). Talos instead writes machine/service + kernel logs
+# to /var/log/*.log; we collect those via loki.source.file in alloy-logs.extraConfig
+# below. So disable the journal source here rather than leaving it broken.
 nodeLogs:
-  enabled: true
+  enabled: false
 
 podLogs:
   enabled: true
@@ -163,6 +168,39 @@ alloy-logs:
     mounts:
       varlog: true
       dockercontainers: false
+  # Collect Talos node logs from /var/log/*.log (machined, kubelet, kernel, apid,
+  # controller-runtime, cri, containerd, ...) -- the machine-level logs otherwise
+  # only reachable via talosctl. This container already mounts /var/log and runs
+  # as root, so it can read the 0640 files. Ships to the same localLoki destination
+  # as pod logs. Replaces the broken journal source (nodeLogs disabled above, #662).
+  extraConfig: |-
+    local.file_match "talos" {
+      path_targets = [{
+        __path__ = "/var/log/*.log",
+        job      = "integrations/talos",
+        instance = sys.env("HOSTNAME"),
+      }]
+    }
+    loki.source.file "talos" {
+      targets    = local.file_match.talos.targets
+      forward_to = [loki.process.talos.receiver]
+    }
+    loki.process "talos" {
+      // service label from the file basename: machined, kubelet, kernel, apid, ...
+      stage.regex {
+        source     = "filename"
+        expression = "/var/log/(?P<service>[^/]+)\\.log$"
+      }
+      stage.labels {
+        values = { service = "" }
+      }
+      stage.static_labels {
+        values = { source = "talos" }
+      }
+      // Ingestion-time on purpose (no embedded-timestamp parse): tailing existing /
+      // rotated content on first start would otherwise be rejected 'entry too far behind'.
+      forward_to = [loki.write.localloki.receiver]
+    }
 
 alloy-receiver:
   enabled: true


### PR DESCRIPTION
Fixes #662. Collects Talos machine/service + kernel logs instead of disabling them.

## Why

The k8s-monitoring chart's `nodeLogs` uses `loki.source.journal` on `/var/log/journal`, which **doesn't exist on Talos** (no systemd journal) → the component is permanently unhealthy on all 8 alloy-logs pods (the standing "8 unhealthy components"). My first instinct to just disable `nodeLogs` was wrong — these are the machine-level logs (`machined`, `kubelet`, `kernel`, `apid`, `controller-runtime`, `cri`, `containerd`, …) that are otherwise only reachable via `talosctl logs`/`dmesg`, exactly the signal that's been hard to see historically.

**Talos v1.13 writes them to `/var/log/*.log`** (verified by `kubectl exec` on the nodes: live, rotating, `0640 root:root`). The alloy-logs container already mounts `/var/log` and runs as uid 0, so it can read them today — `loki.source.journal` was simply the wrong source.

## Change

- `nodeLogs.enabled: false` — stop the broken journal source (Talos has no journald for it to read).
- `alloy-logs.extraConfig`: a `loki.source.file` over `/var/log/*.log` → `loki.process` (labels `job=integrations/talos`, `instance=<node>`, `service=<file basename>`, `source=talos`) → the existing `loki.write.localloki` destination. Ingestion-time (no embedded-timestamp parse) on purpose, so first-start backfill of existing/rotated content isn't rejected `entry too far behind`.

Net effect is *more* collection, not less.

## Safety / validation

- River syntax validated with `alloy fmt` (a bad config here would crashloop alloy-logs — the failure we just fixed, so this was checked up front).
- `alloy-values.yaml` is a runtime value file (loaded by Argo), not part of the chart render, so `rendered.yaml` is unchanged.
- **Deploys to test first.** Before promoting the prod tag, confirm on test: alloy-logs stays healthy (no crashloop), the journal unhealthy component clears (`alloy_component_controller_running_components{health_type="unhealthy"}` drops by one per pod), and Talos logs land in Loki (`{job="integrations/talos"}` shows machined/kubelet/kernel/... per node). I'll re-run `alloy-health.ipynb` to confirm.

Refs: #662, #651, #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Mv2cf5sL2vsD86ibibb48