### PR TITLE
proxmox-alloy: collect host journal logs via hookscript-granted ACL (#686)

### DIFF
--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -1,6 +1,6 @@
 # Proxmox host monitoring (Alloy LXC)
 
-Each **Proxmox cluster node** can run an **unprivileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and its Alloy **config** over `/etc/alloy`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), tails **host log files**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
+Each **Proxmox cluster node** can run an **unprivileged LXC** with **Grafana Alloy**, bind-mounting the host root read-only at `/host` and its Alloy **config** over `/etc/alloy`. Alloy scrapes **unix/node_exporter-style** metrics (including **hwmon** via nesting + host paths), reads the **host systemd journal**, and ships everything to the **tiles** (prod) cluster over **OTLP HTTP**, with **`cluster="bond"`** and per-node **`hostname`** / **`instance`** labels.
 
 **Config delivery:** the config is uploaded as the snippet **`config.alloy`**, bind-mounted over the CT's **`/etc/alloy`** (so `/etc/alloy/config.alloy` is our config), and the entrypoint is set to the **image default** command `/bin/alloy run /etc/alloy/config.alloy ...`. This is **robust to bpg#2789** (the provider not reliably applying the entrypoint to OCI containers on *create*): whether the provider applies our value or falls back to the image-derived one, both are `/bin/alloy run /etc/alloy/config.alloy`, and that path is our config via the mount -- so the CT boots and loads our config either way. **Do not remove the entrypoint** to "let the image default run": an OCI app-container with no entrypoint execs `/sbin/init`, which doesn't exist in the image (`Failed to exec "/sbin/init"` -> the CT fails to spawn). That -- not the `/etc/alloy` mount -- was the #695/#696 outage; the mount itself boots fine with an entrypoint set. (A fully self-contained alternative -- bake a custom Alloy image with the config as the default -- is noted in #695.)
 
@@ -34,12 +34,16 @@ After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxm
 rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])
 ```
 
-**Logs (when working):**
+**Logs (host systemd journal, #686):**
 
 ```logql
