### PR TITLE
Revert #692: privileged Alloy CT breaks OCI create -- edge feed down ~2 days

### DIFF
--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -1,8 +1,6 @@
 # Proxmox host monitoring (Alloy LXC)
 
-Each **Proxmox cluster node** can run a **privileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and Proxmox **snippets** at `/var/lib/vz/snippets`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), reads the **host systemd journal**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
-
-> **Why privileged?** The CT must be **privileged** to read the host journal (#686). Host journal files are `0640 root:systemd-journal`; in an *unprivileged* CT the container's root maps to host uid 100000, so through the read-only `/host` bind mount those files appear owned by `nobody:nogroup` and are unreadable -- `loki.source.journal` silently reads nothing (it opens the world-readable directory but cannot read the files, so there is no loud error -- which is why the gap went unnoticed for 90d). A privileged CT's root **is** host root, so it can read them. Metrics/hwmon never needed this (they read world-readable `/proc` and `/sys` via nesting). Trade-off: the CT can now read every root-owned file under the read-only `/host` mount.
+Each **Proxmox cluster node** can run an **unprivileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and Proxmox **snippets** at `/var/lib/vz/snippets`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), tails **host log files**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
 
 OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring.md).
 
@@ -24,8 +22,6 @@ OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring
 
 Network and entrypoint changes often do not affect a **running** CT until restart. Practical sequence: **stop** Alloy CTs, **`terraform apply`**, **start** (or apply while already stopped, then start). Afterward, **`/interfaces`** should list an IPv4 on **`eth0`**.
 
-The **`unprivileged` -> privileged** flip (#686) cannot be toggled on a live CT: `terraform apply` **destroys and recreates** each Alloy CT. Verify afterward that host journal logs arrive with `{job="proxmox-journal"}` in Loki -- because an unreadable journal fails **silently** (no unhealthy component), the Loki query is the check, not component health.
-
 After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxmox_alloy = true`** to recreate containers.
 
 ## Verification (Explore, tiles tenant)
@@ -34,21 +30,14 @@ After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxm
 
 ```promql
 rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])
-# host RAM -- should read ~15.4 GB, not 0.5 GB (#544)
-node_memory_MemTotal_bytes{cluster="bond", instance=~"nuc-g.*"}
 ```
 
-`node_exporter` reads the host's procfs, sysfs, and rootfs, all bind-mounted under `/host` (`procfs_path = /host/proc`, `sysfs_path = /host/sys`, `rootfs_path = /host`; see [`proxmox-alloy.tf`](../tf/nodes/proxmox-alloy.tf)), so `node_memory_*` reports **host** RAM/swap. Reading the container's own `/proc/meminfo` instead reports the ~512 MB **LXC cgroup** limit (lxcfs-virtualized), which is the #544 blindspot. The `/`->`/host` bind is non-recursive, so `/proc` and `/sys` are bound explicitly.
-
-**Logs (host systemd journal):**
+**Logs (when working):**
 
 ```logql
-{job="proxmox-journal"}
+{job=~"proxmox.*"}
 {host=~"nuc-g.*"}
