### PR TITLE
loki: enable mixin alerting rules (monitoring.rules.enabled: true) (#655)

### DIFF
--- a/charts/argocd-applications/values/loki-values.yaml
+++ b/charts/argocd-applications/values/loki-values.yaml
@@ -40,7 +40,12 @@ monitoring:
   serviceMonitor:
     enabled: true
   rules:
-    enabled: false
+    # Deploy the Loki mixin PrometheusRules (alerting rules included by chart
+    # default: monitoring.rules.alerting=true). Alloy's cluster-wide
+    # mimir.rules.kubernetes loads them into the Mimir ruler, same path as the
+    # other mixins -- so LokiRequestErrors/Latency/Panics/compaction alerts
+    # finally exist here rather than only being cited from the upstream mixin. #655
+    enabled: true
   selfMonitoring:
     enabled: false
 


### PR DESCRIPTION
Fixes #655.

## Why
Loki shipped only its `serviceMonitor` — **no alerting rules at all**. `LokiRequestErrors` / `LokiRequestLatency` / `LokiRequestPanics` / compaction alerts simply didn't exist in the cluster, which is why `loki-health.ipynb` had to source every threshold from the *upstream* mixin and cite it inline. This was blocked on #656 (the crashlooping rule loader); that's fixed and deployed (#658/#665), so it's now actionable.

## Change
One line: `monitoring.rules.enabled: true` in `loki-values.yaml`. Alerting rules are included by the chart default (`monitoring.rules.alerting: true`, verified in loki chart 6.49.0). The chart emits `PrometheusRule` CRs, and the existing cluster-wide `mimir.rules.kubernetes` (alloy-singleton, healthy again) loads them into the Mimir ruler — the same path the other mixins use, no new plumbing.

Left `dashboards` and `selfMonitoring` off (separate concerns; this issue's core is the alerting gap).

## Safety / verification (test-first)
`loki-values.yaml` is a runtime value file, so `rendered.yaml` is unaffected. After the test deploy, before promoting prod, I'll verify:
- Loki rule groups appear in the Mimir ruler (`count by (rule_group) (cortex_prometheus_rule_group_rules{rule_group=~".*[Ll]oki.*"})` > 0),
- they evaluate without a failure spike (`cortex_prometheus_rule_evaluation_failures_total`),
- `loki-health.ipynb`'s alerts cross-check can now see Loki alerts.

I'll run that verification once you review + merge (per your ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Mv2cf5sL2vsD86ibibb48