### PR TITLE
alloy-proxmox: collect host journal (#686) + report host memory (#544) via privileged CT

### DIFF
--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -34,7 +34,11 @@ After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxm
 
 ```promql
 rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])
+# host RAM -- should read ~15.4 GB, not 0.5 GB (#544)
+node_memory_MemTotal_bytes{cluster="bond", instance=~"nuc-g.*"}
 ```
+
+`node_exporter` reads `procfs_path = /host/proc` (a bind of the host's live procfs; see [`proxmox-alloy.tf`](../tf/nodes/proxmox-alloy.tf)) so `node_memory_*` reports **host** RAM/swap. Reading the container's own `/proc/meminfo` instead reports the ~512 MB **LXC cgroup** limit (lxcfs-virtualized), which is the #544 blindspot. `sysfs` stays on the nested `/sys` (hwmon temps read host-true there).
 
 **Logs (host systemd journal):**
 

--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -1,6 +1,8 @@
 # Proxmox host monitoring (Alloy LXC)
 
-Each **Proxmox cluster node** can run an **unprivileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and Proxmox **snippets** at `/var/lib/vz/snippets`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), tails **host log files**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
+Each **Proxmox cluster node** can run a **privileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and Proxmox **snippets** at `/var/lib/vz/snippets`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), reads the **host systemd journal**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
+
+> **Why privileged?** The CT must be **privileged** to read the host journal (#686). Host journal files are `0640 root:systemd-journal`; in an *unprivileged* CT the container's root maps to host uid 100000, so through the read-only `/host` bind mount those files appear owned by `nobody:nogroup` and are unreadable -- `loki.source.journal` silently reads nothing (it opens the world-readable directory but cannot read the files, so there is no loud error -- which is why the gap went unnoticed for 90d). A privileged CT's root **is** host root, so it can read them. Metrics/hwmon never needed this (they read world-readable `/proc` and `/sys` via nesting). Trade-off: the CT can now read every root-owned file under the read-only `/host` mount.
 
 OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring.md).
 
@@ -22,6 +24,8 @@ OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring
 
 Network and entrypoint changes often do not affect a **running** CT until restart. Practical sequence: **stop** Alloy CTs, **`terraform apply`**, **start** (or apply while already stopped, then start). Afterward, **`/interfaces`** should list an IPv4 on **`eth0`**.
 
