### PR TITLE
alloy: keep node_hwmon/cooling/thermal metrics for bare-metal nodes (#580)

### DIFF
--- a/charts/argocd-applications/values/alloy-values.yaml
+++ b/charts/argocd-applications/values/alloy-values.yaml
@@ -166,6 +166,16 @@ hostMetrics:
         - "node_xfs.*"
         - "node_time_seconds"
         - "node_bonding.*"
+        # Bare-metal hardware health (#580): the metal nodes (lancer, acebase) already
+        # load their sensor modules (k10temp+amdgpu / coretemp+drivetemp) and node-exporter's
+        # hwmon collector emits temps, but the default+integration allowlists drop node_hwmon_*,
+        # so no metal temperatures reach Mimir. Keep the hwmon family (temps + their max/crit
+        # thresholds + alarm flags + power/voltage), the cooling-device state (thermal-throttle
+        # response) and the ACPI thermal zone. Low cardinality: VMs emit none of these; edge
+        # hosts (raconteur/proxmox) ship temps via the OTLP path, not this allowlist.
+        - "node_hwmon_.*"
+        - "node_cooling_device_.*"
+        - "node_thermal_zone_.*"
       dropMetricsForFilesystem:
         - ramfs
         - tmpfs


### PR DESCRIPTION
## What

Adds `node_hwmon_.*`, `node_cooling_device_.*`, and `node_thermal_zone_.*` to `hostMetrics.linuxHosts.metricsTuning.includeMetrics` in `alloy-values.yaml`, so the bare-metal Talos nodes' hardware-health metrics reach Mimir. Advances #580 Part 1.

## Why (corrected root cause for #580)

#580 hypothesized the metal nodes need a `machine.kernel.modules` patch to load sensor modules. **That's not the problem.** Verified live by exec'ing into the metal `alloy-node-exporter` pods:

- **lancer**: `k10temp` (CPU 39C), `amdgpu` (iGPU 38C), `nvme`, `acpitz` all loaded; `node_hwmon_temp_celsius` emitted.
- **acebase**: `coretemp` (CPU), `drivetemp` (disk), `acpitz` loaded; temps emitted.
- `node_scrape_collector_success{collector="hwmon"} = 1` on both.

The modules are already loaded and node-exporter already scrapes them. The temps never reach Mimir because the k8s-monitoring `hostMetrics` default+integration allowlists drop `node_hwmon_*` / `node_cooling_device_*` / `node_thermal_zone_*` before remote-write. (Edge hosts -- raconteur, proxmox -- have temps because they ship via the OTLP `alloy-receiver` path, which has no such allowlist.)

## What this unblocks

CPU-clock signals (`node_cpu_scaling_frequency_*`, governor) already pass the allowlist, so with this change a bare-metal thermal/power dashboard + metal temp alerts can span:

- hwmon temps (CPU / iGPU / nvme / drivetemp) vs the hardware's own `_max`/`_crit` thresholds + alarm flags
- `node_cooling_device_*` -- thermal-throttle response
- `node_hwmon_power_*` / `node_hwmon_in_volts` -- power draw (lancer amdgpu ~12 W) + rail voltages
- CPU running-freq vs max (throttle proxy, already available)

## Cardinality

Small: VMs emit no hwmon; only the 2 metal nodes add series (~tens each). Consistent with the #556/#576 cardinality posture.

## Render / snapshot

No committed `rendered.yaml` embeds these values -- the alloy Application references the file as an Argo `valueFile` (`$values/charts/argocd-applications/values/alloy-values.yaml`), read at sync time. CI's argocd-pr-diff will show the live diff.

## Verification

- YAML parses; `includeMetrics` list confirmed.
- The three regex families match real emitted metrics (checked against both metal node-exporters' `:9100/metrics`).
- Not yet observed post-merge: that the series actually land in Mimir after Argo syncs -- worth a spot-check on the metal `instance`s once deployed.

Refs #580. Sibling gap on the edge side: #684 (proxmox feed dark).