### PR TITLE
alloy: drop lancer WMI-mapper ACPI event spam from Talos logs

### DIFF
--- a/charts/argocd-applications/values/alloy-values.yaml
+++ b/charts/argocd-applications/values/alloy-values.yaml
@@ -88,6 +88,15 @@ collectors:
         stage.static_labels {
           values = { source = "talos" }
         }
+        // Drop lancer's WMI-mapper ACPI spam: its AMD firmware fires a PNP0C14 WMI notify
+        // every ~5s that no kernel driver claims, so Talos logs each as an 'ignoring ACPI
+        // event' warning (~17k lines/day, lancer-only, dead-flat -- benign firmware polling,
+        // not a fault). Scoped to the "wmi payload so a genuine ACPI event (thermal, button,
+        // different payload) still comes through.
+        stage.drop {
+          expression          = "ignoring ACPI event: \"wmi"
+          drop_counter_reason = "talos_wmi_acpi_noise"
+        }
         // Ingestion-time on purpose (no embedded-timestamp parse): tailing existing /
         // rotated content on first start would otherwise be rejected 'entry too far behind'.
         forward_to = [loki.write.localloki.receiver]


### PR DESCRIPTION
Follow-up to the host-health notebooks (#691), which surfaced this.

lancer's AMD firmware fires a `PNP0C14` WMI notify roughly every 5 seconds that no in-kernel driver claims, so Talos logs each one as an `ignoring ACPI event: "wmi…"` **warning**. That's **~17,466 lines/day**, **lancer-only** (acebase/Intel emits none), and **dead-flat at 728/hour** — the fixed-interval rate is the tell that it's benign firmware polling chatter, not a fault (a real thermal/sensor problem would be bursty or trending).

This drops it at the `alloy-logs` `loki.process "talos"` ingestion stage:

```hcl
stage.drop {
  expression          = "ignoring ACPI event: \"wmi"
  drop_counter_reason = "talos_wmi_acpi_noise"
}
```

**Scoped tightly to the `"wmi` payload** on purpose — a genuine ACPI event (thermal, power button, any different payload) still comes through. Tradeoff accepted: if this exact event ever starts meaning something we won't see it, which is fine for a constant firmware heartbeat.

## Verification
- `charts/argocd-applications/rendered.yaml` references `alloy-values.yaml` by path and does not inline it (`grep` = 0), so no snapshot regeneration is needed; only the values file changes.
- Not render-validated against the live Alloy DSL locally (the config is an `extraConfig` string inside the k8s-monitoring chart values — no local renderer). `stage.drop` with `expression` / `drop_counter_reason` is standard `loki.process` syntax; the drop will be observable post-deploy as the ACPI line count in Loki going to zero on lancer and a `loki_process_dropped_lines_total{reason="talos_wmi_acpi_noise"}` counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)