### PR TITLE
apprise-mixin: fix AppriseServingErrors alert template (mul not a Prometheus func)

### DIFF
--- a/tanka/environments/apprise-mixin/mixin/alerts/serving.libsonnet
+++ b/tanka/environments/apprise-mixin/mixin/alerts/serving.libsonnet
@@ -32,7 +32,7 @@
             annotations: {
               summary: 'Apprise is returning server errors',
               description: |||
-                {{ printf "%%.1f" (mul $value 100) }}%% of Apprise HTTP responses have been 5xx over the last 5m (threshold %(servingErrorRatioThreshold)g), sustained for %(servingErrorRatioFor)s. This is the service failing, independent of downstream delivery.
+                {{ $value | humanizePercentage }} of Apprise HTTP responses have been 5xx over the last 5m (ratio threshold %(servingErrorRatioThreshold)g), sustained for %(servingErrorRatioFor)s. This is the service failing, independent of downstream delivery.
               ||| % $._config,
             },
           },


### PR DESCRIPTION
Follow-up to #679. On deploy, the Mimir ruler rejected the `apprise-serving` group:

```
group "apprise-serving", rule "AppriseServingErrors": annotation "description":
  template: function "mul" not defined
```

`mul` is a Grafana/Sprig template function, not one of [Prometheus's template functions](https://prometheus.io/docs/prometheus/latest/configuration/template_reference/). Alloy's `mimir.rules.kubernetes` fails to convert the group and the failure blocks the whole apprise-mixin batch — so **both** `apprise-serving` and `apprise-delivery` failed to load (same poison-pill shape as #656, smaller blast radius). The scrape and metrics were unaffected (`up{job="apprise"}=1`, `apprise_*` series present).

Fix: use `{{ $value | humanizePercentage }}` (renders the 0–1 ratio as a percentage, no arithmetic function — the idiom kubernetes-mixin uses).

Verified with `tk eval`: the only remaining `{{…}}` templates are `$labels.instance` and `humanizePercentage`; scanned all annotations for `mul`/`add`/`sub`/`div` — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)