### PR TITLE
proxmox-alloy: read host memory via /host/proc,/host/sys binds (#544)

### DIFF
--- a/docs/proxmox-monitoring.md
+++ b/docs/proxmox-monitoring.md
@@ -32,7 +32,10 @@ After removing old CTs manually, apply **`prod`** workspace with **`deploy_proxm
 
 ```promql
 rate(node_cpu_seconds_total{cluster="bond", instance=~"nuc-g.*"}[5m])
+node_memory_MemTotal_bytes{cluster="bond", instance=~"nuc-g.*"}   # host RAM ~15GB, not 0.5GB (#544)
 ```
+
+`node_exporter` reads `procfs_path=/host/proc` + `sysfs_path=/host/sys` (host `/proc`,`/sys` bind-mounted; see [`proxmox-alloy.tf`](../tf/nodes/proxmox-alloy.tf)), so `node_memory_*` reports **host** RAM/swap. The container's own `/proc/meminfo` is lxcfs-virtualized to the ~512 MB LXC cgroup limit (the #544 blindspot). The `/`->`/host` bind is non-recursive, so `/proc` and `/sys` are bound explicitly.
 
 **Logs (host systemd journal, #686):**
 

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -127,9 +127,21 @@ resource "proxmox_virtual_environment_container" "alloy" {
     mount_options = []
     volume        = "/"
   }
+  # Bind-mount the snippets dir (holds our config.alloy) over the container's /etc/alloy, so
+  # /etc/alloy/config.alloy IS our config -- exactly where the entrypoint above reads it. This shadows
+  # the image's demo /etc/alloy/config.alloy (the snippets dir holds only our file). Mounting here is
+  # fine as long as an entrypoint is set (verified: boots + ships); #696's outage was the *removed*
+  # entrypoint (-> /sbin/init), not this mount.
+  mount_point {
+    path          = "/etc/alloy"
+    read_only     = true
+    mount_options = []
+    volume        = "/var/lib/vz/snippets"
+  }
   # Bind the host's live procfs and sysfs so node_exporter reads HOST memory/CPU, not the
   # lxcfs-virtualized 512 MB cgroup view (#544). procfs_path=/host/proc, sysfs_path=/host/sys in the
-  # template. No privilege needed (/proc/meminfo, /sys are world-readable).
+  # template. No privilege needed (/proc/meminfo, /sys are world-readable). Ordered LAST so they append
+  # as mp2/mp3 (mount_point is ForceNew -- matching the live CTs' mp numbering keeps the apply a no-op).
   mount_point {
     path          = "/host/proc"
     read_only     = true
@@ -141,17 +153,6 @@ resource "proxmox_virtual_environment_container" "alloy" {
     read_only     = true
     mount_options = []
     volume        = "/sys"
-  }
-  # Bind-mount the snippets dir (holds our config.alloy) over the container's /etc/alloy, so
-  # /etc/alloy/config.alloy IS our config -- exactly where the entrypoint above reads it. This shadows
-  # the image's demo /etc/alloy/config.alloy (the snippets dir holds only our file). Mounting here is
-  # fine as long as an entrypoint is set (verified: boots + ships); #696's outage was the *removed*
-  # entrypoint (-> /sbin/init), not this mount.
-  mount_point {
-    path          = "/etc/alloy"
-    read_only     = true
-    mount_options = []
-    volume        = "/var/lib/vz/snippets"
   }
   # Start on boot
   start_on_boot = true

--- a/tf/nodes/proxmox-alloy.tf
+++ b/tf/nodes/proxmox-alloy.tf
@@ -118,14 +118,29 @@ resource "proxmox_virtual_environment_container" "alloy" {
     dedicated = 512
   }
 
-  # Mount host root filesystem (read-only for safety)
-  # This gives access to /sys, /proc, /dev, /run from the host
-  # Same approach as Synology - bind mount host root to /host
+  # Mount host root filesystem (read-only) at /host for node_exporter rootfs/filesystem metrics.
+  # NOTE: this bind is NON-recursive, so it does NOT carry the /proc and /sys submounts (/host/proc is
+  # empty without the explicit binds below). Same approach as Synology - bind mount host root to /host.
   mount_point {
     path          = "/host"
     read_only     = true
     mount_options = []
     volume        = "/"
+  }
+  # Bind the host's live procfs and sysfs so node_exporter reads HOST memory/CPU, not the
+  # lxcfs-virtualized 512 MB cgroup view (#544). procfs_path=/host/proc, sysfs_path=/host/sys in the
+  # template. No privilege needed (/proc/meminfo, /sys are world-readable).
+  mount_point {
+    path          = "/host/proc"
+    read_only     = true
+    mount_options = []
+    volume        = "/proc"
+  }
+  mount_point {
+    path          = "/host/sys"
+    read_only     = true
+    mount_options = []
+    volume        = "/sys"
   }
   # Bind-mount the snippets dir (holds our config.alloy) over the container's /etc/alloy, so
   # /etc/alloy/config.alloy IS our config -- exactly where the entrypoint above reads it. This shadows

--- a/tf/nodes/templates/alloy-proxmox.alloy
+++ b/tf/nodes/templates/alloy-proxmox.alloy
@@ -1,10 +1,13 @@
 // Alloy configuration for Proxmox host monitoring
 // Collects node_exporter metrics (including hwmon sensors) and system logs, forwarding to prod OTLP
 
-// Node exporter for host system metrics (nesting exposes host /proc and /sys to the container)
+// Node exporter for host system metrics. Read the host's real procfs/sysfs, bind-mounted at
+// /host/proc and /host/sys (see proxmox-alloy.tf), NOT the container's own /proc -- lxcfs virtualizes
+// the container /proc/meminfo down to the 512 MB cgroup limit, which made node_memory_* report 512 MB
+// instead of host RAM (#544). /proc/meminfo is world-readable, so this needs no privilege.
 prometheus.exporter.unix "node" {
-  procfs_path = "/proc"
-  sysfs_path  = "/sys"
+  procfs_path = "/host/proc"
+  sysfs_path  = "/host/sys"
   rootfs_path = "/host"
 }
 


### PR DESCRIPTION
Fixes #544 — the other half of "make Proxmox logs *and* metrics work."

## What
`node_exporter` reported the LXC's **512 MB cgroup** memory, not the host's ~16 GB — `procfs_path` was the container's `/proc`, whose `/proc/meminfo` is lxcfs-virtualized. So host memory/swap were effectively unmonitored.

Bind the host's real `/proc` and `/sys` at `/host/proc` and `/host/sys` (the `/`→`/host` bind is non-recursive, so it drops those submounts) and point node_exporter at them: `procfs_path=/host/proc`, `sysfs_path=/host/sys`. **No privilege** — `/proc/meminfo` and `/sys` are world-readable.

## Validated live (nuc-g3p-2, before the PR)
Added the binds + repointed node_exporter + restarted:
- `node_memory_MemTotal_bytes{instance="nuc-g3p-2"}` = **16.5 GB** (was 0.5 GB)
- `node_hwmon_temp_celsius{instance="nuc-g3p-2"}` = **10 series** (hwmon still works via `/host/sys`)
- untouched nuc-g3p-1 still reads **0.5 GB**, confirming the diff
- journal collection unaffected (hook still runs, still readable)

## Rollout
Plan will show whether it's in-place or a recreate; either way the CTs need a restart to pick up the new mounts + `procfs_path`. **nuc-g3p-2 is already on this config** (my validation), so after merge I'll restart the other three (one at a time, confirm each reads ~15 GB) — same as the journal rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rs9DMBPbE8CzQQveEcqvo