### PR TITLE
argo-tag-watcher: deploy via app-of-apps (go-live for #667)

### DIFF
--- a/charts/argo-tag-watcher/Chart.yaml
+++ b/charts/argo-tag-watcher/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: argo-tag-watcher
+description: Watches the prod/test git tag and refreshes Argo CD apps when it moves (tiles#667)
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/argo-tag-watcher/application.yaml
+++ b/charts/argo-tag-watcher/application.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-tag-watcher
+spec:
+  project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+    path: charts/argo-tag-watcher
+    helm:
+      valuesObject:
+        # The ref we deploy from is the ref the watcher polls.
+        targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/charts/argo-tag-watcher/rendered.yaml
+++ b/charts/argo-tag-watcher/rendered.yaml
@@ -1,0 +1,98 @@
+---
+# Source: argo-tag-watcher/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-tag-watcher
+  namespace: "argo-tag-watcher"
+---
+# Source: argo-tag-watcher/templates/rbac.yaml
+# Least privilege: only read Applications and set the refresh annotation.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-tag-watcher
+  namespace: "argo-tag-watcher"
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["list", "patch"]
+---
+# Source: argo-tag-watcher/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-tag-watcher
+  namespace: "argo-tag-watcher"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-tag-watcher
+subjects:
+  - kind: ServiceAccount
+    name: argo-tag-watcher
+    namespace: "argo-tag-watcher"
+
+---
+# Source: argo-tag-watcher/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-tag-watcher
+  namespace: "argo-tag-watcher"
+  labels:
+    app.kubernetes.io/name: argo-tag-watcher
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-tag-watcher
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argo-tag-watcher
+    spec:
+      serviceAccountName: argo-tag-watcher
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: argo-tag-watcher
+          image: "ghcr.io/symmatree/tiles/argo-tag-watcher:main"
+          env:
+            - name: REPO_URL
+              value: "https://github.com/symmatree/tiles.git"
+            # The tag we deploy from is the tag we watch.
+            - name: WATCH_REF
+              value: 'placeholder'
+            - name: ARGOCD_NAMESPACE
+              value: "argo-tag-watcher"
+            - name: INTERVAL
+              value: "60s"
+            - name: BATCH_SIZE
+              value: "4"
+            - name: BATCH_DELAY
+              value: "5s"
+            - name: HOME # git wants a writable HOME even for ls-remote
+              value: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/charts/argo-tag-watcher/templates/deployment.yaml
+++ b/charts/argo-tag-watcher/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-tag-watcher
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/name: argo-tag-watcher
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-tag-watcher
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argo-tag-watcher
+    spec:
+      serviceAccountName: argo-tag-watcher
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: argo-tag-watcher
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          env:
+            - name: REPO_URL
+              value: "{{ .Values.repoURL }}"
+            # The tag we deploy from is the tag we watch.
+            - name: WATCH_REF
+              value: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+            - name: ARGOCD_NAMESPACE
+              value: "{{ .Release.Namespace }}"
+            - name: INTERVAL
+              value: "{{ .Values.interval }}"
+            - name: BATCH_SIZE
+              value: "{{ .Values.batchSize }}"
+            - name: BATCH_DELAY
+              value: "{{ .Values.batchDelay }}"
+            - name: HOME # git wants a writable HOME even for ls-remote
+              value: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/charts/argo-tag-watcher/templates/rbac.yaml
+++ b/charts/argo-tag-watcher/templates/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-tag-watcher
+  namespace: "{{ .Release.Namespace }}"
+---
+# Least privilege: only read Applications and set the refresh annotation.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argo-tag-watcher
+  namespace: "{{ .Release.Namespace }}"
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-tag-watcher
+  namespace: "{{ .Release.Namespace }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-tag-watcher
+subjects:
+  - kind: ServiceAccount
+    name: argo-tag-watcher
+    namespace: "{{ .Release.Namespace }}"

--- a/charts/argo-tag-watcher/values.yaml
+++ b/charts/argo-tag-watcher/values.yaml
@@ -1,0 +1,12 @@
+# Watcher tunables. The propagated values (targetRevision, cluster_name) are
+# injected by the app-of-apps via the Application valuesObject; targetRevision is
+# both where we deploy from and the ref we watch.
+image:
+  repository: ghcr.io/symmatree/tiles/argo-tag-watcher
+  tag: main
+repoURL: https://github.com/symmatree/tiles.git
+interval: 60s
+batchSize: 4
+batchDelay: 5s
+# Placeholder; overridden by --set / valuesObject at render time.
+targetRevision: placeholder

--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -262,6 +262,32 @@ spec:
         pod-security.kubernetes.io/warn: baseline
 
 ---
+# Source: argocd-applications/templates/argo-tag-watcher-application.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-tag-watcher
+spec:
+  project: 'placeholder'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: 'placeholder'
+    path: charts/argo-tag-watcher
+    helm:
+      valuesObject:
+        # The ref we deploy from is the ref the watcher polls.
+        targetRevision: 'placeholder'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+
+---
 # Source: argocd-applications/templates/argocd-application.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/charts/argocd-applications/templates/argo-tag-watcher-application.yaml
+++ b/charts/argocd-applications/templates/argo-tag-watcher-application.yaml
@@ -1,0 +1,1 @@
+../../argo-tag-watcher/application.yaml


### PR DESCRIPTION
Go-live wiring for the watcher (code + image are in #670). Makes it a normal app-of-apps child so Argo deploys and manages it.

## What's here
- **`charts/argo-tag-watcher/`** — Helm chart: ServiceAccount, least-privilege Role/RoleBinding (`list`+`patch` on `applications.argoproj.io`), and the Deployment. `WATCH_REF` is set from the propagated `targetRevision`, so **the tag we deploy from is the tag it watches** (`prod` on prod, `test` on tiles-test). Runs in the `argocd` namespace so it can patch Applications.
- **`application.yaml`** symlinked into `charts/argocd-applications/templates/` — the standard app-of-apps entry.
- **`rendered.yaml`** snapshots regenerated with **helm v4.2.2** (CI's pinned version). The `argocd-applications/rendered.yaml` diff is a **clean addition** of the new Application block only — nothing else displaced.

## Dependency / merge order
Depends on **#670** (container code + image build). Merge **#670 first** so `build-argo-tag-watcher` publishes `:main`, then this. If merged first, Argo will just show the app pulling until the image exists.

## What happens on deploy
Argo syncs the chart → the watcher starts, checks the tag once immediately, and (since it's a fresh start) refreshes all apps — which should converge the ~16 currently-stale prod apps **with nobody touching Argo**. That's the live proof for #667.

## Follow-ups (unchanged)
- Image side (digest-watch → rollout restart) is still a separate PR.
- `containers/argo-tag-watcher/deploy/` (the plain-YAML manifests in #670) becomes redundant once this is in; can be dropped in a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)