-{job="proxmox-journal", unit="pveproxy.service"}
 ```
-
-The journal reader stamps `job="proxmox-journal"`, `host="<node>"`, and promotes the systemd unit to a `unit` label (see `loki.relabel "journal"` in the template). Before #686 the template tailed `/var/log/{syslog,messages,auth.log,daemon.log}`, which never exist on journald-only PVE 9 hosts, so `{job=~"proxmox.*"}` was empty for 90d.
 
 **Proxmox API (eth0 has an address):** `GET /nodes/{node}/lxc/{vmid}/interfaces`
 

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -87,52 +87,25 @@ resource "proxmox_virtual_environment_container" "alloy" {
     type      = "console"
   }
 
-  # Nesting: expose host procfs and sysfs to the guest (per Proxmox docs), so node_exporter reads host /proc and /sys.
+  # Nesting: expose host procfs and sysfs to the guest (per Proxmox docs). With nesting we could use /proc and /sys in Alloy for host metrics; privileged + /host bind is an alternative.
   features {
     nesting = true
   }
 
-  # Privileged (unprivileged = false): required to read the host systemd journal for log collection (#686).
-  # Host journal files are 0640 root:systemd-journal; in an unprivileged CT the container's root maps to
-  # host uid 100000, so through the /host bind mount those files appear owned by nobody:nogroup and the
-  # container's root is "other" with no read bit -- the read is denied (verified live on nuc-g3p-1: a
-  # container-root read of system.journal returned DENIED). loki.source.journal then opens the world-
-  # readable directory but reads no entries, silently (no unhealthy component). A privileged CT's root IS
-  # host root (no userns remap), so it can read them. Trade-off: the CT can now read every root-owned
-  # file under the read-only /host mount.
-  # Metrics/hwmon never needed this -- they read world-readable /proc and /sys via nesting.
-  unprivileged = false
+  # Unprivileged + nesting: nesting exposes host /proc and /sys to the container, so we use those paths in Alloy (no privileged needed for metrics). /host bind still used for rootfs and host logs.
+  unprivileged = true
   memory {
     dedicated = 512
   }
 
-  # Mount host root filesystem (read-only) at /host, for node_exporter rootfs/filesystem metrics.
-  # NOTE: this bind is NON-recursive, so it does NOT carry the /proc, /sys, /dev, /run submounts --
-  # /host/proc is empty. The /proc and /sys binds below are what expose the live host procfs/sysfs.
-  # Same approach as Synology - bind mount host root to /host.
+  # Mount host root filesystem (read-only for safety)
+  # This gives access to /sys, /proc, /dev, /run from the host
+  # Same approach as Synology - bind mount host root to /host
   mount_point {
     path          = "/host"
     read_only     = true
     mount_options = []
     volume        = "/"
-  }
-  # The /->/host bind above is NON-recursive, so it drops the /proc and /sys submounts -- /host/proc
-  # and /host/sys are empty without these. Bind them explicitly so node_exporter reads the whole host
-  # via /host (procfs_path=/host/proc, sysfs_path=/host/sys in the template). This is what fixes #544:
-  # otherwise procfs_path=/proc reads the container's own /proc/meminfo, which lxcfs virtualizes down
-  # to the 512 MB cgroup limit, so node_memory_* reported 512 MB instead of the host's ~15.4 GB.
-  # Standard containerized-node_exporter pattern; requires the privileged CT above.
-  mount_point {
-    path          = "/host/proc"
-    read_only     = true
-    mount_options = []
-    volume        = "/proc"
-  }
-  mount_point {
-    path          = "/host/sys"
-    read_only     = true
-    mount_options = []
-    volume        = "/sys"
   }
   # Snippets dir bind mount at same path as host so we leave image /etc/alloy untouched (avoid unpack/permission issues).
   mount_point {

--- a/tf/nodes/templates/alloy-proxmox.alloy
+++ b/tf/nodes/templates/alloy-proxmox.alloy
@@ -1,12 +1,10 @@
 // Alloy configuration for Proxmox host monitoring
 // Collects node_exporter metrics (including hwmon sensors) and system logs, forwarding to prod OTLP
 
-// Node exporter reads the host's procfs, sysfs, and rootfs, all bind-mounted under /host
-// (see proxmox-alloy.tf). Reading the container's own /proc instead would report lxcfs-virtualized
-// memory -- the 512 MB cgroup limit -- rather than host RAM (#544).
+// Node exporter for host system metrics (nesting exposes host /proc and /sys to the container)
 prometheus.exporter.unix "node" {
-  procfs_path = "/host/proc"
-  sysfs_path  = "/host/sys"
+  procfs_path = "/proc"
+  sysfs_path  = "/sys"
   rootfs_path = "/host"
 }
 
@@ -80,30 +78,31 @@ otelcol.processor.attributes "main" {
   }
 }
 
-// Log collection from host.
-// PVE 9 hosts run Debian 13 (trixie), which is journald-only: rsyslog is not installed
-// and /var/log/{syslog,messages,auth.log,daemon.log} never exist, so the previous
-// loki.source.file tail collected nothing (0 lines/90d, #686). Read the host's persistent
-// journal, bind-mounted read-only at /host/var/log/journal, instead. (Mirror image of #662:
-// in-cluster Talos has no journal so we tail files there; the Proxmox host is the opposite.)
-loki.relabel "journal" {
-  forward_to = []
-
-  // Promote the systemd unit to a real label so host logs are filterable by service.
-  rule {
-    source_labels = ["__journal__systemd_unit"]
-    target_label  = "unit"
-  }
-}
-
-loki.source.journal "host" {
-  path          = "/host/var/log/journal"
-  max_age       = "12h"
-  relabel_rules = loki.relabel.journal.rules
-  labels        = {
-    job  = "proxmox-journal",
-    host = "${hostname}",
-  }
+// Log collection from host
+// Proxmox uses systemd, so we can collect from journald or traditional syslog
+loki.source.file "syslog" {
+  targets = [
+    {
+      __path__ = "/host/var/log/syslog",
+      job      = "proxmox-syslog",
+      host     = "${hostname}",
+    },
+    {
+      __path__ = "/host/var/log/messages",
+      job      = "proxmox-messages",
+      host     = "${hostname}",
+    },
+    {
+      __path__ = "/host/var/log/auth.log",
+      job      = "proxmox-auth",
+      host     = "${hostname}",
+    },
+    {
+      __path__ = "/host/var/log/daemon.log",
+      job      = "proxmox-daemon",
+      host     = "${hostname}",
+    },
+  ]
   forward_to = [otelcol.receiver.loki.main.receiver]
 }
 


### PR DESCRIPTION
## Incident recovery -- merge to restore the Proxmox edge monitoring feed

#692 (privileged Alloy CTs, for #686 journal reads) **took down the edge feed and wedged the `tf/nodes` prod pipeline.** This reverts it to the known-good unprivileged config.

### Root cause
Proxmox **OCI app-containers** (entrypoint `/bin/alloy`, not `/sbin/init`) can only be created **unprivileged**. Flipping `unprivileged = false` breaks creation. The post-merge prod apply (CI applies prod on push to main) destroyed all four CTs and failed to recreate them:
```
Error: Container create
unable to create CT 400/401/402/403 - setgid(0): Invalid argument   (Detected OCI archive)
```

### Impact (ongoing since 2026-08-03 19:17)
- All four edge Alloy CTs (400-403) **destroyed, not recreated** -- confirmed cluster-wide (`/etc/pve/nodes/*/lxc/` all empty).
- Edge feed dark: no `cluster="bond"` node_exporter / hwmon-temp metrics, no host logs.
- `tf/nodes` prod apply **wedged** -- every main push fails the same way (08-03 ×2, 08-05 #653 merge). Blocks all `tf/nodes` changes.

### This PR
Full revert of #692 (commits 558983a, 26884c9, 820b30f) -- tf files byte-identical to pre-#692, the config that created and ran for weeks. On merge, the prod apply recreates the four CTs unprivileged and the feed returns.

### What I got wrong
I validated that a privileged CT's root *can read* the journal, but never that the CT could be *created* privileged with the OCI image. That was the load-bearing unknown, and it failed at the real apply -- exactly the "verified at rollout" risk, realized as a 2-day outage.

### Follow-ups (separate, properly validated -- NOT in this PR)
- **#544 (memory):** re-add the `/host/proc` bind + `procfs_path=/host/proc`. This does **not** need privilege (`/proc/meminfo` is world-readable), so it's compatible with the unprivileged OCI CT. Ship on its own and confirm at rollout.
- **#686 (journal):** needs an unprivileged-compatible read path -- a gid-idmap mapping a container gid to the host `systemd-journal` gid, or drop host-journal collection and cover the need with an alert. Privileged is off the table for OCI app-containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rs9DMBPbE8CzQQveEcqvo