### PR TITLE
alloy: migrate k8s-monitoring 3.8.11 -> 4.3.2 (v4), Alloy 1.18.0 (#659)

### DIFF
--- a/charts/argocd-applications/rendered.yaml
+++ b/charts/argocd-applications/rendered.yaml
@@ -8,7 +8,7 @@ spec:
   project: 'placeholder'
   sources:
     - repoURL: https://grafana.github.io/helm-charts
-      targetRevision: "3.8.11"
+      targetRevision: "4.3.2"
       chart: k8s-monitoring
       helm:
         valueFiles:
@@ -19,15 +19,16 @@ spec:
           cluster_name: 'placeholder'
           cluster:
             name: 'placeholder'
+          # v4: destinations is a map keyed by name (was an array in v3).
           destinations:
-            - name: localMimir
+            localMimir:
               type: prometheus
               url: http://mimir-gateway.mimir.svc/api/v1/push
               tenantId: 'placeholder'
               secret:
                 create: false
                 embed: true
-            - name: localLoki
+            localLoki:
               type: loki
               url: http://loki.loki.svc:3100/loki/api/v1/push
               tenantId: 'placeholder'
@@ -131,40 +132,41 @@ spec:
                               name: alloy-alloy-receiver
                               port:
                                 number: 4318
-          alloy-singleton:
-            alloy:
-              # mimir.alerts.kubernetes is an experimental Alloy component.
-              stabilityLevel: experimental
-            extraConfig: |-
-              mimir.rules.kubernetes "default" {
-                address = "http://mimir-gateway.mimir.svc"
-                tenant_id = "placeholder"
-              }
-              // Push per-tenant Alertmanager routing to the Mimir alertmanager. This
-              // component has no tenant_id arg, so the tenant is the X-Scope-OrgID
-              // header. global_config is only a null default -- the real routing lives
-              // in per-tenant AlertmanagerConfig CRs (label mimir_tenant=<cluster>),
-              // merged as a tenant-wide catch-all via strategy=None.
-              mimir.alerts.kubernetes "default" {
-                address       = "http://mimir-gateway.mimir.svc"
-                global_config = "global:\n  resolve_timeout: 5m\nroute:\n  receiver: \"null\"\nreceivers:\n- name: \"null\"\n"
-                http_headers  = {
-                  "X-Scope-OrgID" = ["placeholder"],
+          # v4: per-instance config lives under the collectors map. The singleton's
+          # presets/stabilityLevel/resources are in alloy-values.yaml; only this templated
+          # extraConfig (needs cluster_name) is set here and deep-merged onto it.
+          collectors:
+            alloy-singleton:
+              extraConfig: |-
+                mimir.rules.kubernetes "default" {
+                  address = "http://mimir-gateway.mimir.svc"
+                  tenant_id = "placeholder"
                 }
-                alertmanagerconfig_selector {
-                  match_labels = {
-                    mimir_tenant = "placeholder",
+                // Push per-tenant Alertmanager routing to the Mimir alertmanager. This
+                // component has no tenant_id arg, so the tenant is the X-Scope-OrgID
+                // header. global_config is only a null default -- the real routing lives
+                // in per-tenant AlertmanagerConfig CRs (label mimir_tenant=<cluster>),
+                // merged as a tenant-wide catch-all via strategy=None.
+                mimir.alerts.kubernetes "default" {
+                  address       = "http://mimir-gateway.mimir.svc"
+                  global_config = "global:\n  resolve_timeout: 5m\nroute:\n  receiver: \"null\"\nreceivers:\n- name: \"null\"\n"
+                  http_headers  = {
+                    "X-Scope-OrgID" = ["placeholder"],
+                  }
+                  alertmanagerconfig_selector {
+                    match_labels = {
+                      mimir_tenant = "placeholder",
+                    }
+                  }
+                  alertmanagerconfig_namespace_selector {
+                    match_labels = {
+                      "kubernetes.io/metadata.name" = "alloy",
+                    }
+                  }
+                  alertmanagerconfig_matcher {
+                    strategy = "None"
                   }
                 }
-                alertmanagerconfig_namespace_selector {
-                  match_labels = {
-                    "kubernetes.io/metadata.name" = "alloy",
-                  }
-                }
-                alertmanagerconfig_matcher {
-                  strategy = "None"
-                }
-              }
     - repoURL: https://github.com/symmatree/tiles.git
       targetRevision: 'placeholder'
       ref: values

--- a/charts/argocd-applications/templates/alloy-application.yaml
+++ b/charts/argocd-applications/templates/alloy-application.yaml
@@ -6,7 +6,7 @@ spec:
   project: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
   sources:
     - repoURL: https://grafana.github.io/helm-charts
-      targetRevision: "3.8.11"
+      targetRevision: "4.3.2"
       chart: k8s-monitoring
       helm:
         valueFiles:
@@ -17,15 +17,16 @@ spec:
           cluster_name: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
           cluster:
             name: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
+          # v4: destinations is a map keyed by name (was an array in v3).
           destinations:
-            - name: localMimir
+            localMimir:
               type: prometheus
               url: http://mimir-gateway.mimir.svc/api/v1/push
               tenantId: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
               secret:
                 create: false
                 embed: true
-            - name: localLoki
+            localLoki:
               type: loki
               url: http://loki.loki.svc:3100/loki/api/v1/push
               tenantId: '{{ required ".Values.cluster_name is required" .Values.cluster_name }}'
@@ -129,40 +130,41 @@ spec:
                               name: alloy-alloy-receiver
                               port:
                                 number: 4318
-          alloy-singleton:
-            alloy:
-              # mimir.alerts.kubernetes is an experimental Alloy component.
-              stabilityLevel: experimental
-            extraConfig: |-
-              mimir.rules.kubernetes "default" {
-                address = "http://mimir-gateway.mimir.svc"
-                tenant_id = "{{ required ".Values.cluster_name is required" .Values.cluster_name }}"
-              }
-              // Push per-tenant Alertmanager routing to the Mimir alertmanager. This
-              // component has no tenant_id arg, so the tenant is the X-Scope-OrgID
-              // header. global_config is only a null default -- the real routing lives
-              // in per-tenant AlertmanagerConfig CRs (label mimir_tenant=<cluster>),
-              // merged as a tenant-wide catch-all via strategy=None.
-              mimir.alerts.kubernetes "default" {
-                address       = "http://mimir-gateway.mimir.svc"
-                global_config = "global:\n  resolve_timeout: 5m\nroute:\n  receiver: \"null\"\nreceivers:\n- name: \"null\"\n"
-                http_headers  = {
-                  "X-Scope-OrgID" = ["{{ required ".Values.cluster_name is required" .Values.cluster_name }}"],
+          # v4: per-instance config lives under the collectors map. The singleton's
+          # presets/stabilityLevel/resources are in alloy-values.yaml; only this templated
+          # extraConfig (needs cluster_name) is set here and deep-merged onto it.
+          collectors:
+            alloy-singleton:
+              extraConfig: |-
+                mimir.rules.kubernetes "default" {
+                  address = "http://mimir-gateway.mimir.svc"
+                  tenant_id = "{{ required ".Values.cluster_name is required" .Values.cluster_name }}"
                 }
-                alertmanagerconfig_selector {
-                  match_labels = {
-                    mimir_tenant = "{{ required ".Values.cluster_name is required" .Values.cluster_name }}",
+                // Push per-tenant Alertmanager routing to the Mimir alertmanager. This
+                // component has no tenant_id arg, so the tenant is the X-Scope-OrgID
+                // header. global_config is only a null default -- the real routing lives
+                // in per-tenant AlertmanagerConfig CRs (label mimir_tenant=<cluster>),
+                // merged as a tenant-wide catch-all via strategy=None.
+                mimir.alerts.kubernetes "default" {
+                  address       = "http://mimir-gateway.mimir.svc"
+                  global_config = "global:\n  resolve_timeout: 5m\nroute:\n  receiver: \"null\"\nreceivers:\n- name: \"null\"\n"
+                  http_headers  = {
+                    "X-Scope-OrgID" = ["{{ required ".Values.cluster_name is required" .Values.cluster_name }}"],
+                  }
+                  alertmanagerconfig_selector {
+                    match_labels = {
+                      mimir_tenant = "{{ required ".Values.cluster_name is required" .Values.cluster_name }}",
+                    }
+                  }
+                  alertmanagerconfig_namespace_selector {
+                    match_labels = {
+                      "kubernetes.io/metadata.name" = "alloy",
+                    }
+                  }
+                  alertmanagerconfig_matcher {
+                    strategy = "None"
                   }
                 }
-                alertmanagerconfig_namespace_selector {
-                  match_labels = {
-                    "kubernetes.io/metadata.name" = "alloy",
-                  }
-                }
-                alertmanagerconfig_matcher {
-                  strategy = "None"
-                }
-              }
     - repoURL: https://github.com/symmatree/tiles.git
       targetRevision: '{{ required ".Values.targetRevision is required" .Values.targetRevision }}'
       ref: values

--- a/charts/argocd-applications/values/alloy-tiles-values.yaml
+++ b/charts/argocd-applications/values/alloy-tiles-values.yaml
@@ -1,25 +1,28 @@
 # Resource overrides for tiles (prod). Tune from observed usage plus headroom.
+# v4: resources live under the `collectors` map (was top-level named instances in v3).
+# Deep-merged over the base collector definitions in alloy-values.yaml.
 
-alloy-logs:
-  alloy:
-    resources:
-      requests:
-        memory: 128Mi
-      limits:
-        memory: 384Mi
+collectors:
+  alloy-logs:
+    alloy:
+      resources:
+        requests:
+          memory: 128Mi
+        limits:
+          memory: 384Mi
 
-alloy-receiver:
-  alloy:
-    resources:
-      requests:
-        memory: 128Mi
-      limits:
-        memory: 256Mi
+  alloy-receiver:
+    alloy:
+      resources:
+        requests:
+          memory: 128Mi
+        limits:
+          memory: 256Mi
 
-alloy-singleton:
-  alloy:
-    resources:
-      requests:
-        memory: 128Mi
-      limits:
-        memory: 256Mi
+  alloy-singleton:
+    alloy:
+      resources:
+        requests:
+          memory: 128Mi
+        limits:
+          memory: 256Mi

--- a/charts/argocd-applications/values/alloy-values.yaml
+++ b/charts/argocd-applications/values/alloy-values.yaml
@@ -1,4 +1,11 @@
-# Static k8s-monitoring values. Templated/extraObjects in alloy-application.yaml valuesObject.
+# Static k8s-monitoring v4 values. Templated/extraObjects in alloy-application.yaml valuesObject.
+#
+# v4 migration (#659): named Alloy instances (alloy-metrics/-singleton/-logs/-receiver)
+# became entries in the `collectors` map; supplemental services (kube-state-metrics,
+# node-exporter) moved to `telemetryServices`; node-exporter scraping/tuning moved to the
+# `hostMetrics` feature; `destinations` became a map (in valuesObject). Collector names are
+# kept identical to the v3 instance names so the operator-created Service names
+# (alloy-alloy-metrics-cluster, alloy-alloy-receiver) that extraObjects reference are preserved.
 
 global:
   extraEnv:
@@ -13,8 +20,89 @@ global:
       mountPath: /etc/ssl/certs
       readOnly: true
 
+# ---- Collectors (v4: replaces the v3 named-instance top-level keys) ----
+collectors:
+  alloy-metrics:
+    presets: [clustered, statefulset]
+    includeDestinations: [localMimir]
+    extraConfig: |-
+      prometheus.exporter.blackbox "blackbox_exporter" {
+        config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
+      }
+    alloy:
+      resources:
+        requests:
+          memory: 768Mi
+        limits:
+          memory: 1Gi
+
+  alloy-singleton:
+    presets: [singleton]
+    # clusterEvents runs here and ships to Loki. The mimir.rules/mimir.alerts extraConfig
+    # (in valuesObject) talks to Mimir directly via its own address, not a destination.
+    includeDestinations: [localLoki]
+    alloy:
+      # mimir.alerts.kubernetes is an experimental Alloy component. v4 validates at
+      # template time that the collector's stability level covers its components, so this
+      # is required for the render (and the runtime) to accept the extraConfig -- the #658
+      # CrashLoop class of failure is now caught before deploy.
+      stabilityLevel: experimental
+      resources:
+        limits:
+          memory: 512Mi
+
+  alloy-logs:
+    presets: [filesystem-log-reader, daemonset]
+    includeDestinations: [localLoki]
+    alloy:
+      mounts:
+        # The filesystem-log-reader preset also mounts /var/lib/docker/containers; Talos
+        # doesn't use it, so turn it back off (v3 alloy-logs.alloy.mounts.dockercontainers).
+        dockercontainers: false
+    # Collect Talos node logs from /var/log/*.log (machined, kubelet, kernel, apid,
+    # controller-runtime, cri, containerd, ...) -- the machine-level logs otherwise only
+    # reachable via talosctl. This container mounts /var/log (varlog preset) and runs as
+    # root, so it can read the 0640 files. Ships to the same localLoki destination as pod
+    # logs. Replaces the broken journal source (nodeLogs disabled below, #662).
+    extraConfig: |-
+      local.file_match "talos" {
+        path_targets = [{
+          __path__ = "/var/log/*.log",
+          job      = "integrations/talos",
+          instance = sys.env("HOSTNAME"),
+        }]
+      }
+      loki.source.file "talos" {
+        targets    = local.file_match.talos.targets
+        forward_to = [loki.process.talos.receiver]
+      }
+      loki.process "talos" {
+        // service label from the file basename: machined, kubelet, kernel, apid, ...
+        stage.regex {
+          source     = "filename"
+          expression = "/var/log/(?P<service>[^/]+)\\.log$"
+        }
+        stage.labels {
+          values = { service = "" }
+        }
+        stage.static_labels {
+          values = { source = "talos" }
+        }
+        // Ingestion-time on purpose (no embedded-timestamp parse): tailing existing /
+        // rotated content on first start would otherwise be rejected 'entry too far behind'.
+        forward_to = [loki.write.localloki.receiver]
+      }
+
+  alloy-receiver:
+    # otel-receiver opens the standard OTLP ports (4317 gRPC / 4318 HTTP) on the Service;
+    # deployment runs it as a single Deployment (v3 alloy-receiver.controller.type).
+    presets: [otel-receiver, deployment]
+    includeDestinations: [localMimir, localLoki]
+
+# ---- Features (v4: each enabled feature must name its collector) ----
 clusterMetrics:
   enabled: true
+  collector: alloy-metrics
   controlPlane:
     enabled: true
   apiServer:
@@ -61,17 +149,15 @@ clusterMetrics:
         - kube_job_spec_.*
         - kube_job_status_completion_time
         - kube_job_status_succeeded
-  windows-exporter:
-    enabled: false
-    deploy: false
-  node-exporter:
+
+# node-exporter host metrics (v3: clusterMetrics.node-exporter). The DaemonSet itself is
+# deployed under telemetryServices below; this feature scrapes + tunes it. source defaults
+# to "node-exporter", which auto-discovers the telemetryServices deployment.
+hostMetrics:
+  enabled: true
+  collector: alloy-metrics
+  linuxHosts:
     enabled: true
-    deploy: true
-    # Intentionally BestEffort (no request/limit). node-exporter is a
-    # must-run-on-every-node DaemonSet, so a memory *request* can block it from a
-    # node whose allocatable is fully committed -- and it can't relocate, so that
-    # node just goes dark. Hit exactly that on wk-3 (99% committed) with a 64Mi
-    # request. Its ~31Mi footprint is trivial; keep it schedulable everywhere.
     metricsTuning:
       useDefaultAllowList: true
       useIntegrationAllowList: true
@@ -87,30 +173,27 @@ clusterMetrics:
         - rootfs
         - iso9660
         - overlay
-    extraArgs:
-      - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs|nsfs|rootfs|iso9660|overlay)$
-  kepler:
-    enabled: false
-  opencost:
-    enabled: false
 
 clusterEvents:
   enabled: true
+  collector: alloy-singleton
   logFormat: json
 
-# Talos has no systemd journal, so the chart's journal-based node logs
-# (loki.source.journal on /var/log/journal) fail on every node -- a permanent
-# unhealthy component (#662). Talos instead writes machine/service + kernel logs
-# to /var/log/*.log; we collect those via loki.source.file in alloy-logs.extraConfig
-# below. So disable the journal source here rather than leaving it broken.
+# Talos has no systemd journal, so the chart's journal-based node logs fail on every node
+# (#662). Talos writes machine/service + kernel logs to /var/log/*.log; we collect those via
+# the alloy-logs collector's extraConfig above. So disable the journal source here.
 nodeLogs:
   enabled: false
 
-podLogs:
+podLogsViaLoki:
   enabled: true
+  collector: alloy-logs
 
 applicationObservability:
   enabled: true
+  collector: alloy-receiver
+  # Node/pod k8s enrichment is on by default in v4 (resourceDetection + k8sattributes
+  # processors), replacing the v3 processors.kubernetes_node toggle.
   receivers:
     otlp:
       grpc:
@@ -121,9 +204,6 @@ applicationObservability:
         enabled: true
         port: 4318
         includeMetadata: true
-  processors:
-    kubernetes_node:
-      enabled: true
   metrics:
     enabled: true
   logs:
@@ -133,93 +213,12 @@ applicationObservability:
 
 prometheusOperatorObjects:
   enabled: true
+  collector: alloy-metrics
   crds:
     deploy: false
 
-alloy-metrics:
-  enabled: true
-  serviceMonitor:
-    enabled: false
-  extraConfig: |-
-    prometheus.exporter.blackbox "blackbox_exporter" {
-      config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
-    }
-  alloy:
-    resources:
-      requests:
-        memory: 768Mi
-      limits:
-        memory: 1Gi
-
-alloy-singleton:
-  enabled: true
-  serviceMonitor:
-    enabled: false
-  alloy:
-    resources:
-      limits:
-        memory: 512Mi
-
-alloy-logs:
-  enabled: true
-  serviceMonitor:
-    enabled: false
-  alloy:
-    mounts:
-      varlog: true
-      dockercontainers: false
-  # Collect Talos node logs from /var/log/*.log (machined, kubelet, kernel, apid,
-  # controller-runtime, cri, containerd, ...) -- the machine-level logs otherwise
-  # only reachable via talosctl. This container already mounts /var/log and runs
-  # as root, so it can read the 0640 files. Ships to the same localLoki destination
-  # as pod logs. Replaces the broken journal source (nodeLogs disabled above, #662).
-  extraConfig: |-
-    local.file_match "talos" {
-      path_targets = [{
-        __path__ = "/var/log/*.log",
-        job      = "integrations/talos",
-        instance = sys.env("HOSTNAME"),
-      }]
-    }
-    loki.source.file "talos" {
-      targets    = local.file_match.talos.targets
-      forward_to = [loki.process.talos.receiver]
-    }
-    loki.process "talos" {
-      // service label from the file basename: machined, kubelet, kernel, apid, ...
-      stage.regex {
-        source     = "filename"
-        expression = "/var/log/(?P<service>[^/]+)\\.log$"
-      }
-      stage.labels {
-        values = { service = "" }
-      }
-      stage.static_labels {
-        values = { source = "talos" }
-      }
-      // Ingestion-time on purpose (no embedded-timestamp parse): tailing existing /
-      // rotated content on first start would otherwise be rejected 'entry too far behind'.
-      forward_to = [loki.write.localloki.receiver]
-    }
-
-alloy-receiver:
-  enabled: true
-  serviceMonitor:
-    enabled: false
-  controller:
-    type: "deployment"
-  alloy:
-    extraPorts:
-      - name: otlp-grpc
-        port: 4317
-        targetPort: 4317
-        protocol: TCP
-      - name: otlp-http
-        port: 4318
-        targetPort: 4318
-        protocol: TCP
-
 integrations:
+  collector: alloy-metrics
   alloy:
     instances:
       - name: alloy
@@ -252,3 +251,20 @@ integrations:
               - otelcol_process_memory_rss_bytes
               - otelcol_process_runtime_total_alloc_bytes_total
               - otelcol_process_uptime_seconds_total
+
+# ---- Telemetry services (v4: supplemental deployments, explicit) ----
+telemetryServices:
+  kube-state-metrics:
+    deploy: true
+  node-exporter:
+    deploy: true
+    # Intentionally BestEffort (no request/limit). node-exporter is a must-run-on-every-node
+    # DaemonSet, so a memory *request* can block it from a node whose allocatable is fully
+    # committed -- and it can't relocate, so that node just goes dark. Hit exactly that on
+    # wk-3 (99% committed) with a 64Mi request. Its ~31Mi footprint is trivial; keep it
+    # schedulable everywhere.
+    resources: {}
+    extraArgs:
+      - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs|nsfs|rootfs|iso9660|overlay)$
+  windows-exporter:
+    deploy: false


### PR DESCRIPTION
Migrates the `alloy` app to the **k8s-monitoring v4** chart (4.3.2), reaching **head on both the chart and Alloy (v1.18.0)** -- the goal of #659. v4 is a breaking rewrite (named instances -> `collectors` map), not a version bump.

## Why v4 (not the 3.8.12 shortcut)
3.8.12 would also reach Alloy 1.18.0 (it bundles operator 1.11.0), but the goal here is chart **and** Alloy on head, so this does the real v4 migration rather than defer it again.

## What changed (v3 -> v4)
- **Named instances -> `collectors` map.** `alloy-metrics/-singleton/-logs/-receiver` are now collectors. Names kept **identical** so the operator-created Service names that `extraObjects` reference (`alloy-alloy-metrics-cluster`, `alloy-alloy-receiver`) are preserved.
- **Roles via presets:** `clustered`+`statefulset` (metrics), `singleton`, `filesystem-log-reader`+`daemonset` (logs), `otel-receiver`+`deployment` (receiver).
- **`destinations` array -> map** (`localMimir` / `localLoki`).
- **Supplemental services -> `telemetryServices`** (kube-state-metrics, node-exporter `deploy`). node-exporter **scraping/tuning** -> the `hostMetrics` feature (`linuxHosts`, `source: node-exporter` auto-discovers the deployed DaemonSet).
- **Each feature now names its collector** (clusterMetrics, hostMetrics, clusterEvents, podLogsViaLoki, applicationObservability, prometheusOperatorObjects, integrations).
- v3 `processors.kubernetes_node` dropped -- v4 does node/pod enrichment by default (`resourceDetection` + `k8sattributes`).

## Carried over (behavior unchanged)
The #635 per-tenant AlertmanagerConfig routing + singleton `mimir.rules`/`mimir.alerts` extraConfig (**`stabilityLevel: experimental`** -- v4 now validates this at template time, so the #658 CrashLoop class is caught before deploy), the blackbox exporter + 3 Probes, the Talos `/var/log` node-log collection (#662), OTLP receiver ports + ingress, destinations, and the prod resource overlay.

## Validation (this PR)
End-to-end `helm template` of the **actual** value files + templated valuesObject against k8s-monitoring 4.3.2 renders clean: operator **1.11.0 -> Alloy v1.18.0**, all four collectors, `mimir.alerts.kubernetes` + `strategy = "None"` + stability validation, Talos `loki.source.file`, `node_exporter` scrape with tuning, `otelcol.receiver.otlp` 4317/4318, and all extraObjects (3 Probes, AlertmanagerConfig, Ingress). rendered.yaml render-diff is confined to the alloy Application (only `targetRevision` + the valuesObject).

## Rollout -- **test first** (per #659)
This is exactly the novel config that must be proven on test before prod. On tiles-test:
- Alloy pods report **v1.18.x**; all four collectors healthy.
- `alloy-health.ipynb` / `alloy-nomon.ipynb` (#651) re-run clean.
- **Confirm the operator-created Services `alloy-alloy-metrics-cluster` and `alloy-alloy-receiver` exist** -- the Probes and OTLP ingress hardcode these; their names are inferred from the (preserved) collector names but are only created by the operator at runtime, so they can't be render-verified.
- Rule + alert sync intact (Mimir ruler tracks PrometheusRule CRs; #635 per-tenant routing applies; a test alert reaches apprise).
- Edge OTLP still accepted -- watch the Alloy 1.18 `otelcol.receiver.otlp` HTTP timeout default change (write 30s / idle 1m, were 0s).
- Host/node metrics still flowing (hostMetrics now scrapes the telemetryServices node-exporter).

Then promote the prod tag.

Refs #659. Supersedes the 3.8.12 interim option discussed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fgp8wDZU6F87k3VMss9wr