### PR TITLE
mixins: ArgoCD-deploy annotations on every Grafana dashboard (#29)

### DIFF
--- a/tanka/lib/monitoring-resources.libsonnet
+++ b/tanka/lib/monitoring-resources.libsonnet
@@ -28,6 +28,16 @@
 //       'news-serving'). This enables cross-cutting search in Grafana's
 //       dashboard list by cluster or application.
 //
+//   deployAnnotation  - When true (default), an "ArgoCD deploys" annotation
+//       query is injected into every dashboard's annotations list. It is a
+//       Prometheus (Mimir) query over the already-scraped argocd_app_sync_total
+//       counter, so a marker appears whenever an ArgoCD app finishes a sync and
+//       metric changes line up with the deploy that caused them. This is the
+//       "pull" side of the integration -- Grafana reads a metric rather than
+//       ArgoCD pushing annotations, so there is no ArgoCD->Grafana dependency
+//       and no API key. deployAnnotationDatasourceUid selects the datasource
+//       (default 'prom', the provisioned Mimir uid on every cluster).
+//
 local k = import 'k.libsonnet';
 local po = import 'github.com/jsonnet-libs/prometheus-operator-libsonnet/0.77/main.libsonnet';
 local libutil = import 'util.libsonnet';
@@ -45,6 +55,8 @@ local libutil = import 'util.libsonnet';
     ruleGroupsToDrop: [],
     tags: [],
     dirAnnotation: 'k8s-sidecar-target-directory',
+    deployAnnotation: true,  // See file header: inject an ArgoCD-deploy annotation.
+    deployAnnotationDatasourceUid: 'prom',
   },
   new(mixin, overrides)::
     {
@@ -94,6 +106,33 @@ local libutil = import 'util.libsonnet';
           local injected = std.sort(config.tags);
           dashboard { tags: std.setUnion(existing, injected) },
 
+      // See file header. Adds a Grafana annotation query that draws a marker on
+      // every panel whenever an ArgoCD app finishes a sync, so metric changes
+      // line up visually with the deploy that caused them. Pulled from the
+      // already-scraped argocd_app_sync_total counter (no ArgoCD->Grafana push
+      // dependency). Idempotent: skipped if a dashboard already declares one.
+      local deployAnnotationQuery = {
+        name: 'ArgoCD deploys',
+        enable: true,
+        hide: false,
+        iconColor: 'rgba(255, 96, 96, 1)',
+        datasource: { type: 'prometheus', uid: config.deployAnnotationDatasourceUid },
+        target: {
+          expr: 'changes(argocd_app_sync_total{phase="Succeeded"}[$__interval]) > 0',
+          refId: 'Anno',
+        },
+        titleFormat: 'deploy: {{name}}',
+        tagKeys: 'name,project',
+        step: '60s',
+      },
+      local setDeployAnnotation(dashboard) =
+        if !config.deployAnnotation then dashboard
+        else
+          local existing = std.get(dashboard, 'annotations', { list: [] });
+          local existingList = std.get(existing, 'list', []);
+          if std.member([std.get(a, 'name', '') for a in existingList], 'ArgoCD deploys') then dashboard
+          else dashboard { annotations+: { list: existingList + [deployAnnotationQuery] } },
+
       local dashBlobs = mixin.grafanaDashboards,
       assert dashBlobs != null,
       dashboards: std.filterMap(
@@ -101,7 +140,7 @@ local libutil = import 'util.libsonnet';
           !std.member(config.dashboardsToDrop, toK8s(name)),
         function(name)
           assert dashBlobs[name] != null;
-          local dashContent = std.manifestJsonEx(setTags(prefixUid(setDatasourceDefaults(dashBlobs[name]))), indent=' ', newline='\n');
+          local dashContent = std.manifestJsonEx(setDeployAnnotation(setTags(prefixUid(setDatasourceDefaults(dashBlobs[name])))), indent=' ', newline='\n');
           kConfigMap.new(toK8s(name))
           + kConfigMap.metadata.withNamespace(config.namespace)
           + kConfigMap.metadata.withLabelsMixin({ grafana_dashboard: '1' })


### PR DESCRIPTION
## What

Injects a single Grafana annotation query -- "ArgoCD deploys" -- into every mixin dashboard, so a marker appears whenever an ArgoCD app finishes a sync. Metric changes then line up visually with the deploy that caused them ("what deployed here?").

Closes the intent of #29 (and supersedes the stale, Copilot-authored PR #177).

## Approach: pull, not push

#29 references ArgoCD's grafana *notification service* (push: ArgoCD POSTs annotations into Grafana via an API key). PR #177 implemented that -- a Helm-hook Job that logs into Grafana with the admin secret, mints a service account + token, and writes it cross-namespace into `argocd/`. That is (a) structurally stale (it targets `charts/grafana/`, removed when the umbrella charts were flattened in #208), and (b) imperative token-minting in a declarative repo, and (c) it couples ArgoCD to Grafana -- the exact dependency #29 says to avoid.

This PR takes the **pull** side instead. The annotation is a Prometheus (Mimir) query over the already-scraped `argocd_app_sync_total` counter, evaluated client-side by Grafana:

```promql
changes(argocd_app_sync_total{phase="Succeeded"}[$__interval]) > 0
```

No notifications controller, no API key, no service account, no secret plumbing, **no ArgoCD->Grafana dependency**. Grafana just reads a metric it already has.

## Implementation

One place: `tanka/lib/monitoring-resources.libsonnet`, the shared mixin post-processor that already injects tags / datasource-defaults / UID prefixes. A new `setDeployAnnotation` transform appends the annotation to each dashboard's `annotations.list`, so it applies to **all** mixins with no per-mixin change.

- On by default; disable per-environment with `deployAnnotation: false`.
- Datasource via `deployAnnotationDatasourceUid` (default `prom`, the provisioned Mimir uid on every cluster).
- Idempotent (skips if a dashboard already declares an "ArgoCD deploys" annotation).
- Annotation title is `deploy: {{name}}` and tags carry the app `name` + `project`.

## Verification

- **Metric is live** on tiles Mimir: `argocd_app_sync_total` is scraped with a per-app `name` label (also `phase`, `project`, `cluster`).
- **End-to-end query** runs through Grafana's Mimir datasource (tenant header and all) and returns discrete events at real deploy times.
- **Schema accepted**: a throwaway dashboard carrying the annotation round-tripped through the Grafana 12.3 API (then deleted). I did not eyeball the rendered line headless -- verified query-eval + schema acceptance, not pixels.
- **Chattiness**: deploy events are sparse day-to-day (~2/day) and cluster at releases (a tag bump fans out ~30 apps) -- i.e. quiet normally, dense at a release. Tunable later without touching the pull/push decision.
- **Render-diff** across `argocd-mixin` (3 dashboards), `node-exporter-mixin` (6), and `cilium-mixin` (20): the *only* change is the annotation appended to each dashboard's `annotations.list` -- nothing displaced.

## Follow-ups (not in scope)

- Per-mixin precision (scope the cilium dashboard to the app that deploys cilium) needs an app->dashboard mapping; left as a follow-up. First cut is global (any app, every dashboard).
- If per-reconcile noise ever becomes a problem, the one thing push does that pull can't easily do is dedupe to once-per-git-revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)