### PR TITLE
ci: push triggers on the image builds that lacked them; all five watch their own workflow

### DIFF
--- a/.github/workflows/build-datascience-notebook-ssh.yaml
+++ b/.github/workflows/build-datascience-notebook-ssh.yaml
@@ -8,6 +8,7 @@ on:
       - main
     paths:
       - containers/datascience-notebook-ssh/**
+      - .github/workflows/build-datascience-notebook-ssh.yaml
 jobs:
   build-datascience-notebook-ssh:
     permissions:

--- a/.github/workflows/build-mavproxy.yaml
+++ b/.github/workflows/build-mavproxy.yaml
@@ -1,6 +1,11 @@
 name: build-mavproxy
 on:
   workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - containers/mavproxy/**
+      - .github/workflows/build-mavproxy.yaml
   schedule:
     - cron: 0 9 * * *
 jobs:

--- a/.github/workflows/build-mimir-webhook.yaml
+++ b/.github/workflows/build-mimir-webhook.yaml
@@ -1,10 +1,11 @@
 name: build-mimir-webhook
 on:
-  # push:
-  #   branches:
-  #     # Run post-commit to validate, also to update caches.
-  #     - main
   workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - charts/mimir/webhook/**
+      - .github/workflows/build-mimir-webhook.yaml
   schedule:
     - cron: 0 8 * * *
 jobs:

--- a/.github/workflows/build-rtkbase.yaml
+++ b/.github/workflows/build-rtkbase.yaml
@@ -1,6 +1,11 @@
 name: build-rtkbase
 on:
   workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - containers/rtkbase/**
+      - .github/workflows/build-rtkbase.yaml
   schedule:
     - cron: 0 9 * * *
 jobs:


### PR DESCRIPTION
## Why

`build-mavproxy`, `build-mimir-webhook` and `build-rtkbase` ran only on `schedule` + `workflow_dispatch`. Merging a change to one of those images built **nothing** -- the change sat unbuilt until the next daily cron, with no signal anywhere that this was the case.

Hit concretely with #699: merged, and it produced no image. Nothing in the PR or the merge indicated that "merged" and "built" were different states.

## What

A path-filtered push trigger per workflow, matching its actual build context:

| workflow | build context | paths filter |
|---|---|---|
| `build-mavproxy` | `./containers/mavproxy` | `containers/mavproxy/**` |
| `build-mimir-webhook` | `./charts/mimir/webhook` | `charts/mimir/webhook/**` |
| `build-rtkbase` | `./containers/rtkbase` | `containers/rtkbase/**` |

Plus: **every** build workflow now watches **its own file**, so changing how an image is built rebuilds it. `build-argo-tag-watcher` already did this; `build-datascience-notebook-ssh` was the last one that did not, and is now aligned. All five are consistent.

The daily `schedule` stays untouched as the backstop for base-image drift, which is what it is actually for. Crons kept as they were (mimir-webhook 08:00, notebook weekly Sundays, the rest 09:00).

## Note on build-mimir-webhook

It already had a push trigger, **commented out**, with no `paths` filter:

```yaml
on:
  # push:
  #   branches:
  #     # Run post-commit to validate, also to update caches.
  #     - main
```

Unfiltered, that rebuilds on every merge to `main`, which is presumably why it was switched off. Re-enabled with the filter rather than deleted -- the filter is what makes it reasonable.

## Deliberately not clever

No tag/dispatch matrices, no chart-to-image dependency graph, no attempt to catch transitive changes. One path filter per image, and the cron catches anything the filter misses. Both failure directions are cheap: a missed rebuild waits at most a day, a spurious rebuild costs one cached build.

## Side effect worth knowing

This PR touches `.github/workflows/build-rtkbase.yaml`, which its own new filter matches -- so **merging this triggers a `build-rtkbase` run**, which picks up the #699 raw-logging change. That removes the need for a manual dispatch to get #699's image built.

It does **not** restart the pod. `rtkbase` still needs a rollout to pull the new `:main`, and that is a live change to a privileged device-bound pod that briefly drops RTK (`strategy: Recreate`) -- your call, not automatic.

Verified: all five build workflows carry `push schedule workflow_dispatch`, all five watch their own workflow file, all parse under `yaml.safe_load`, actionlint passes in pre-commit.