### PR TITLE
proxmox-alloy: load config via image default entrypoint, drop the unreliable override (#695)

### DIFF
--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -1,6 +1,8 @@
 # Proxmox host monitoring (Alloy LXC)
 
-Each **Proxmox cluster node** can run an **unprivileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and Proxmox **snippets** at `/var/lib/vz/snippets`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), tails **host log files**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
+Each **Proxmox cluster node** can run an **unprivileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and its Alloy **config** at `/etc/alloy`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), tails **host log files**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
+
+**Config delivery (#695):** the config is uploaded as the snippet **`config.alloy`** and the snippets dir is bind-mounted over the container's **`/etc/alloy`**, so it lands at **`/etc/alloy/config.alloy`** -- exactly where the OCI image's **default entrypoint** (`/bin/alloy run /etc/alloy/config.alloy --storage.path=...`) reads it. We deliberately do **not** set `initialization.entrypoint`: the bpg provider doesn't reliably apply `initialization` settings to OCI-image containers on create ([bpg#2789](https://github.com/bpg/terraform-provider-proxmox/issues/2789)), so an overridden entrypoint is silently dropped on recreate and the CT falls back to the image's demo config -- what left the feed dark after the #692/#694 incident. Letting the default entrypoint load our config makes a recreate self-correcting.
 
 OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring.md).
 
