### PR TITLE
bond-mixin: metal-node CPU + iGPU temp alerts (#580 Part 2)

### DIFF
--- a/tanka/environments/bond-mixin/mixin/alerts/alerts.libsonnet
+++ b/tanka/environments/bond-mixin/mixin/alerts/alerts.libsonnet
@@ -1,2 +1,3 @@
 (import 'proxmox.libsonnet') +
-(import 'raconteur.libsonnet')
+(import 'raconteur.libsonnet') +
+(import 'metal.libsonnet')

--- a/tanka/environments/bond-mixin/mixin/alerts/metal.libsonnet
+++ b/tanka/environments/bond-mixin/mixin/alerts/metal.libsonnet
@@ -1,0 +1,40 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'bond-metal',
+        rules: [
+          {
+            // Bare-metal Talos workers (lancer=AMD/k10temp, acebase=Intel/coretemp) report
+            // hwmon temps into Mimir since #580/#685. The CPU chip label is a hashed PCI path
+            // (k10temp) or platform_coretemp_0 (coretemp), so we select the CPU sensor by
+            // joining on node_hwmon_chip_names.chip_name -- which also auto-scopes to nodes
+            // that actually have CPU hwmon (VMs emit none), so future metal nodes are covered
+            // without listing instances. max (not avg) to catch the hottest core.
+            alert: 'BondMetalHighCpuTemperature',
+            expr: |||
+              max by (instance) (
+                node_hwmon_temp_celsius{
+                  job="%(metalNodeExporterJob)s",
+                  cluster="%(metalCluster)s",
+                }
+                * on (instance, chip) group_left (chip_name)
+                node_hwmon_chip_names{chip_name=~"%(metalCpuChipNames)s"}
+              ) > %(metalCpuTempThresholdCelsius)g
+            ||| % $._config,
+            'for': $._config.metalCpuTempFor,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Bare-metal node {{ $labels.instance }} CPU temperature is high',
+              description: |||
+                Hottest CPU sensor (k10temp/coretemp) on {{ $labels.instance }} has been above %(metalCpuTempThresholdCelsius)g C for %(metalCpuTempFor)s (current value {{ printf "%%.1f" $value }} C).
+              ||| % $._config,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/tanka/environments/bond-mixin/mixin/alerts/metal.libsonnet
+++ b/tanka/environments/bond-mixin/mixin/alerts/metal.libsonnet
@@ -33,6 +33,34 @@
               ||| % $._config,
             },
           },
+          {
+            // Integrated GPU temp. Only AMD APUs expose a GPU hwmon (chip_name=amdgpu, e.g.
+            // lancer's Radeon 8060S); Intel iGPUs (acebase) report none, so this is lancer-only
+            // today and auto-covers future AMD-GPU nodes. amdgpu exposes no temp_crit, so the
+            // threshold is a fixed warn -- set above the CPU's since an APU GPU legitimately runs
+            // hotter under ROCm/ODM load and throttles ~95-100 C.
+            alert: 'BondMetalHighGpuTemperature',
+            expr: |||
+              max by (instance) (
+                node_hwmon_temp_celsius{
+                  job="%(metalNodeExporterJob)s",
+                  cluster="%(metalCluster)s",
+                }
+                * on (instance, chip) group_left (chip_name)
+                node_hwmon_chip_names{chip_name=~"%(metalGpuChipNames)s"}
+              ) > %(metalGpuTempThresholdCelsius)g
+            ||| % $._config,
+            'for': $._config.metalGpuTempFor,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              summary: 'Bare-metal node {{ $labels.instance }} iGPU temperature is high',
+              description: |||
+                Integrated GPU (amdgpu) on {{ $labels.instance }} has been above %(metalGpuTempThresholdCelsius)g C for %(metalGpuTempFor)s (current value {{ printf "%%.1f" $value }} C).
+              ||| % $._config,
+            },
+          },
         ],
       },
     ],

--- a/tanka/environments/bond-mixin/mixin/config.libsonnet
+++ b/tanka/environments/bond-mixin/mixin/config.libsonnet
@@ -16,6 +16,14 @@ local snmpHexLabel(str) =
     proxmoxCoreTempFor: '10m',
     proxmoxInstanceSelector: 'instance=~"nuc-g.*"',
 
