### PR TITLE
rtkbase: log raw receiver data to the PVC (enables PPP re-survey, no RTK downtime)

### DIFF
--- a/containers/rtkbase/README.md
+++ b/containers/rtkbase/README.md
@@ -26,7 +26,24 @@ docker run --rm -it --privileged \
 
 ## Boot
 
-`rtk-base-user-on-bootup` runs as ExecStartPre on `rtkbase_web.service` and starts `str2str_tcp.service` and `str2str_local_ntrip_caster.service`. Base coords, mountpoint, and caster auth live in [`tanka/environments/ntrip/settings.conf`](../../tanka/environments/ntrip/settings.conf) (ConfigMap seed).
+`rtk-base-user-on-bootup` runs as ExecStartPre on `rtkbase_web.service` and starts `str2str_tcp.service`, `str2str_local_ntrip_caster.service`, and `str2str_file.service`. Base coords, mountpoint, and caster auth live in [`tanka/environments/ntrip/settings.conf`](../../tanka/environments/ntrip/settings.conf) (ConfigMap seed).
+
+### str2str topology (why raw logging is free)
+
+`str2str_tcp` is the only service that opens the serial device (`/dev/gnss`); it republishes the receiver stream on `127.0.0.1:5015`. Every other service consumes that TCP relay:
+
+```
+/dev/gnss --[str2str_tcp]--> 127.0.0.1:5015 --+--> str2str_local_ntrip_caster  (RTCM, port 2101)
+                                              +--> str2str_file               (raw log to PVC)
+```
+
+So `str2str_file` (`run_cast.sh in_tcp out_file`) is **additive** -- enabling raw logging does not contend for the receiver and does not interrupt RTK.
+
+### Raw logging
+
+Raw UBX lands in `/persist/rtkbase/data` (`[local_storage]` in `settings.conf`), rotating every 24 h; `rtkbase_archive.timer` zips daily at 04:00 and keeps `archive_rotate=60` archives. Measured stream rate is ~4.7 KiB/s, so roughly **420 MB/day** uncompressed against 200+ GB free on the PVC.
+
+The receiver emits `UBX-RXM-RAWX` (1 Hz) and `UBX-RXM-SFRBX`, so these logs are **PPP-usable**: `convbin` them to RINEX and submit to a PPP service to re-solve the base position. That is the point of keeping them -- the current fixed position's derivation is not recorded (see [`facts` `geospatial/locations/base_station.md`](https://github.com/symmatree/facts/blob/main/geospatial/locations/base_station.md)).
 
 ## Kubernetes (phase 3)
 

--- a/containers/rtkbase/rtk-base-user-on-bootup
+++ b/containers/rtkbase/rtk-base-user-on-bootup
@@ -14,3 +14,10 @@ mount --bind "${PERSIST}/settings.conf" /root/rtkbase/settings.conf
 
 systemctl start str2str_tcp.service
 systemctl start str2str_local_ntrip_caster.service
+
+# Raw receiver log to the PVC (settings.conf [local_storage]: /persist/rtkbase/data,
+# 24 h rotation; rtkbase_archive.timer zips daily and keeps archive_rotate=60).
+# Reads in_tcp -- the 127.0.0.1:5015 relay str2str_tcp already publishes -- NOT the
+# serial device, so this is additive and does not contend with the NTRIP caster.
+# Enables re-solving the base position by PPP without taking RTK down (see #698).
+systemctl start str2str_file.service


### PR DESCRIPTION
## What

Start `str2str_file.service` at boot alongside the existing tcp + caster services, so raw UBX lands in `/persist/rtkbase/data` on a 24 h rotation.

Two lines of actual change, plus a README section documenting the str2str topology (which is the non-obvious part).

## The ask was "take NTRIP down for 24h" -- that turns out to be unnecessary

The plan I was given was: stop `rtkbase`, run a Kubernetes Job bound to `/dev/gnss` on `acebase`, accept ~24 h without RTK. Reasonable premise, but the architecture is kinder:

```
/dev/gnss --[str2str_tcp]--> 127.0.0.1:5015 --+--> str2str_local_ntrip_caster  (RTCM 2101)
                                              +--> str2str_file               (raw log -> PVC)
```

`str2str_tcp` is the **only** service that opens the serial device. `str2str_file` runs `run_cast.sh in_tcp out_file` -- it attaches to the TCP relay, not the receiver. So enabling it is additive and the caster keeps serving throughout. **No RTK downtime.**

(Merging this does restart the pod once -- `strategy: Recreate` -- so RTK blips for the length of a pod restart, not a day.)

## Verified before writing, not assumed

- **`UBX-RXM-RAWX` at 1 Hz and `UBX-RXM-SFRBX` are both live** on the receiver today -- sampled 38 KB off the 5015 relay and decoded it. The 2023 receiver config persisted, so these logs are genuinely PPP-usable (`convbin` -> RINEX). No NMEA in the stream. This was the make-or-break check: without raw observations the whole exercise is pointless.
- **~4.7 KiB/s measured** -> ~420 MB/day uncompressed, against 200+ GB free on `rtkbase-persist`.
- **Retention is already handled by RTKBase**, not by anything new here: `[local_storage]` already targets `/persist/rtkbase/data` with `file_rotate_time=24`, and `rtkbase_archive.timer` is already active, zipping daily at 04:00 and keeping `archive_rotate=60`.
- `/persist/rtkbase/data` is currently **empty**, confirming logging genuinely was not running.

## Why permanent rather than a one-shot

The immediate driver is #698 (re-solve the base position by PPP), which needs one 24 h window. But keeping raw logs permanently means the base can be re-solved **at any time** without another round of coordination, and it costs ~420 MB/day against a disk with 200+ GB free, with rotation and archiving already built in.

If you would rather this be temporary, revert the one line after the #698 capture completes -- I have deliberately **not** added a toggle for it, since a flag nobody can reach is more surface than the behaviour itself.

## Testing

Not bench-tested -- this changes a boot script for a privileged, device-bound pod that I am not going to exercise live. What I did verify is listed above (receiver output, stream rate, disk headroom, unit definition, existing empty data dir). After merge, the checks are: files appearing under `/persist/rtkbase/data`, and the NTRIP caster still serving on 2101.

Refs #698. Context: symmatree/facts#15.