-{job=~"proxmox.*"}
-{host=~"nuc-g.*"}
+{job="proxmox-journal"}
+{job="proxmox-journal", host="nuc-g3p-1", unit="pveproxy.service"}
 ```
+
+Host logs come from the **systemd journal** (`loki.source.journal` reading `/host/var/log/journal`), labeled `job="proxmox-journal"`, `host="<node>"`, with the systemd `unit` promoted to a label. dmesg/kernel logs are included (`journalctl -k` is in the journal). PVE 9 is journald-only, so the old `loki.source.file` tail of `/var/log/{syslog,messages,...}` collected nothing.
+
+**How an unprivileged CT reads the `0640 root:systemd-journal` journal:** a Proxmox **hookscript** (`tf/nodes/templates/alloy-journal-hook.sh`, wired via `hook_script_file_id`) runs on the host at CT **pre-start** and `setfacl`s `u:100000:rX` (the CT's mapped root) onto `/var/log/journal` (installing the `acl` package first if missing) -- so Alloy reads the journal without a privileged CT (privileged is impossible here: OCI images can't create privileged, bpg#2513). The hookscript is best-effort and always exits 0 (a failing pre-start hook would abort the CT start), so a journal-ACL problem degrades to "no host logs this boot", never a down CT. It's delivered as an **executable** snippet (`file_mode = "0755"`, `upload_mode = "sftp"` -- the API upload can't set the exec bit; needs the provider `ssh` block).
 
 **Proxmox API (eth0 has an address):** `GET /nodes/{node}/lxc/{vmid}/interfaces`
 

--- a/tf/nodes/main.tf
+++ b/tf/nodes/main.tf
@@ -40,6 +40,15 @@ provider "proxmox" {
   username = "root@pam"
   password = var.proxmox_root_password
   insecure = true
+
+  # Needed so proxmox_virtual_environment_file can upload a snippet with an executable file_mode via
+  # SFTP (the API upload path can't set the exec bit). Only the hookscript upload sets upload_mode =
+  # "sftp"; other uploads (config.alloy) stay on the API path. bpg resolves node addresses via the API.
+  ssh {
+    username = "root"
+    password = var.proxmox_root_password
+    agent    = false
+  }
 }
 
 provider "unifi" {

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -35,10 +35,15 @@ resource "proxmox_oci_image" "alloy" {
 resource "proxmox_virtual_environment_container" "alloy" {
   for_each   = local.alloy_nodes
   provider   = proxmox.proxmox_root
-  depends_on = [proxmox_virtual_environment_file.alloy_config]
+  depends_on = [proxmox_virtual_environment_file.alloy_config, proxmox_virtual_environment_file.alloy_journal_hook]
 
   node_name = each.value
   vm_id     = local.alloy_vm_ids[each.key]
+
+  # Hookscript runs on the host at pre-start and setfacls the systemd journal so this unprivileged
+  # CT can read it for host-log collection (#686; see alloy-journal-hook.sh + the loki.source.journal
+  # block in the template). Must be executable, which is why the file below uploads via SFTP w/ 0755.
+  hook_script_file_id = proxmox_virtual_environment_file.alloy_journal_hook[each.value].id
 
   # Use OCI image - grafana/alloy:latest (same as Synology setup)
   operating_system {
@@ -159,5 +164,24 @@ resource "proxmox_virtual_environment_file" "alloy_config" {
       hostname   = each.value
     })
     file_name = "config.alloy"
+  }
+}
+
+# Upload the CT hookscript as an EXECUTABLE snippet. Proxmox refuses a non-executable hookscript, and
+# the API upload path can't set the exec bit -- so this uses upload_mode = "sftp" + file_mode = "0755"
+# (requires the provider `ssh` block in main.tf). Referenced by hook_script_file_id on the CT above;
+# it grants the CT read on the host journal at pre-start so loki.source.journal works unprivileged (#686).
+resource "proxmox_virtual_environment_file" "alloy_journal_hook" {
+  for_each = local.alloy_nodes
+  provider = proxmox.proxmox_root
+
+  node_name    = each.value
+  datastore_id = "local"
+  content_type = "snippets"
+  file_mode    = "0755"
+  upload_mode  = "sftp"
+  source_raw {
+    data      = file("${path.root}/templates/alloy-journal-hook.sh")
+    file_name = "alloy-journal-hook"
   }
 }

--- a/tf/nodes/templates/alloy-journal-hook.sh
+++ b/tf/nodes/templates/alloy-journal-hook.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Proxmox hookscript for the Alloy monitoring CT (#686).
+#
+# Runs ON THE HOST as root at CT lifecycle phases. At pre-start it grants the CT's mapped root
+# (host uid 100000 -- the default unprivileged idmap base 0->100000) read access to the host
+# systemd journal, so Alloy's loki.source.journal can collect host logs from an UNPRIVILEGED CT
+# (privileged is not an option: OCI-image containers fail to create privileged, bpg#2513).
+#
+# SAFETY: this MUST always exit 0. A non-zero pre-start hook aborts the CT start. Every step is
+# best-effort and non-fatal -- if the ACL can't be applied, host-log collection is skipped for this
+# boot but the CT (and its metrics) still come up. Kept noisy (logs to the file below + stderr,
+# which lands in the Proxmox task log) until we trust it.
+#
+# Args: $1 = vmid, $2 = phase (pre-start|post-start|pre-stop|post-stop).
+set +e
+
+VMID="$1"
+PHASE="$2"
+JOURNAL_DIR="/var/log/journal"
+CT_MAPPED_UID="100000" # unprivileged CT: container root (0) -> host 100000 (default idmap)
+LOG="/var/log/alloy-journal-hook.log"
+
+log() { echo "[$(date -Is 2>/dev/null)] alloy-journal-hook vmid=${VMID} phase=${PHASE}: $*" | tee -a "$LOG" >&2; }
+
+if [ "$PHASE" != "pre-start" ]; then
+	exit 0
+fi
+
+log "pre-start: granting u:${CT_MAPPED_UID} read on ${JOURNAL_DIR}"
+
+if [ ! -d "$JOURNAL_DIR" ]; then
+	log "WARNING: ${JOURNAL_DIR} does not exist (no persistent journal?); skipping"
+	exit 0
+fi
+
+if ! command -v setfacl >/dev/null 2>&1; then
+	log "setfacl missing; installing the 'acl' package"
+	# Bounded so a slow/unreachable mirror at boot can't stall the CT start (the whole hook is pre-start).
+	if timeout 90 apt-get -o DPkg::Lock::Timeout=60 install -y acl >>"$LOG" 2>&1; then
+		log "acl installed"
+	else
+		log "WARNING: acl install failed/timed out (rc=$?); host-log collection skipped this boot"
+		exit 0
+	fi
+fi
+
+# Access ACL for existing journal files, plus a default ACL so journald's newly-rotated files inherit it.
+if setfacl -R -m "u:${CT_MAPPED_UID}:rX" "$JOURNAL_DIR" >>"$LOG" 2>&1; then
+	log "access ACL applied"
+else
+	log "WARNING: access ACL failed (rc=$?)"
+fi
+if setfacl -R -d -m "u:${CT_MAPPED_UID}:rX" "$JOURNAL_DIR" >>"$LOG" 2>&1; then
+	log "default ACL applied"
+else
+	log "WARNING: default ACL failed (rc=$?)"
+fi
+
+log "done"
+exit 0

--- a/tf/nodes/templates/alloy-proxmox.alloy
+++ b/tf/nodes/templates/alloy-proxmox.alloy
@@ -78,31 +78,33 @@ otelcol.processor.attributes "main" {
   }
 }
 
-// Log collection from host
-// Proxmox uses systemd, so we can collect from journald or traditional syslog
-loki.source.file "syslog" {
-  targets = [
-    {
-      __path__ = "/host/var/log/syslog",
-      job      = "proxmox-syslog",
-      host     = "${hostname}",
-    },
-    {
-      __path__ = "/host/var/log/messages",
-      job      = "proxmox-messages",
-      host     = "${hostname}",
-    },
-    {
-      __path__ = "/host/var/log/auth.log",
-      job      = "proxmox-auth",
-      host     = "${hostname}",
-    },
-    {
-      __path__ = "/host/var/log/daemon.log",
-      job      = "proxmox-daemon",
-      host     = "${hostname}",
-    },
-  ]
+// Host log collection from the systemd journal (#686).
+// PVE 9 hosts run Debian 13 (trixie), which is journald-only -- rsyslog is not installed and
+// /var/log/{syslog,messages,auth.log,daemon.log} never exist, so the old loki.source.file tail
+// collected nothing (0 lines/90d). Read the host's persistent journal, bind-mounted read-only at
+// /host/var/log/journal. dmesg/kernel logs come along for free (journalctl -k lives in the journal).
+//
+// The journal files are 0640 root:systemd-journal and this CT is unprivileged, so its mapped root
+// (host uid 100000) can't read them by default. The CT's hook_script_file_id (see proxmox-alloy.tf)
+// runs on the host at pre-start and grants that uid read via setfacl -- so this reads unprivileged.
+loki.relabel "journal" {
+  forward_to = []
+
+  // Promote the systemd unit to a real label so host logs are filterable by service.
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+}
+
+loki.source.journal "host" {
+  path          = "/host/var/log/journal"
+  max_age       = "12h"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = {
+    job  = "proxmox-journal",
+    host = "${hostname}",
+  }
   forward_to = [otelcol.receiver.loki.main.receiver]
 }
 


### PR DESCRIPTION
Fixes #686 (host logs → Loki). dmesg/journalctl for quick host sanity.

## What
Proxmox host logs have never been collected — PVE 9 is journald-only, but the config tailed nonexistent `/var/log/*.log`. This reads the **systemd journal**:
- `loki.source.journal` on `/host/var/log/journal` → `{job="proxmox-journal", host="<node>"}`, systemd `unit` promoted to a label. dmesg/kernel included (`journalctl -k` is in the journal).
- The journal files are `0640 root:systemd-journal`; the CT is unprivileged (its mapped root = host uid 100000 can't read them) and **privileged is impossible** here (OCI images can't create privileged, bpg#2513).
- So a **Proxmox hookscript** (`alloy-journal-hook.sh`, wired via `hook_script_file_id`) runs on the host at CT **pre-start** and `setfacl`s `u:100000:rX` onto `/var/log/journal` (installing `acl` if missing). Delivered as an executable snippet (`file_mode="0755"` + `upload_mode="sftp"`, which needs the new `ssh` block on the `proxmox_root` provider — scoped: only the hook uses sftp).

## Safety (given the recent outage streak)
- The hookscript is **best-effort and always `exit 0`** — a failing pre-start hook would abort the CT start, so any ACL/apt problem degrades to *"no host logs this boot"*, never a down CT. `apt-get` is `timeout`-bounded so a slow mirror at boot can't stall the start.
- A **non-executable** hook is rejected by Proxmox at set-time → a **loud terraform apply error**, not a CT-start abort (verified: `pct set --hookscript` on a `0644` file errors and leaves the CT untouched).

## Validated live (nuc-g3p-1)
- The core permission model: after `setfacl u:100000:rX /var/log/journal`, the **unprivileged CT can read the journal** (was `DENIED` before). `acl` installed cleanly via apt.
- Hookscript is `bash -n` clean, non-fatal, and shellcheck/shfmt-clean.
- (Alloy's `loki.source.journal` graph loads on the deployed Alloy — validated in the earlier #692 attempt.)

## Untested here — the TF file-delivery bits you flagged (verified at rollout)
1. That `upload_mode="sftp"` + `file_mode="0755"` + the provider `ssh` block actually yields a **+x** hookscript on the node (sftp path / node-address resolution untested from here). If it doesn't, the `hook_script_file_id` set fails **loud** (apply error), CTs untouched.
2. That the `OTLP → Loki` logs path delivers `{job="proxmox-journal"}` (the metrics path works; edge logs have never flowed).
3. Whether the apply reboots the CTs to activate (hook runs at pre-start; new config loads on restart) — may need a manual restart if the apply doesn't.

**Suggested rollout:** merge, watch the apply; if it's green, restart one CT and confirm `{job="proxmox-journal", host="nuc-g3p-1"}` lands in Loki before assuming all four; also re-check journal readability after some activity (the default-ACL-on-rotated-files durability question). I'm happy to babysit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rs9DMBPbE8CzQQveEcqvo