+    // Bare-metal Talos workers (cluster="tiles"): CPU temp via chip_name join, so both
+    // Intel (coretemp) and AMD (k10temp) match without hardcoding node names or hashed chips.
+    metalNodeExporterJob: 'integrations/node_exporter',
+    metalCluster: 'tiles',
+    metalCpuChipNames: 'k10temp|coretemp',
+    metalCpuTempThresholdCelsius: 90,
+    metalCpuTempFor: '10m',
+
     raconteurInstance: 'raconteur',
     raconteurSnmpJob: 'integrations/snmp/raconteur',
     raconteurNodeExporterJob: 'integrations/node_exporter',

--- a/tanka/environments/bond-mixin/mixin/config.libsonnet
+++ b/tanka/environments/bond-mixin/mixin/config.libsonnet
@@ -23,6 +23,11 @@ local snmpHexLabel(str) =
     metalCpuChipNames: 'k10temp|coretemp',
     metalCpuTempThresholdCelsius: 90,
     metalCpuTempFor: '10m',
+    // iGPU: only AMD APUs expose a GPU hwmon (amdgpu); no temp_crit is reported, so fixed warn
+    // set above the CPU's (APU GPU runs hotter under load, throttles ~95-100 C).
+    metalGpuChipNames: 'amdgpu',
+    metalGpuTempThresholdCelsius: 95,
+    metalGpuTempFor: '10m',
 
     raconteurInstance: 'raconteur',
     raconteurSnmpJob: 'integrations/snmp/raconteur',


### PR DESCRIPTION
## What

Adds temperature alerts for the bare-metal Talos workers (lancer, acebase) to **bond-mixin** (the catch-all custom mixin), alongside the existing proxmox/raconteur temp alerts. Advances #580 Part 2, building on the now-merged #685 (which got metal hwmon temps into Mimir -- verified live, see #580).

Two rules in a new `bond-metal` group:

**`BondMetalHighCpuTemperature`** (both nodes, 90 C / 10m)
```promql
max by (instance) (
  node_hwmon_temp_celsius{job="integrations/node_exporter", cluster="tiles"}
  * on (instance, chip) group_left (chip_name)
  node_hwmon_chip_names{chip_name=~"k10temp|coretemp"}
) > 90
```

**`BondMetalHighGpuTemperature`** (lancer iGPU, 95 C / 10m)
```promql
max by (instance) (
  node_hwmon_temp_celsius{job="integrations/node_exporter", cluster="tiles"}
  * on (instance, chip) group_left (chip_name)
  node_hwmon_chip_names{chip_name=~"amdgpu"}
) > 95
```

## Design

- **chip_name join** selects the right sensor without hardcoding node names or the hashed `chip` label, so Intel (coretemp) and AMD (k10temp / amdgpu) all match, and it **auto-scopes to nodes that actually have that hwmon** (VMs emit none; only AMD APUs expose amdgpu) -- future metal nodes are covered for free. Today: CPU = lancer + acebase, iGPU = lancer only (acebase's Intel iGPU reports no hwmon temp).
- **Thresholds**: CPU 90 C (as agreed; nodes idle ~40 C). iGPU 95 C -- amdgpu exposes no `temp_crit`, and an APU GPU legitimately runs hotter under ROCm/ODM load (throttles ~95-100 C), so set above the CPU's.
- **Placement**: metal nodes are `cluster="tiles"`, not `bond`; the mixin folder is just where the rule is authored (the expr selects tiles data). Kept in bond-mixin per operator preference -- catch-all custom mixin, not a new mixin per subject. Clean add: `alerts.libsonnet` concatenates per-subject files.

## Verification

- `jsonnet` renders both `bond-metal` rules; interpolation intact.
- Each **rendered** expr's inner form (minus the threshold) run against live Mimir returns exactly the expected nodes -- CPU: `lancer 38.5 C` + `acebase 41.0 C`; iGPU: `lancer 38.0 C` -- no VMs, no stray matches. Both stay inactive below threshold.
- No committed rendered snapshot to regenerate (bond-mixin renders via the ArgoCD Tanka CMP at sync).

Refs #580. Depends on #685 (merged).