### PR TITLE
apprise-mixin: dashboard + serving/delivery alerts + scrape (#676)

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -265,6 +265,42 @@ spec:
         pod-security.kubernetes.io/warn: baseline
 
 ---
+# Source: argocd-applications/templates/apprise-mixin-application.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apprise-mixin
+spec:
+  project: 'placeholder'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: 'placeholder'
+    path: tanka
+    plugin:
+      env:
+        - name: TK_ENV
+          value: apprise-mixin
+      parameters:
+        - name: cluster_name
+          string: 'placeholder'
+        - name: vault_name
+          string: 'placeholder'
+        - name: project_id
+          string: 'placeholder'
+        - name: app_settings
+          map: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: apprise-mixin
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+
+---
 # Source: argocd-applications/templates/argo-tag-watcher-application.yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/charts/argocd-applications/templates/apprise-mixin-application.yaml
+++ b/charts/argocd-applications/templates/apprise-mixin-application.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apprise-mixin
+spec:
+  project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+  source:
+    repoURL: https://github.com/symmatree/tiles.git
+    targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
+    path: tanka
+    plugin:
+      env:
+        - name: TK_ENV
+          value: apprise-mixin
+      parameters:
+        - name: cluster_name
+          string: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+        - name: vault_name
+          string: '{{ required ".Values.vault_name is required" .Values.vault_name }}'
+        - name: project_id
+          string: '{{ required ".Values.project_id is required" .Values.project_id }}'
+        - name: app_settings
+          map: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: apprise-mixin
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/tanka/environments/apprise-mixin/README.md
+++ b/tanka/environments/apprise-mixin/README.md
@@ -1,0 +1,68 @@
+# Apprise mixin
+
+A monitoring mixin for [Apprise](https://github.com/caronc/apprise-api) (the
+`caronc/apprise` notification service): a Grafana dashboard plus alerts for
+**serving** health and **delivery** health, kept as separate concerns because
+Apprise can be perfectly healthy as an HTTP service while every notification is
+silently dropped downstream.
+
+There is (as of 2026-07) no Apprise mixin in the
+[monitoring-mixins registry](https://monitoring.mixins.dev/); the `mixin/`
+directory here is deliberately generic so it can be contributed upstream. The
+tiles-specific wiring (Tanka environment, ServiceMonitor, Argo CD Application)
+lives outside `mixin/`.
+
+## Metrics it needs
+
+Apprise exposes Prometheus metrics at `/metrics` via
+[django-prometheus](https://github.com/korfuri/django-prometheus). Point a scrape
+at the pod (the bundled `ServiceMonitor` in [`main.jsonnet`](main.jsonnet) does
+this for the `caronc/apprise` deployment). Key series:
+
+- `apprise_django_http_responses_total_by_status_view_method_total{view,status,method}`
+  — responses by Django view and HTTP status. `view="notify"` + `status="200"`
+  is a fully-delivered notification; `status="424"` means at least one target
+  was not delivered.
+- `apprise_django_http_requests_latency_seconds_by_view_method_bucket{view,method,le}`
+  — request latency histogram.
+- `process_resident_memory_bytes`, `process_cpu_seconds_total` — process resources.
+
+The `apprise_` prefix is django-prometheus's `PROMETHEUS_METRIC_NAMESPACE`;
+override `_config.metricNamespace` if your deployment differs.
+
+## Configuration
+
+All knobs live in [`mixin/config.libsonnet`](mixin/config.libsonnet) under
+`_config`; override them the usual mixin way. The important ones:
+
+| key | default | purpose |
+| --- | --- | --- |
+| `appriseSelector` | `job="apprise"` | label matcher for the Apprise target |
+| `metricNamespace` | `apprise` | django-prometheus metric-name prefix |
+| `notifyView` | `notify` | Django view name for the delivery endpoint |
+| `servingErrorRatioThreshold` | `0.05` | 5xx ratio that trips `AppriseServingErrors` |
+| `deliveryFailureFor` / `deliveryAllFailingFor` | `15m` / `30m` | delivery-alert `for` windows |
+
+## Dashboards
+
+- **Apprise / Overview** (`apprise-overview`): delivery success rate, notify
+  outcomes by status, serving status classes, request latency quantiles,
+  requests by view, and process resources.
+
+## Alerts
+
+Two groups, kept separate on purpose:
+
+- **`apprise-serving`** — `AppriseDown` (target unreachable), `AppriseServingErrors`
+  (sustained 5xx ratio).
+- **`apprise-delivery`** — `AppriseDeliveryFailing` (any 424 on notify),
+  `AppriseAllDeliveriesFailing` (notify traffic but zero successes — alerts
+  reaching nobody).
+
+## Wiring here (tiles)
+
+[`main.jsonnet`](main.jsonnet) wraps the mixin with the shared
+`monitoring-resources.libsonnet` (dashboards → ConfigMaps, alerts → PrometheusRules
+that Alloy pushes to the Mimir ruler) and adds the ServiceMonitor. Deployed by
+Argo CD via `charts/argocd-applications/templates/apprise-mixin-application.yaml`.
+Render locally with `tk eval environments/apprise-mixin`.

--- a/tanka/environments/apprise-mixin/main.jsonnet
+++ b/tanka/environments/apprise-mixin/main.jsonnet
@@ -1,0 +1,44 @@
+// Apprise mixin: dashboards + alerts for the Apprise notification backend, plus a
+// ServiceMonitor that scrapes Apprise's /metrics so the mixin has data to work with.
+// The mixin itself (mixin/) is generic and contributable; tiles-specific wiring lives
+// here.
+local appriseMixin = import 'mixin/mixin.libsonnet';
+local libMonResources = import 'monitoring-resources.libsonnet';
+
+local namespace = 'apprise-mixin';
+
+libMonResources.new(
+  appriseMixin,
+  {
+    folder: 'Apprise',
+    namespace: namespace,
+    tags: ['apprise'],
+  },
+) + {
+  // Scrape the Apprise pod's /metrics (django-prometheus). Apprise lives in the
+  // `apprise` namespace; nginx allows in-cluster ranges without auth. The relabel
+  // pins job="apprise" so it matches the mixin's default appriseSelector.
+  serviceMonitor: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata: {
+      name: 'apprise',
+      namespace: namespace,
+      labels: { 'app.kubernetes.io/name': 'apprise' },
+    },
+    spec: {
+      namespaceSelector: { matchNames: ['apprise'] },
+      selector: { matchLabels: { name: 'apprise' } },
+      endpoints: [
+        {
+          port: 'apprise-http',
+          path: '/metrics',
+          interval: '30s',
+          relabelings: [
+            { targetLabel: 'job', replacement: 'apprise' },
+          ],
+        },
+      ],
+    },
+  },
+}

--- a/tanka/environments/apprise-mixin/mixin/alerts/alerts.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/alerts/alerts.libsonnet
@@ -1,0 +1,2 @@
+(import 'serving.libsonnet') +
+(import 'delivery.libsonnet')

--- a/tanka/environments/apprise-mixin/mixin/alerts/delivery.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/alerts/delivery.libsonnet
@@ -1,0 +1,49 @@
+// Delivery errors: Apprise accepted a notify request but one or more of the
+// configured targets (Slack, email, ...) was not delivered. Apprise reports this
+// as HTTP 424 on the notify view. Kept separate from serving errors because the
+// service can be perfectly healthy while every notification is silently dropped.
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'apprise-delivery',
+        rules: [
+          {
+            alert: 'AppriseDeliveryFailing',
+            expr: |||
+              sum(rate(%(metricNamespace)s_django_http_responses_total_by_status_view_method_total{%(appriseSelector)s, view="%(notifyView)s", status="424"}[15m])) > 0
+            ||| % $._config,
+            'for': $._config.deliveryFailureFor,
+            labels: { severity: $._config.deliverySeverity },
+            annotations: {
+              summary: 'Apprise notifications are failing to deliver',
+              description: |||
+                Apprise /notify has returned 424 (at least one target not delivered) for %(deliveryFailureFor)s. Check the Apprise pod logs for the failing target -- common causes are a Slack bot missing from the channel, a bad Gmail app-password, or a tag that matches no configured target.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'AppriseAllDeliveriesFailing',
+            expr: |||
+              (
+                sum(rate(%(metricNamespace)s_django_http_responses_total_by_status_view_method_total{%(appriseSelector)s, view="%(notifyView)s", status="200"}[15m])) == 0
+              )
+              and
+              (
+                sum(rate(%(metricNamespace)s_django_http_responses_total_by_status_view_method_total{%(appriseSelector)s, view="%(notifyView)s"}[15m])) > 0
+              )
+            ||| % $._config,
+            'for': $._config.deliveryAllFailingFor,
+            labels: { severity: $._config.deliveryAllFailingSeverity },
+            annotations: {
+              summary: 'No Apprise notifications are being delivered',
+              description: |||
+                Apprise has received notify requests but none have succeeded (every response was a non-200) for %(deliveryAllFailingFor)s -- alerts are reaching nobody. This is the "delivered nothing" failure mode.
+              ||| % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/tanka/environments/apprise-mixin/mixin/alerts/serving.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/alerts/serving.libsonnet
@@ -1,0 +1,43 @@
+// Serving errors: is the Apprise service itself healthy and answering HTTP?
+// (Distinct from delivery errors -- see delivery.libsonnet.)
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'apprise-serving',
+        rules: [
+          {
+            alert: 'AppriseDown',
+            expr: 'up{%(appriseSelector)s} == 0' % $._config,
+            'for': $._config.appriseDownFor,
+            labels: { severity: $._config.appriseDownSeverity },
+            annotations: {
+              summary: 'Apprise is down',
+              description: |||
+                The Apprise target ({{ $labels.instance }}) has been unreachable/unscrapable for %(appriseDownFor)s. While it is down no notifications can be delivered and this is the delivery backend for cluster alerting.
+              ||| % $._config,
+            },
+          },
+          {
+            alert: 'AppriseServingErrors',
+            expr: |||
+              (
+                sum(rate(%(metricNamespace)s_django_http_responses_total_by_status_view_method_total{%(appriseSelector)s, status=~"5.."}[5m]))
+                /
+                sum(rate(%(metricNamespace)s_django_http_responses_total_by_status_view_method_total{%(appriseSelector)s}[5m]))
+              ) > %(servingErrorRatioThreshold)g
+            ||| % $._config,
+            'for': $._config.servingErrorRatioFor,
+            labels: { severity: $._config.servingErrorSeverity },
+            annotations: {
+              summary: 'Apprise is returning server errors',
+              description: |||
+                {{ printf "%%.1f" (mul $value 100) }}%% of Apprise HTTP responses have been 5xx over the last 5m (threshold %(servingErrorRatioThreshold)g), sustained for %(servingErrorRatioFor)s. This is the service failing, independent of downstream delivery.
+              ||| % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/tanka/environments/apprise-mixin/mixin/config.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/config.libsonnet
@@ -1,0 +1,46 @@
+{
+  _config+:: {
+    // --- target selection ---------------------------------------------------
+    // Label matcher identifying the Apprise scrape target. The bundled
+    // ServiceMonitor relabels the job to `apprise`, so this default works
+    // out-of-the-box; override it if you scrape Apprise under a different job.
+    appriseSelector: 'job="apprise"',
+
+    // django-prometheus prefixes every metric with its PROMETHEUS_METRIC_NAMESPACE.
+    // The caronc/apprise image uses `apprise`, giving `apprise_django_http_*`.
+    // Override if your deployment sets a different namespace.
+    metricNamespace: 'apprise',
+
+    // Django view name for the delivery endpoint (`POST /notify/<key>`).
+    notifyView: 'notify',
+
+    // --- alerting tunables ---------------------------------------------------
+    // Target unreachable/unscrapable (alerts and notifications both stop).
+    appriseDownFor: '10m',
+    appriseDownSeverity: 'critical',
+
+    // Fraction of HTTP responses that may be 5xx before AppriseServingErrors fires.
+    servingErrorRatioThreshold: 0.05,
+    servingErrorRatioFor: '10m',
+    servingErrorSeverity: 'warning',
+
+    // Any 424 on the notify view means >=1 target was not delivered.
+    deliveryFailureFor: '15m',
+    deliverySeverity: 'warning',
+    // Notify traffic present but zero successes -> alerts reach nobody.
+    deliveryAllFailingFor: '30m',
+    deliveryAllFailingSeverity: 'critical',
+
+    // --- dashboard ----------------------------------------------------------
+    dashboardTags: ['apprise'],
+    dashboardTitle: 'Apprise / Overview',
+    dashboardUid: 'apprise-overview',
+    dashboardPeriod: 'now-6h',
+    dashboardTimezone: 'utc',
+    dashboardRefresh: '1m',
+    // Name of the datasource template variable; the deploy-time wrapper can set
+    // its default via `datasourceDefaults` so the dashboard opens on the right
+    // Prometheus/Mimir without a manual pick.
+    datasourceName: 'datasource',
+  },
+}

--- a/tanka/environments/apprise-mixin/mixin/dashboards/apprise-overview.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/dashboards/apprise-overview.libsonnet
@@ -1,0 +1,155 @@
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+
+{
+  grafanaDashboards+:: {
+    'apprise-overview.json':
+      local cfg = $._config;
+      local ds = '${' + cfg.datasourceName + '}';
+      local m = cfg.metricNamespace + '_django_http_responses_total_by_status_view_method_total';
+      local latBucket = cfg.metricNamespace + '_django_http_requests_latency_seconds_by_view_method_bucket';
+      local notify = 'view="%s"' % cfg.notifyView;
+
+      local q(expr, legend) =
+        g.query.prometheus.new(ds, expr % cfg)
+        + g.query.prometheus.withLegendFormat(legend);
+
+      local ts(title, unit, targets, desc) =
+        g.panel.timeSeries.new(title)
+        + g.panel.timeSeries.panelOptions.withDescription(desc)
+        + g.panel.timeSeries.standardOptions.withUnit(unit)
+        + g.panel.timeSeries.options.legend.withDisplayMode('table')
+        + g.panel.timeSeries.options.legend.withPlacement('bottom')
+        + g.panel.timeSeries.fieldConfig.defaults.custom.withFillOpacity(10)
+        + g.panel.timeSeries.queryOptions.withTargets(targets);
+
+      local stat(title, unit, target, desc) =
+        g.panel.stat.new(title)
+        + g.panel.stat.panelOptions.withDescription(desc)
+        + g.panel.stat.standardOptions.withUnit(unit)
+        + g.panel.stat.options.withColorMode('value')
+        + g.panel.stat.queryOptions.withTargets([target]);
+
+      local pos(p, x, y, w, h) = p { gridPos: { x: x, y: y, w: w, h: h } };
+
+      local rowAt(title, y) =
+        g.panel.row.new(title) + { gridPos: { x: 0, y: y, w: 24, h: 1 } };
+
+      // --- Overview stats ---------------------------------------------------
+      local sUp = pos(stat(
+        'Apprise up',
+        'bool',
+        q('up{%(appriseSelector)s}', 'up') + g.query.prometheus.withInstant(true),
+        'Is the Apprise scrape target up.'
+      ), 0, 1, 6, 4);
+
+      local sSuccess = pos(stat(
+        'Notify success rate (5m)',
+        'percentunit',
+        q('sum(rate(' + m + '{%(appriseSelector)s, ' + notify + ', status="200"}[5m])) / sum(rate(' + m + '{%(appriseSelector)s, ' + notify + '}[5m]))', 'success')
+        + g.query.prometheus.withInstant(true),
+        'Fraction of notify requests that fully delivered (HTTP 200) over 5m.'
+      ), 6, 1, 6, 4);
+
+      local sRate = pos(stat(
+        'Notify requests/s (5m)',
+        'reqps',
+        q('sum(rate(' + m + '{%(appriseSelector)s, ' + notify + '}[5m]))', 'notify')
+        + g.query.prometheus.withInstant(true),
+        'Rate of notify requests Apprise is receiving.'
+      ), 12, 1, 6, 4);
+
+      local sFail = pos(stat(
+        'Delivery failures/s (424, 5m)',
+        'reqps',
+        q('sum(rate(' + m + '{%(appriseSelector)s, ' + notify + ', status="424"}[5m]))', '424')
+        + g.query.prometheus.withInstant(true),
+        'Rate of notify requests where at least one target was not delivered.'
+      ), 18, 1, 6, 4);
+
+      // --- Delivery ---------------------------------------------------------
+      local pOutcomes = pos(ts(
+        'Notify outcomes by status',
+        'reqps',
+        [q('sum by (status) (rate(' + m + '{%(appriseSelector)s, ' + notify + '}[$__rate_interval]))', '{{ status }}')],
+        'Notify responses per second by HTTP status. 200 = delivered to all matched targets; 424 = one or more not delivered.'
+      ), 0, 6, 12, 8);
+
+      local pRatio = pos(ts(
+        'Delivery success ratio',
+        'percentunit',
+        [q('sum(rate(' + m + '{%(appriseSelector)s, ' + notify + ', status="200"}[$__rate_interval])) / sum(rate(' + m + '{%(appriseSelector)s, ' + notify + '}[$__rate_interval]))', 'success ratio')],
+        'Share of notify requests that fully delivered.'
+      ), 12, 6, 12, 8);
+
+      // --- Serving ----------------------------------------------------------
+      local pStatus = pos(ts(
+        'HTTP responses by status',
+        'reqps',
+        [q('sum by (status) (rate(' + m + '{%(appriseSelector)s}[$__rate_interval]))', '{{ status }}')],
+        'All Apprise HTTP responses per second by status (5xx = serving errors).'
+      ), 0, 15, 8, 8);
+
+      local pLatency = pos(ts(
+        'Request latency',
+        's',
+        [
+          q('histogram_quantile(0.50, sum by (le) (rate(' + latBucket + '{%(appriseSelector)s}[$__rate_interval])))', 'p50'),
+          q('histogram_quantile(0.90, sum by (le) (rate(' + latBucket + '{%(appriseSelector)s}[$__rate_interval])))', 'p90'),
+          q('histogram_quantile(0.99, sum by (le) (rate(' + latBucket + '{%(appriseSelector)s}[$__rate_interval])))', 'p99'),
+        ],
+        'Apprise request latency quantiles across all views.'
+      ), 8, 15, 8, 8);
+
+      local pByView = pos(ts(
+        'Requests by view',
+        'reqps',
+        [q('sum by (view) (rate(' + m + '{%(appriseSelector)s}[$__rate_interval]))', '{{ view }}')],
+        'Request rate by Django view (notify, health, metrics).'
+      ), 16, 15, 8, 8);
+
+      // --- Resources --------------------------------------------------------
+      local pMem = pos(ts(
+        'Process memory',
+        'bytes',
+        [q('process_resident_memory_bytes{%(appriseSelector)s}', 'rss')],
+        'Resident memory of the Apprise process.'
+      ), 0, 24, 12, 7);
+
+      local pCpu = pos(ts(
+        'Process CPU',
+        'short',
+        [q('rate(process_cpu_seconds_total{%(appriseSelector)s}[$__rate_interval])', 'cpu cores')],
+        'CPU seconds per second (cores) used by the Apprise process.'
+      ), 12, 24, 12, 7);
+
+      g.dashboard.new(cfg.dashboardTitle)
+      + g.dashboard.withUid(cfg.dashboardUid)
+      + g.dashboard.withTags(cfg.dashboardTags)
+      + g.dashboard.withTimezone(cfg.dashboardTimezone)
+      + g.dashboard.withRefresh(cfg.dashboardRefresh)
+      + g.dashboard.withEditable(false)
+      + g.dashboard.time.withFrom(cfg.dashboardPeriod)
+      + g.dashboard.time.withTo('now')
+      + g.dashboard.withVariables([
+        g.dashboard.variable.datasource.new(cfg.datasourceName, 'prometheus')
+        + g.dashboard.variable.datasource.generalOptions.withLabel('Data source'),
+      ])
+      + g.dashboard.withPanels([
+        rowAt('Overview', 0),
+        sUp,
+        sSuccess,
+        sRate,
+        sFail,
+        rowAt('Delivery', 5),
+        pOutcomes,
+        pRatio,
+        rowAt('Serving', 14),
+        pStatus,
+        pLatency,
+        pByView,
+        rowAt('Resources', 23),
+        pMem,
+        pCpu,
+      ]),
+  },
+}

--- a/tanka/environments/apprise-mixin/mixin/dashboards/dashboards.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,1 @@
+(import 'apprise-overview.libsonnet')

--- a/tanka/environments/apprise-mixin/mixin/mixin.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/mixin.libsonnet
@@ -1,0 +1,4 @@
+(import 'config.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'dashboards/dashboards.libsonnet') +
+(import 'rules/rules.libsonnet')

--- a/tanka/environments/apprise-mixin/mixin/rules/rules.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/rules/rules.libsonnet
@@ -1,0 +1,7 @@
+// No recording rules yet -- the dashboard computes ratios inline and the alerts
+// are cheap. Slot kept for mixin convention / future additions.
+{
+  prometheusRules+:: {
+    groups: [],
+  },
+}

--- a/tanka/environments/apprise-mixin/spec.json
+++ b/tanka/environments/apprise-mixin/spec.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": {
+    "name": "environments/apprise-mixin"
+  },
+  "spec": {
+    "namespace": "apprise-mixin",
+    "resourceDefaults": {},
+    "expectVersions": {}
+  }
+}

--- a/tanka/environments/apprise/README.md
+++ b/tanka/environments/apprise/README.md
@@ -104,13 +104,26 @@ Configuration is managed through the Application's plugin parameters:
 
 ## Monitoring & Observability
 
+Full monitoring (scrape + dashboard + alerts) lives in the sibling
+[`apprise-mixin`](../apprise-mixin/README.md) environment.
+
 ### Metrics
 
-- TODO: Document if Apprise exposes metrics
+- Apprise exposes Prometheus metrics at `/metrics` (django-prometheus, `apprise_django_*`).
+  The `apprise-mixin` `ServiceMonitor` scrapes them under `job="apprise"`. The key
+  series is `apprise_django_http_responses_total_by_status_view_method_total`
+  (`view="notify"`, `status="200"` delivered / `status="424"` not delivered).
 
 ### Dashboards
 
-- TODO: Document if Apprise has dashboards
+- **Apprise / Overview** (`apprise-overview`), from `apprise-mixin`: delivery success
+  rate, notify outcomes by status, serving errors, latency, and process resources.
+
+### Alerts
+
+- From `apprise-mixin`, in two groups: `apprise-serving` (`AppriseDown`,
+  `AppriseServingErrors`) and `apprise-delivery` (`AppriseDeliveryFailing`,
+  `AppriseAllDeliveriesFailing`).
 
 ### Logs
 


### PR DESCRIPTION
Implements the Apprise mixin from #676. No Apprise mixin exists in the [monitoring-mixins registry](https://monitoring.mixins.dev/), so this adds one; `mixin/` is kept generic so it can be contributed upstream, with tiles-specific wiring in `main.jsonnet`.

## What's here

- **Scrape** — a `ServiceMonitor` for Apprise's django-prometheus `/metrics` (job `apprise`). Verified a cluster pod gets HTTP 200 on `/metrics` (nginx allows in-cluster ranges without auth).
- **Dashboard** — *Apprise / Overview* (grafonnet v11): notify success rate, notify outcomes by status (200 vs 424), HTTP status classes (serving errors), request latency p50/p90/p99, requests by view, process memory/CPU.
- **Alerts** — two **separate** groups, as requested:
  - `apprise-serving`: `AppriseDown`, `AppriseServingErrors` (sustained 5xx ratio)
  - `apprise-delivery`: `AppriseDeliveryFailing` (any 424 on the notify view), `AppriseAllDeliveriesFailing` (notify traffic but zero successes — "alerts reaching nobody")
- **Configurable** via `_config` (`appriseSelector`, `metricNamespace`, `notifyView`, thresholds and `for` windows) following mixin conventions.
- **Docs** — a mixin README (metrics needed, config table, reuse notes) and filled the monitoring TODOs in the apprise deployment README.

## Metric it keys on

`apprise_django_http_responses_total_by_status_view_method_total{view="notify",status="200"|"424"}` — the delivery success/failure counter surfaced during the #677 debugging.

## Validation

- `tk eval environments/apprise-mixin` renders 4 resources (2 PrometheusRules, dashboard ConfigMap with `grafana_dashboard=1` + folder annotation, ServiceMonitor); dashboard JSON parses (15 panels); `jsonnetfmt --test` clean.
- Regenerated `charts/argocd-applications/rendered.yaml` — only the new `apprise-mixin` Application is added.

## To confirm post-deploy

The scrape's `job` label (the ServiceMonitor relabels it to `apprise`). If Alloy labels it differently, `_config.appriseSelector` is a one-line override. The dashboard/alerts can't be exercised until Apprise is actually scraped (this PR is what starts that).

Closes #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)