### PR TITLE
alloy: tag alertmanager->apprise webhook so alerts actually deliver

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -56,7 +56,10 @@ spec:
                     webhookConfigs:
                       # alert-forward sidecar shares the mimir-alertmanager pod,
                       # so localhost:3000; it forwards to apprise /notify/apprise.
-                      - url: http://localhost:3000?template=alertmanager&key=apprise
+                      # tag=<cluster_name> so apprise routes to this cluster's targets
+                      # (#tiles / #tiles-test etc). A no-tag notify matches zero apprise
+                      # targets and is silently dropped -- the delivered-nothing bug.
+                      - url: http://localhost:3000?template=alertmanager&key=apprise&tag=placeholder
                         sendResolved: true
             - apiVersion: monitoring.coreos.com/v1
               kind: Probe

--- a/charts/argocd-applications/templates/alloy-application.yaml
+++ b/charts/argocd-applications/templates/alloy-application.yaml
@@ -54,7 +54,10 @@ spec:
                     webhookConfigs:
                       # alert-forward sidecar shares the mimir-alertmanager pod,
                       # so localhost:3000; it forwards to apprise /notify/apprise.
-                      - url: http://localhost:3000?template=alertmanager&key=apprise
+                      # tag=<cluster_name> so apprise routes to this cluster's targets
+                      # (#tiles / #tiles-test etc). A no-tag notify matches zero apprise
+                      # targets and is silently dropped -- the delivered-nothing bug.
+                      - url: http://localhost:3000?template=alertmanager&key=apprise&tag={{ required ".Values.cluster_name is required" .Values.cluster_name }}
                         sendResolved: true
             - apiVersion: monitoring.coreos.com/v1
               kind: Probe


### PR DESCRIPTION
## The bug

The `apprise-catchall` webhook (Mimir alertmanager -> `alert-forward` sidecar -> apprise) POSTed with **no tag**. apprise routes purely by tag, and a **no-tag notify matches zero targets** in the apprise config, so it returns 424 and delivers to **nothing** -- not Slack, not the Gmail archive. This is the actual reason no alerts were getting through, downstream of the (already-fixed) #656 rule/alert-sync crashloop.

Verified live: `tag=tiles|tiles-test|priority` -> HTTP 200 (delivered); no-tag -> HTTP 424 (`Sent Email` counter flat, nothing posted to Slack).

## Fix

Add `tag={{ .Values.cluster_name }}` to the webhook URL. `cluster_name` is `tiles` / `tiles-test`, matching the existing `#tiles` / `#tiles-test` apprise targets, so each cluster routes to its own channel. The sidecar already forwards `query.tag` straight through to `/notify/apprise`.

Rendered snapshot regenerated (local Helm v4.2.2, byte-identical to committed before this change); the only diff is the webhook line (`&tag=placeholder` in the snapshot, `&tag=tiles` on prod).

## Still needed for full delivery (not in git)

The shared `apprise-config` 1Password item tags the Gmail archive entry `bond,tales` -- `tales` is the **retired** cluster. Update to `bond,tiles` so prod alerts also archive to Gmail, then `kubectl -n apprise rollout restart deploy/apprise`. (Owner action; the config is a read-only secret mount, not in git.)

## Follow-ups
- Severity-based routing (`#priority` for critical vs `#tiles` for the rest) -- the sidecar would need to map alert labels -> tag.
- Apprise metrics/mixin + canary delivery test: #676.

Refs #635, #656, #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)