@@ -20,7 +22,7 @@ OTLP ingress and receiver behavior: [synology-monitoring.md](synology-monitoring
 
 ## Deploy / config changes
 
-Network and entrypoint changes often do not affect a **running** CT until restart. Practical sequence: **stop** Alloy CTs, **`terraform apply`**, **start** (or apply while already stopped, then start). Afterward, **`/interfaces`** should list an IPv4 on **`eth0`**.
+Changes do not all affect a **running** CT the same way. **Config content** (`config.alloy`) updates the snippet, but a running CT keeps the old file open until restarted. **Mount and network** changes are **`ForceNew`** (recreate the CT). Practical sequence: **`terraform apply`**, then **stop/start** (or let the recreate happen). Afterward, **`/interfaces`** should list an IPv4 on **`eth0`**, and `cat /proc/1/cmdline` in the CT should show `/bin/alloy run /etc/alloy/config.alloy` loading the mounted config.
 
 After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxmox_alloy = true`** to recreate containers.
 

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -8,9 +8,10 @@
 # VM/CT IDs are unique cluster-wide in Proxmox, so we assign one per node (200, 201, ...).
 # When deploy_proxmox_alloy is false, no containers/OCI/images/snippets are created.
 #
-# Operational note: After changing entrypoint, network (e.g. host_managed), or config, the first
-# apply may not update a running CT. Stop the containers in the Proxmox UI, then re-apply or start
-# them so they pick up the new settings.
+# Operational note: config is delivered as the snippet config.alloy bind-mounted at /etc/alloy, and
+# loaded by the image's default entrypoint (no override -- see the initialization block, #695). A
+# config-content change updates the snippet but a running CT keeps the old file open until restarted;
+# mount/network changes are ForceNew and recreate the CT. Stop/restart (or recreate) to pick up changes.
 locals {
   alloy_nodes  = var.deploy_proxmox_alloy ? toset(data.proxmox_virtual_environment_nodes.nodes.names) : toset([])
   alloy_vm_ids = { for i, n in sort(tolist(local.alloy_nodes)) : n => var.alloy_vm_base_id + i }
@@ -48,10 +49,17 @@ resource "proxmox_virtual_environment_container" "alloy" {
   }
 
   # Initialization
+  # NOTE: no `entrypoint` override. The bpg provider does not reliably apply
+  # initialization settings (entrypoint, env vars) to OCI-image containers on create
+  # (bpg/terraform-provider-proxmox#2789), so an overridden entrypoint gets silently
+  # dropped on (re)create and the CT falls back to the image default -- which loads the
+  # image's demo /etc/alloy/config.alloy and ships nothing (see #695). Instead we let the
+  # image's default entrypoint (`/bin/alloy run /etc/alloy/config.alloy --storage.path=...`,
+  # always present) run, and bind-mount OUR config over /etc/alloy/config.alloy below. That
+  # makes a recreate self-correcting. Trade-off: no --server.http.listen-addr override, so the
+  # Alloy UI binds localhost (it was firewall-blocked externally anyway; OTLP export is outbound).
   initialization {
     hostname = "alloy-${each.value}"
-    # Default from container does not have the listen-addr set.
-    entrypoint = "/bin/alloy run /var/lib/vz/snippets/alloy-proxmox.alloy '--storage.path=/var/lib/alloy/data' '--server.http.listen-addr=0.0.0.0:12345'"
     ip_config {
       ipv4 {
         address = "dhcp"
@@ -107,9 +115,12 @@ resource "proxmox_virtual_environment_container" "alloy" {
     mount_options = []
     volume        = "/"
   }
-  # Snippets dir bind mount at same path as host so we leave image /etc/alloy untouched (avoid unpack/permission issues).
+  # Mount the snippets dir (which holds only our config, uploaded as config.alloy) over the image's
+  # /etc/alloy, so /etc/alloy/config.alloy IS our config and the image's default entrypoint loads it
+  # (#695). This deliberately shadows the image's demo /etc/alloy/config.alloy. mount_point is
+  # ForceNew, so changing this recreates the CT -- intended: the recreate is what applies the new layout.
   mount_point {
-    path          = "/var/lib/vz/snippets"
+    path          = "/etc/alloy"
     read_only     = true
     mount_options = []
     volume        = "/var/lib/vz/snippets"
@@ -124,7 +135,9 @@ resource "proxmox_virtual_environment_container" "alloy" {
   description = "Alloy monitoring container for ${each.value} - collects host metrics and logs via node_exporter (hwmon sensors) and system logs"
 }
 
-# Upload Alloy config file as a snippet (mounted into container at /var/lib/vz/snippets/alloy-proxmox.alloy)
+# Upload the Alloy config as a snippet named config.alloy. The snippets dir is bind-mounted over the
+# container's /etc/alloy (above), so this lands at /etc/alloy/config.alloy -- exactly where the image's
+# default entrypoint (`/bin/alloy run /etc/alloy/config.alloy`) reads it (#695). Must be config.alloy.
 resource "proxmox_virtual_environment_file" "alloy_config" {
   for_each = local.alloy_nodes
   provider = proxmox.proxmox_root
@@ -137,6 +150,6 @@ resource "proxmox_virtual_environment_file" "alloy_config" {
       otlp_tiles = "https://otlp.tiles.symmatree.com"
       hostname   = each.value
     })
-    file_name = "alloy-proxmox.alloy"
+    file_name = "config.alloy"
   }
 }


### PR DESCRIPTION
Fixes #695.

## Problem
`initialization.entrypoint` isn't reliably applied to OCI-image containers by the bpg provider on create ([bpg#2789](https://github.com/bpg/terraform-provider-proxmox/issues/2789)). So on any **recreate**, our override is silently dropped and the CT runs the image's demo `/etc/alloy/config.alloy` — shipping nothing, with no error. That's what kept the edge feed dark after the #692/#694 privileged-flip incident forced the first recreate in a while; it was restored only by a manual `pct set --entrypoint … && pct reboot`.

## Fix: stop depending on the override
Let the image's **default** entrypoint (`/bin/alloy run /etc/alloy/config.alloy --storage.path=…`, always present) load our config, by putting our config where it reads it:
- upload the snippet as **`config.alloy`** (was `alloy-proxmox.alloy`);
- bind-mount the snippets dir over the container's **`/etc/alloy`** (was `/var/lib/vz/snippets`) → `/etc/alloy/config.alloy` **is** our config, shadowing the image's demo (the dir holds only our file; the image's `/etc/alloy` holds only that demo);
- **remove** `initialization.entrypoint`.

A recreate is now **self-correcting** — no override to drop.

## Why this is grounded (not "verified at rollout" hand-waving)
- The image default entrypoint running `/bin/alloy run /etc/alloy/config.alloy --storage.path=/var/lib/alloy/data` is **exactly what the broken CTs ran** (observed in `/proc/1/cmdline`) — the entrypoint mechanism is proven.
- Directory bind mounts are proven (`/` and the snippets mount already work).
- The snippets dir contains only our file; the image's `/etc/alloy` contains only the demo `config.alloy` — so shadowing hides nothing needed.
- Per-node metric labels (`instance`/`hostname`) are baked into each node's **rendered config**, so they don't depend on any CT `initialization` setting.

## Rollout / impact
- `mount_point` is `ForceNew`, so the apply **recreates the four CTs once** — a brief, self-healing edge gap. (Prod applies on merge to main.)
- Drops the `--server.http.listen-addr=0.0.0.0:12345` override → Alloy UI binds localhost (was firewall-blocked externally anyway; OTLP export is outbound and unaffected).
- `environment_variables` (`ALLOY_DEPLOY_MODE`, `PATH`) are subject to the same bpg#2789 unreliability — left as-is (not load-bearing), noted in #695.

## Verify after merge
```logql
{host=~"nuc-g.*"}        # still tailing (metrics/temps flowing)
```
```promql
node_load1{cluster="bond", instance=~"nuc-g.*"}          # all 4 fresh
node_hwmon_temp_celsius{cluster="bond", instance=~"nuc-g.*"}
```
And in a CT: `cat /proc/1/cmdline` → `/bin/alloy run /etc/alloy/config.alloy …`. I'll follow the apply after you merge and confirm the four CTs come back on our config (the real validation, per the recreate).

**Rollback:** revert this → restores the override; then hand-correct entrypoints (`pct set … && pct reboot`) as we did during recovery.

## Follow-ups (separate)
#544 (host memory, procfs bind — unprivileged) and #686 (host journal — needs an unprivileged path) remain open; findings added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rs9DMBPbE8CzQQveEcqvo