+The **`unprivileged` -> privileged** flip (#686) cannot be toggled on a live CT: `terraform apply` **destroys and recreates** each Alloy CT. Verify afterward that host journal logs arrive with `{job="proxmox-journal"}` in Loki -- because an unreadable journal fails **silently** (no unhealthy component), the Loki query is the check, not component health.
+
 After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxmox_alloy = true`** to recreate containers.
 
 ## Verification (Explore, tiles tenant)
@@ -32,12 +36,15 @@ After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxm
 rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])
 ```
 
-**Logs (when working):**
+**Logs (host systemd journal):**
 
 ```logql
-{job=~"proxmox.*"}
+{job="proxmox-journal"}
 {host=~"nuc-g.*"}
+{job="proxmox-journal", unit="pveproxy.service"}
 ```
+
+The journal reader stamps `job="proxmox-journal"`, `host="<node>"`, and promotes the systemd unit to a `unit` label (see `loki.relabel "journal"` in the template). Before #686 the template tailed `/var/log/{syslog,messages,auth.log,daemon.log}`, which never exist on journald-only PVE 9 hosts, so `{job=~"proxmox.*"}` was empty for 90d.
 
 **Proxmox API (eth0 has an address):** `GET /nodes/{node}/lxc/{vmid}/interfaces`
 

--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -38,7 +38,7 @@ rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])
 node_memory_MemTotal_bytes{cluster="bond", instance=~"nuc-g.*"}
 ```
 
-`node_exporter` reads `procfs_path = /host/proc` (a bind of the host's live procfs; see [`proxmox-alloy.tf`](../tf/nodes/proxmox-alloy.tf)) so `node_memory_*` reports **host** RAM/swap. Reading the container's own `/proc/meminfo` instead reports the ~512 MB **LXC cgroup** limit (lxcfs-virtualized), which is the #544 blindspot. `sysfs` stays on the nested `/sys` (hwmon temps read host-true there).
+`node_exporter` reads the host's procfs, sysfs, and rootfs, all bind-mounted under `/host` (`procfs_path = /host/proc`, `sysfs_path = /host/sys`, `rootfs_path = /host`; see [`proxmox-alloy.tf`](../tf/nodes/proxmox-alloy.tf)), so `node_memory_*` reports **host** RAM/swap. Reading the container's own `/proc/meminfo` instead reports the ~512 MB **LXC cgroup** limit (lxcfs-virtualized), which is the #544 blindspot. The `/`->`/host` bind is non-recursive, so `/proc` and `/sys` are bound explicitly.
 
 **Logs (host systemd journal):**
 

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -116,18 +116,23 @@ resource "proxmox_virtual_environment_container" "alloy" {
     mount_options = []
     volume        = "/"
   }
-  # Bind the host's live procfs so node_exporter reads HOST memory, not the lxcfs-virtualized cgroup
-  # view (#544). Without this, procfs_path=/proc reads the container's /proc/meminfo, which lxcfs
-  # virtualizes down to the 512 MB cgroup limit -- so node_memory_* has been reporting 512 MB instead
-  # of the host's ~15.4 GB, leaving host memory/swap unmonitored. Pointing node_exporter at this bind
-  # (procfs_path=/host/proc in the template) is the standard containerized-node_exporter pattern.
-  # Requires the privileged CT above. Only /proc is affected -- sysfs (hwmon temps etc.) reads
-  # host-true already, so it is left on the nested /sys and not disturbed here.
+  # The /->/host bind above is NON-recursive, so it drops the /proc and /sys submounts -- /host/proc
+  # and /host/sys are empty without these. Bind them explicitly so node_exporter reads the whole host
+  # via /host (procfs_path=/host/proc, sysfs_path=/host/sys in the template). This is what fixes #544:
+  # otherwise procfs_path=/proc reads the container's own /proc/meminfo, which lxcfs virtualizes down
+  # to the 512 MB cgroup limit, so node_memory_* reported 512 MB instead of the host's ~15.4 GB.
+  # Standard containerized-node_exporter pattern; requires the privileged CT above.
   mount_point {
     path          = "/host/proc"
     read_only     = true
     mount_options = []
     volume        = "/proc"
+  }
+  mount_point {
+    path          = "/host/sys"
+    read_only     = true
+    mount_options = []
+    volume        = "/sys"
   }
   # Snippets dir bind mount at same path as host so we leave image /etc/alloy untouched (avoid unpack/permission issues).
   mount_point {

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -106,14 +106,28 @@ resource "proxmox_virtual_environment_container" "alloy" {
     dedicated = 512
   }
 
-  # Mount host root filesystem (read-only for safety)
-  # This gives access to /sys, /proc, /dev, /run from the host
-  # Same approach as Synology - bind mount host root to /host
+  # Mount host root filesystem (read-only) at /host, for node_exporter rootfs/filesystem metrics.
+  # NOTE: this bind is NON-recursive, so it does NOT carry the /proc, /sys, /dev, /run submounts --
+  # /host/proc is empty. The /proc and /sys binds below are what expose the live host procfs/sysfs.
+  # Same approach as Synology - bind mount host root to /host.
   mount_point {
     path          = "/host"
     read_only     = true
     mount_options = []
     volume        = "/"
+  }
+  # Bind the host's live procfs so node_exporter reads HOST memory, not the lxcfs-virtualized cgroup
+  # view (#544). Without this, procfs_path=/proc reads the container's /proc/meminfo, which lxcfs
+  # virtualizes down to the 512 MB cgroup limit -- so node_memory_* has been reporting 512 MB instead
+  # of the host's ~15.4 GB, leaving host memory/swap unmonitored. Pointing node_exporter at this bind
+  # (procfs_path=/host/proc in the template) is the standard containerized-node_exporter pattern.
+  # Requires the privileged CT above. Only /proc is affected -- sysfs (hwmon temps etc.) reads
+  # host-true already, so it is left on the nested /sys and not disturbed here.
+  mount_point {
+    path          = "/host/proc"
+    read_only     = true
+    mount_options = []
+    volume        = "/proc"
   }
   # Snippets dir bind mount at same path as host so we leave image /etc/alloy untouched (avoid unpack/permission issues).
   mount_point {

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -87,13 +87,21 @@ resource "proxmox_virtual_environment_container" "alloy" {
     type      = "console"
   }
 
-  # Nesting: expose host procfs and sysfs to the guest (per Proxmox docs). With nesting we could use /proc and /sys in Alloy for host metrics; privileged + /host bind is an alternative.
+  # Nesting: expose host procfs and sysfs to the guest (per Proxmox docs), so node_exporter reads host /proc and /sys.
   features {
     nesting = true
   }
 
-  # Unprivileged + nesting: nesting exposes host /proc and /sys to the container, so we use those paths in Alloy (no privileged needed for metrics). /host bind still used for rootfs and host logs.
-  unprivileged = true
+  # Privileged (unprivileged = false): required to read the host systemd journal for log collection (#686).
+  # Host journal files are 0640 root:systemd-journal; in an unprivileged CT the container's root maps to
+  # host uid 100000, so through the /host bind mount those files appear owned by nobody:nogroup and the
+  # container's root is "other" with no read bit -- the read is denied (verified live on nuc-g3p-1: a
+  # container-root read of system.journal returned DENIED). loki.source.journal then opens the world-
+  # readable directory but reads no entries, silently (no unhealthy component). A privileged CT's root IS
+  # host root (no userns remap), so it can read them. Trade-off: the CT can now read every root-owned
+  # file under the read-only /host mount.
+  # Metrics/hwmon never needed this -- they read world-readable /proc and /sys via nesting.
+  unprivileged = false
   memory {
     dedicated = 512
   }

--- a/tf/nodes/templates/alloy-proxmox.alloy
+++ b/tf/nodes/templates/alloy-proxmox.alloy
@@ -1,14 +1,12 @@
 // Alloy configuration for Proxmox host monitoring
 // Collects node_exporter metrics (including hwmon sensors) and system logs, forwarding to prod OTLP
 
-// Node exporter for host system metrics.
-// procfs reads the host's live procfs bind-mounted at /host/proc (see proxmox-alloy.tf), NOT the
-// container's own /proc: lxcfs virtualizes the container /proc/meminfo down to the 512 MB cgroup
-// limit, which made node_memory_* report 512 MB instead of host RAM (#544). sysfs stays on the
-// nested /sys (hwmon temps etc. already read host-true there); rootfs stays /host.
+// Node exporter reads the host's procfs, sysfs, and rootfs, all bind-mounted under /host
+// (see proxmox-alloy.tf). Reading the container's own /proc instead would report lxcfs-virtualized
+// memory -- the 512 MB cgroup limit -- rather than host RAM (#544).
 prometheus.exporter.unix "node" {
   procfs_path = "/host/proc"
-  sysfs_path  = "/sys"
+  sysfs_path  = "/host/sys"
   rootfs_path = "/host"
 }
 

--- a/tf/nodes/templates/alloy-proxmox.alloy
+++ b/tf/nodes/templates/alloy-proxmox.alloy
@@ -1,9 +1,13 @@
 // Alloy configuration for Proxmox host monitoring
 // Collects node_exporter metrics (including hwmon sensors) and system logs, forwarding to prod OTLP
 
-// Node exporter for host system metrics (nesting exposes host /proc and /sys to the container)
+// Node exporter for host system metrics.
+// procfs reads the host's live procfs bind-mounted at /host/proc (see proxmox-alloy.tf), NOT the
+// container's own /proc: lxcfs virtualizes the container /proc/meminfo down to the 512 MB cgroup
+// limit, which made node_memory_* report 512 MB instead of host RAM (#544). sysfs stays on the
+// nested /sys (hwmon temps etc. already read host-true there); rootfs stays /host.
 prometheus.exporter.unix "node" {
-  procfs_path = "/proc"
+  procfs_path = "/host/proc"
   sysfs_path  = "/sys"
   rootfs_path = "/host"
 }

--- a/tf/nodes/templates/alloy-proxmox.alloy
+++ b/tf/nodes/templates/alloy-proxmox.alloy
@@ -78,31 +78,30 @@ otelcol.processor.attributes "main" {
   }
 }
 
-// Log collection from host
-// Proxmox uses systemd, so we can collect from journald or traditional syslog
-loki.source.file "syslog" {
-  targets = [
-    {
-      __path__ = "/host/var/log/syslog",
-      job      = "proxmox-syslog",
-      host     = "${hostname}",
-    },
-    {
-      __path__ = "/host/var/log/messages",
-      job      = "proxmox-messages",
-      host     = "${hostname}",
-    },
-    {
-      __path__ = "/host/var/log/auth.log",
-      job      = "proxmox-auth",
-      host     = "${hostname}",
-    },
-    {
-      __path__ = "/host/var/log/daemon.log",
-      job      = "proxmox-daemon",
-      host     = "${hostname}",
-    },
-  ]
+// Log collection from host.
+// PVE 9 hosts run Debian 13 (trixie), which is journald-only: rsyslog is not installed
+// and /var/log/{syslog,messages,auth.log,daemon.log} never exist, so the previous
+// loki.source.file tail collected nothing (0 lines/90d, #686). Read the host's persistent
+// journal, bind-mounted read-only at /host/var/log/journal, instead. (Mirror image of #662:
+// in-cluster Talos has no journal so we tail files there; the Proxmox host is the opposite.)
+loki.relabel "journal" {
+  forward_to = []
+
+  // Promote the systemd unit to a real label so host logs are filterable by service.
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+}
+
+loki.source.journal "host" {
+  path          = "/host/var/log/journal"
+  max_age       = "12h"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = {
+    job  = "proxmox-journal",
+    host = "${hostname}",
+  }
   forward_to = [otelcol.receiver.loki.main.receiver]
 }
 


### PR DESCRIPTION
Fixes #686. Fixes #544.

Two "the unprivileged LXC can't see host truth" problems on the Proxmox edge Alloy CTs, fixed together because they share one root (the CT can't read host-owned/host-real state) and one enabling change (make the CT privileged).

## #686 -- host logs never collected
The template tailed `/host/var/log/{syslog,messages,auth.log,daemon.log}` via `loki.source.file`, but PVE 9 hosts run Debian 13 (trixie), which is **journald-only** -- those files never exist, so `{job=~"proxmox.*"}` was 0 lines/90d.

- Switch to `loki.source.journal` reading the persistent journal at `/host/var/log/journal`, labeled `job="proxmox-journal"`, `host="<node>"`, systemd unit promoted to `unit`. Mirror image of #662.
- **Make the CT privileged** (`unprivileged = false`). Host journal files are `0640 root:systemd-journal`; an unprivileged CT's root maps to host uid 100000, sees them as `nobody:nogroup`, and can't read them -- the reader then silently collects nothing (no unhealthy component, which is why 90d went unnoticed).

## #544 -- host memory unmonitored
`node_exporter` read the container's `/proc`, whose `/proc/meminfo` is lxcfs-virtualized to the 512 MB cgroup limit, so `node_memory_*` reported 512 MB instead of the host's ~15.4 GB (caused a misdiagnosis during the nuc-g3p-2 wedge).

- The originally-proposed `--path.procfs=/host/proc` couldn't work as written: the `/`->`/host` bind is **non-recursive**, so `/host/proc` didn't exist (confirmed live: `/host/proc/meminfo` = No such file or directory).
- The design already bind-mounts the whole host root at `/host`; the non-recursive bind just drops the `/proc` and `/sys` submounts. Bind them explicitly and read the whole host uniformly: `procfs_path = /host/proc`, `sysfs_path = /host/sys`, `rootfs_path = /host`. Standard containerized-node_exporter pattern; relies on the privileged CT above.

## Validation -- honest status
- **#686 read-perm** (measured live, read-only, nuc-g3p-1/CT 402): unprivileged container-root read of `system.journal` = **DENIED**; host-root (== privileged CT root) = **READABLE**, real content present. New Alloy config graph **loads cleanly on the deployed Alloy v1.16.1**.
- **#544 candidate ruled out** (measured live): `/host/proc` doesn't exist today, so the `/proc` (and `/sys`) binds are genuine additions, not no-ops.
- **Not pre-provable:** the privileged-CT behavior and the new binds only exist after `terraform apply` (privilege can't be toggled live; the apply **destroys and recreates** each CT). A throwaway test CT is the same system + same operation, so it wouldn't prove anything the real apply wouldn't -- these are verified **at rollout**, not before.

## Rollout verification (prod workspace, `deploy_proxmox_alloy = true`)
```logql
{job="proxmox-journal"}                 # #686: host journal now flowing (silent failure -> Loki is the check, not component health)
```
```promql
node_memory_MemTotal_bytes{cluster="bond", instance=~"nuc-g.*"}   # #544: ~15.4 GB, not 0.5 GB
node_hwmon_temp_celsius{cluster="bond", instance=~"nuc-g.*"}      # sysfs moved to /host/sys -- confirm temps still report
```
If a bind doesn't take, the corresponding host metrics go missing -- revert `procfs_path`/`sysfs_path` to `/proc`/`/sys` (back to today's state).

Docs updated in `docs/proxmox-monitoring.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rs9DMBPbE8CzQQveEcqvo