### PR TITLE
rtkbase: let str2str_file write to the PVC (ProtectSystem=strict blocked it)

### DIFF
--- a/containers/rtkbase/Dockerfile
+++ b/containers/rtkbase/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY rtk-base-user-on-bootup /usr/local/bin/
+# str2str_file logs to the PVC, which upstream's ProtectSystem=strict forbids.
+COPY str2str_file-persist-datadir.conf /etc/systemd/system/str2str_file.service.d/
 RUN chmod +x /usr/local/bin/rtk-base-user-on-bootup \
     && sed -i '/^ExecStart=.*/i ExecStartPre=/usr/local/bin/rtk-base-user-on-bootup' /etc/systemd/system/rtkbase_web.service \
     && rm -f /usr/sbin/policy-rc.d

--- a/containers/rtkbase/README.md
+++ b/containers/rtkbase/README.md
@@ -43,6 +43,8 @@ So `str2str_file` (`run_cast.sh in_tcp out_file`) is **additive** -- enabling ra
 
 Raw UBX lands in `/persist/rtkbase/data` (`[local_storage]` in `settings.conf`), rotating every 24 h; `rtkbase_archive.timer` zips daily at 04:00 and keeps `archive_rotate=60` archives. Measured stream rate is ~4.7 KiB/s, so roughly **420 MB/day** uncompressed against 200+ GB free on the PVC.
 
+Upstream's `str2str_file.service` ships `ProtectSystem=strict` with `ReadWritePaths=/root/rtkbase`, which assumes the datadir sits inside the RTKBase install. Ours is on the PVC, so systemd mounts it read-only and str2str exits 1 with `stream server start error`, crash-looping on its 30 s `RestartSec`. [`str2str_file-persist-datadir.conf`](str2str_file-persist-datadir.conf) is a drop-in granting `ReadWritePaths=/persist/rtkbase` and nothing else. **If the datadir ever moves, that drop-in has to move with it.**
+
 The receiver emits `UBX-RXM-RAWX` (1 Hz) and `UBX-RXM-SFRBX`, so these logs are **PPP-usable**: `convbin` them to RINEX and submit to a PPP service to re-solve the base position. That is the point of keeping them -- the current fixed position's derivation is not recorded (see [`facts` `geospatial/locations/base_station.md`](https://github.com/symmatree/facts/blob/main/geospatial/locations/base_station.md)).
 
 ## Kubernetes (phase 3)

--- a/containers/rtkbase/str2str_file-persist-datadir.conf
+++ b/containers/rtkbase/str2str_file-persist-datadir.conf
@@ -1,0 +1,12 @@
+# systemd drop-in for str2str_file.service.
+#
+# Upstream ships ProtectSystem=strict with ReadWritePaths=/root/rtkbase, which
+# assumes the raw-data datadir lives under the RTKBase install. We point
+# [local_storage] datadir at /persist/rtkbase/data (the PVC) so logs survive pod
+# restarts, and systemd then mounts that path read-only for this unit -- str2str
+# exits 1 with "stream server start error" and the unit crash-loops on its
+# 30 s RestartSec.
+#
+# Grant the PVC path explicitly. Nothing else about the sandbox is relaxed.
+[Service]
+ReadWritePaths=/persist/rtkbase


### PR DESCRIPTION
## What went wrong

#699 started `str2str_file.service`, but the service **could not actually run**. Caught on rollout:

```
str2str_file.service   loaded  activating (auto-restart)  RTKBase File - Log data
  str2str_file[126]: stream server start error
  Main process exited, code=exited, status=1/FAILURE
```

It crash-looped on its 30 s `RestartSec`, while `str2str_tcp` and `str2str_local_ntrip_caster` stayed healthy -- so RTK was fine and nothing looked broken from outside. `/persist/rtkbase/data` stayed empty.

## Cause

Upstream ships the unit as:

```
ProtectSystem=strict
ReadWritePaths=/root/rtkbase
```

which assumes the raw datadir lives inside the RTKBase install. We deliberately point `[local_storage] datadir` at `/persist/rtkbase/data` so logs survive pod restarts -- and systemd then mounts that path **read-only for this unit**.

What makes it confusing: the directory is perfectly writable outside the sandbox (`touch /persist/rtkbase/data/.wtest` succeeds), so nothing about permissions, the PVC, or disk space looks wrong. Only the unit's own namespace is restricted.

## Fix

A drop-in baked into the image granting the PVC path and **relaxing nothing else**:

```ini
[Service]
ReadWritePaths=/persist/rtkbase
```

Left as a separate file rather than patched into the upstream unit, so the RTKBase version bump stays a clean `RTKBASE_VERSION` change.

## Verified against the live pod before shipping

Applied the drop-in by hand on the running pod:

```
systemctl is-active str2str_file.service   ->  active
/persist/rtkbase/data/2026-08-13_00-55-01_GNSS-1.ubx       52676 bytes, growing
/persist/rtkbase/data/2026-08-13_00-55-01_GNSS-1.ubx.tag     628 bytes
```

Then **reverted it** -- removed the drop-in, stopped the service, deleted the test capture -- so the box carries no unmerged state. `str2str_tcp` and the caster confirmed `active` afterwards.

## Current state of the deployment

`ntrip/rtkbase` is running the #699 image (`sha256:f4b9986b...`, up from `sha256:92559070...`) with `str2str_file` crash-looping and no raw logging. RTK itself is unaffected and serving. Merging this builds a new image (the push trigger from #702 works -- that is how the #699 image got built), and a rollout after that starts the capture for #698.

## My error

#699 claimed this was untested and listed what I had verified -- receiver output, stream rate, disk headroom, unit definition. I read the unit file closely enough to quote its `ExecStart` and argue the topology was additive, and did not notice `ProtectSystem=strict` three lines above it, which is precisely the thing that made the change not work.

Refs #698, #699.